### PR TITLE
fix: correct default tenant label in start output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "0.9.46"
+version = "0.9.47"
 edition = "2024"
 rust-version = "1.91"
 description = "Greentic - The operation system for digital workers"

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -135,7 +135,7 @@ pub(crate) fn run_start(sub_matches: &ArgMatches, debug: bool, locale: &str) -> 
     println!("Deployment mode: local runtime");
     println!(
         "Starting tenant={} team={}",
-        request.tenant.as_deref().unwrap_or("default"),
+        request.tenant.as_deref().unwrap_or("demo"),
         request.team.as_deref().unwrap_or("default")
     );
     let args = request.to_runtime_start_args(locale);


### PR DESCRIPTION
## Summary
- Fix startup log showing `tenant=default` when no `--tenant` flag passed
- The runtime defaults to `demo` (via `DemoConfig::default()`), not `default`
- Changed fallback in gtc start output to match actual runtime behavior

## Test plan
- [x] `cargo test` passes
- [ ] Run `gtc start` without --tenant and verify log shows `tenant=demo`