### PR TITLE
chore: move nightly cron into 03:XX UTC window (Phase A.7.2)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -4,7 +4,7 @@ name: Perf (lightweight)
 
 on:
   schedule:
-    - cron: "34 4 * * *"
+    - cron: "39 3 * * *"
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Re-crons scheduled nightly workflows into the 03:00-03:59 UTC window per plans/binary-bifurcation.md Phase A.7.2
- Cron-only change; no job logic modified
- Slot assignments follow the fleet-wide allocation (tier-5 binaries in 03:14-03:57)

## Changes
- `perf.yml`: `34 4 * * *` → `39 3 * * *`

## Test plan
- [x] yaml-parse clean (verified locally)
- [x] No other hunks in the diff