### PR TITLE
fix(deps): revert greentic-i18n to 0.4 (0.5 is bin-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,23 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-i18n"
-version = "0.5.1"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb91ab8082b35cad324daac10ffe7a8072aeaef308066b8569f750c4e3599da6"
-dependencies = [
- "greentic-i18n-lib",
- "serde_json",
-]
-
-[[package]]
-name = "greentic-i18n-lib"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c181b9a5fb0beccd9959fb11296572a7802ee1e237d90ca37ff46e8a1fbef3"
-dependencies = [
- "blake3",
- "data-encoding",
-]
+checksum = "44951881c763069e14624cf8cf1dddff706ad4d8132570dc299af0b855cf4458"
 
 [[package]]
 name = "greentic-interfaces"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.5", features = ["std"] }
 directories = "6"
 flate2 = "1.1"
 greentic-distributor-client = { version = "0.5", features = ["dist-client", "oci-components"] }
-greentic-i18n = "0.5"
+greentic-i18n = "0.4"
 greentic-types = "0.5"
 # `oci-distribution` 0.11.0 is still the newest crates.io release available as
 # of 2026-03-30, so ARCH-017 is tracked as resolved-by-verification rather than


### PR DESCRIPTION
## Summary
PR #141 ("Roll out canonical docs system and schema sync") silently bumped three core deps `0.4 → 0.5`:

- `greentic-distributor-client` — fine (0.5.0 has a lib)
- `greentic-types` — fine (0.5.2 has a lib)
- `greentic-i18n` — **broken**: at 0.5.x the library was split into a new `greentic-i18n-lib` crate; the `greentic-i18n` package is now CLI-only (no `src/lib.rs`).

`use greentic_i18n::{normalize_locale, select_locale_with_sources}` in `src/perf_targets.rs:7` and `use greentic_i18n::normalize_locale` in `src/bin/gtc/i18n.rs:5` therefore fail to resolve, breaking `cargo check --lib` on `main`. Symptoms:
- `Perf (lightweight)` workflow failing on every `main` push (run [24790715127](https://github.com/greenticai/greentic/actions/runs/24790715127)).
- PR #141's own `CI` was red for the same reason but was merged anyway.

## Fix
Revert just that one dep to `0.4`. Cargo resolves to `0.4.56` (latest `0.4.x`), which ships `src/lib.rs` with both `normalize_locale` and `select_locale_with_sources` as `pub fn`. Other 0.5 bumps from PR #141 are kept — they compile fine.

## Test plan
- [x] `cargo check --lib` — passes locally
- [x] `cargo check --bins` — passes locally
- [ ] CI clippy + test on this PR pass
- [ ] `Perf (lightweight)` goes green on the next push to main

## Follow-ups (not in this PR)
- If the forward-migration to `greentic-i18n-lib` 0.5.x is actually desired, it needs a separate PR that adds `greentic-i18n-lib = "0.5"` and updates both `use` sites to `greentic_i18n_lib::*`.
- Crates.io `gtc 1.0.7` shipped (via the pre-#140 parallel-race caller on tag `v1.0.7`, which was created from PR #139 before #140 merged); GH release `v1.0.7` was never created (2 of 6 build targets failed with cross-compile `can't find crate for std`). Next bump to `1.0.8` will go through the embedded pipeline from #140 — separate decision.