### PR TITLE
fix(test): hermetic escape hatch for ensure_deployer_dist_pack test

### DIFF
--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -397,6 +397,14 @@ fn ensure_deployer_dist_pack(debug: bool, locale: &str) -> GtcResult<()> {
 }
 
 fn hydrate_deployer_dist_pack(dist_dir: &Path, filename: &str, locale: &str) -> GtcResult<()> {
+    // Test-only escape hatch: allow hermetic tests to short-circuit the
+    // GitHub Release download path. Used by
+    // `ensure_deployer_dist_pack_requires_installed_dist_pack`.
+    if env::var_os("GTC_SKIP_DIST_HYDRATE").is_some() {
+        return Err(GtcError::message(
+            "dist pack hydrate disabled via GTC_SKIP_DIST_HYDRATE",
+        ));
+    }
     fs::create_dir_all(dist_dir)
         .map_err(|e| GtcError::io(format!("failed to create {}", dist_dir.display()), e))?;
     let target = dist_dir.join(filename);
@@ -2061,8 +2069,13 @@ mod tests {
         let _deployer = fake_deployer_contract(None);
         let dir = tempfile::tempdir().expect("tempdir");
         let original_cargo_home = env::var_os("CARGO_HOME");
+        let original_skip_hydrate = env::var_os("GTC_SKIP_DIST_HYDRATE");
         unsafe {
             env::set_var("CARGO_HOME", dir.path());
+            // Without this, hydrate_deployer_dist_pack downloads from
+            // github.com/greenticai/greentic/releases/download/v{CARGO_PKG_VERSION}/...
+            // and the first `expect_err` below fails on networked CI runners.
+            env::set_var("GTC_SKIP_DIST_HYDRATE", "1");
         }
 
         let err = ensure_deployer_dist_pack(false, "en").expect_err("missing pack should fail");
@@ -2101,6 +2114,10 @@ mod tests {
             match original_cargo_home {
                 Some(value) => env::set_var("CARGO_HOME", value),
                 None => env::remove_var("CARGO_HOME"),
+            }
+            match original_skip_hydrate {
+                Some(value) => env::set_var("GTC_SKIP_DIST_HYDRATE", value),
+                None => env::remove_var("GTC_SKIP_DIST_HYDRATE"),
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes \`install::tests::ensure_deployer_dist_pack_requires_installed_dist_pack\` which has been broken on networked CI runners since \`v1.0.0\` was published on 2026-04-08.

## Root cause

The test sets \`CARGO_HOME\` to an empty tempdir and expects \`ensure_deployer_dist_pack()\` to fail with \"missing pack\". But that function has a **hydrate-on-miss** fallback that downloads from:

\`\`\`
https://github.com/greenticai/greentic/releases/download/v{CARGO_PKG_VERSION}/{filename}
\`\`\`

Since \`v1.0.0\` now exists with the required dist pack assets, hydrate **succeeds** on any runner with network access, the file is written to the tempdir, validation passes, and \`ensure_deployer_dist_pack()\` returns \`Ok(())\`. The test's first \`expect_err(\"missing pack should fail\")\` then panics.

## Timing evidence

\`Publish And Release\` workflow history on \`main\`:

| Date | SHA | Result |
|------|-----|--------|
| 2026-04-08 11:34 | \`9ca66b7\` | ✅ success (v1.0.0 release run) |
| **2026-04-13 08:37** | \`afb0e92\` | ❌ **failure** — first main merge after v1.0.0 landed |

There were zero main merges between those two dates, so nobody noticed the latent breakage until PR #115 landed this morning. My Tier 5 dev-publish enrollment ([.github#59](https://github.com/greenticai/.github/pull/59), [#117](https://github.com/greenticai/greentic/pull/117)) just exposed the same failure through a different code path.

## Fix

Add a test-only env var escape hatch to \`hydrate_deployer_dist_pack\`:

\`\`\`rust
fn hydrate_deployer_dist_pack(dist_dir: &Path, filename: &str, locale: &str) -> GtcResult<()> {
    if env::var_os(\"GTC_SKIP_DIST_HYDRATE\").is_some() {
        return Err(GtcError::message(
            \"dist pack hydrate disabled via GTC_SKIP_DIST_HYDRATE\",
        ));
    }
    // ... existing code unchanged
}
\`\`\`

Set it in the test, restore it on teardown alongside \`CARGO_HOME\`.

## Why this approach

Minimal delta, clear intent, no user-facing surface. Alternatives considered:

| Option | Rejected because |
|--------|------------------|
| \`#[ignore]\` | Loses coverage of all three code paths (missing / invalid / valid) |
| URL override via env var | Same size but wider misuse surface |
| Inject HTTP client trait | ~50 lines of refactor for a 10-line test bug |

## Test plan

- [x] \`cargo test --bin gtc -- ensure_deployer_dist_pack_requires_installed_dist_pack\` passes locally (\`1 passed; 0 failed\`)
- [ ] Verify dev-publish + Publish And Release go green on merge