### PR TITLE
chore: bump gtc to 1.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary
- Bumps `gtc` to 1.0.7.
- Skips 1.0.6: already on crates.io (published 2026-04-22 ~15:33 UTC) but no matching GitHub release — the tagged v1.0.6 release workflow failed on `install::tests::run_update_reports_failure_after_attempting_all_packages_and_tools`; PR #137 fixed the test but did not rev the version.
- Unblocks `cargo binstall gtc`, which currently falls back to source compile because crates.io 1.0.6 has no matching GH asset.

## Test plan
- [ ] CI on this PR passes (esp. the previously-failing install test).
- [ ] After merge, `tag-on-version-bump.yml` creates `v1.0.7` on main.
- [ ] Both `release.yml` and `crates-publish.yml` succeed on the tag.
- [ ] `cargo binstall gtc@1.0.7` on Linux x64 fetches the GH asset (not source).