### PR TITLE
chore: bump gtc to 1.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary
Bumps `gtc` to 1.0.8. First release cut through the embedded pipeline from #140 — crates.io publish is gated on `github_release` + `provenance` success.

## Context
- 1.0.6 and 1.0.7 both shipped to crates.io without matching GitHub releases (separate races: 1.0.6 pre-pipeline-fix, 1.0.7 interleaved with the #139/#140 merge order). `cargo binstall gtc` has been falling back to source compile against both.
- Main is clean again after #142 reverted the accidental `greentic-i18n 0.5` bump from #141; `Perf (lightweight)` passed.
- On merge, `tag-on-version-bump` creates `v1.0.8`, `release.yml` runs, and the final `publish_crates` job only fires if `github_release` and `provenance` succeed.

## Test plan
- [ ] CI passes on this PR.
- [ ] `tag-on-version-bump` creates `v1.0.8` after merge.
- [ ] `release.yml` for `v1.0.8` runs full matrix → `github_release` → `provenance` → `publish_crates`, in that order.
- [ ] `cargo binstall gtc@1.0.8` resolves to GH asset, not source.

## Known risk
The `v1.0.7` release failed on two matrix targets with `can't find crate for std`:
- `build_binaries (macos-15, x86_64-apple-darwin, tgz, false)`
- `build_binaries (windows-latest, aarch64-pc-windows-msvc, zip, false)`

If that cross-compile issue is unresolved, `v1.0.8` will hit the same failures and `publish_crates` will be correctly gated off (no split state this time). Worth looking at before or right after this merge.