### PR TITLE
chore(ci): pin Rust toolchain to 1.94.0 (remove @stable / @1.91.0)

### DIFF
--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           toolchain: 1.94.0
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           toolchain: 1.94.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           path: greentic-deployer
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           toolchain: 1.94.0
 
@@ -117,7 +117,7 @@ jobs:
           path: assets/deployer
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           toolchain: 1.94.0
           targets: ${{ matrix.target }}
@@ -230,7 +230,7 @@ jobs:
           path: assets/deployer
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           toolchain: 1.94.0
 


### PR DESCRIPTION
## Summary

P1.6 from release-pipeline audit (`plans/release-pipeline-audit-nightly-dev-weekly-stable.md`).

Pin every `dtolnay/rust-toolchain@stable` and `@1.91.0` reference to `@1.94.0`, matching the canonical `rust-toolchain.toml` and the project's declared MSRV.

Also updates any `RUST_VERSION: "1.91.0"` env/input defaults to `"1.94.0"`.

**Why:** `@stable` floats with upstream Rust releases — CI builds diverge from developer environments. `@1.91.0` is an old pin from before the toolchain standardization. The shared reusable workflows in `greenticai/.github` already default to `1.94.0`; this brings inline workflows into alignment.

## Test plan
- [ ] PR CI green (build still compiles on 1.94.0)
