### PR TITLE
fix(test): prevent hydration bypass in deployer dist pack test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "criterion",
@@ -1942,9 +1942,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.91"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -2065,7 +2065,16 @@ mod tests {
             env::set_var("CARGO_HOME", dir.path());
         }
 
+        // Create bin/dist as a *file* so the hydration fallback cannot
+        // mkdir + download the pack from GitHub releases.  This ensures the
+        // "missing pack" path is exercised even when online.
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("mkdir bin");
+        fs::write(bin_dir.join("dist"), b"blocker").expect("write dist blocker");
+
         let err = ensure_deployer_dist_pack(false, "en").expect_err("missing pack should fail");
+        // Remove the blocker so subsequent phases can create the real dir.
+        let _ = fs::remove_file(bin_dir.join("dist"));
         assert!(
             err.to_string()
                 .contains("greentic-deployer dist pack is missing")
@@ -2073,10 +2082,30 @@ mod tests {
 
         let dist_dir = dir.path().join("bin/dist");
         fs::create_dir_all(&dist_dir).expect("mkdirs");
-        for filename in required_deployer_dist_pack_filenames(false, "en").expect("filenames") {
+        let pack_filenames = required_deployer_dist_pack_filenames(false, "en").expect("filenames");
+        for filename in &pack_filenames {
             fs::write(dist_dir.join(filename), b"pack-bytes").expect("write pack");
         }
+        // Make files AND dir read-only so hydration cannot overwrite.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for filename in &pack_filenames {
+                fs::set_permissions(dist_dir.join(filename), fs::Permissions::from_mode(0o444))
+                    .expect("chmod file ro");
+            }
+            fs::set_permissions(&dist_dir, fs::Permissions::from_mode(0o555))
+                .expect("chmod dist ro");
+        }
         let err = ensure_deployer_dist_pack(false, "en").expect_err("invalid pack should fail");
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&dist_dir, fs::Permissions::from_mode(0o755))
+                .expect("chmod dist rw");
+            for filename in &pack_filenames {
+                fs::set_permissions(dist_dir.join(filename), fs::Permissions::from_mode(0o644))
+                    .expect("chmod file rw");
+            }
+        }
         assert!(
             err.to_string()
                 .contains("greentic-deployer dist pack is invalid")


### PR DESCRIPTION
## Summary
- Fix pre-existing flaky test `ensure_deployer_dist_pack_requires_installed_dist_pack` that fails when online because `hydrate_deployer_dist_pack()` downloads the real pack from GitHub releases, overwriting test fixtures
- Set dist directory and files to read-only during the "invalid pack" test phase to prevent hydration from overwriting
- Also block hydration in the "missing pack" phase by creating `dist` as a regular file

## Test plan
- [x] `cargo test --all-features` — 247 tests pass (including the previously failing test)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean