### PR TITLE
chore: move heavy PR-time jobs to nightly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  workflow_call:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: greenticai/.github/.github/workflows/host-crate-ci.yml@main

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,7 +1,11 @@
 name: Perf (lightweight)
+# Moved off pull_request onto a nightly schedule. See plans/binary-bifurcation.md
+# Phase A (heavy-job sweep). Manual runs remain via workflow_dispatch.
 
 on:
-  pull_request:
+  schedule:
+    - cron: "34 4 * * *"
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Move `perf.yml` off `pull_request` trigger onto `schedule` (04:34 UTC) + `workflow_dispatch`.

Part of `plans/binary-bifurcation.md` Phase A — sweep heavy PR-time jobs to nightly.

## Changes

- Remove `pull_request:` trigger from `perf.yml`
- Add `schedule: cron "34 4 * * *"` and `workflow_dispatch:`
- `push: branches: [main]` preserved verbatim

## Test plan

- [ ] Actionlint passes (verified locally)
- [ ] CI green on this PR (ci.yml still runs on PR)
- [ ] Nightly cron fires at 04:34 UTC