### PR TITLE
fix(docs_cmd): canonicalize paths in macOS-sensitive test

### DIFF
--- a/src/bin/gtc/docs_cmd.rs
+++ b/src/bin/gtc/docs_cmd.rs
@@ -107,6 +107,11 @@ mod tests {
         let resolved = resolve_sync_script_path().expect("script path");
         env::set_current_dir(old).expect("restore cwd");
 
-        assert_eq!(resolved, script);
+        // macOS tempdirs live under /var which is a symlink to /private/var;
+        // `current_dir()` returns the canonical form, so compare canonicalized paths.
+        assert_eq!(
+            resolved.canonicalize().expect("canonicalize resolved"),
+            script.canonicalize().expect("canonicalize script"),
+        );
     }
 }


### PR DESCRIPTION
## Summary
`docs_cmd::tests::resolve_sync_script_path_prefers_repo_cwd` was passing on Linux/Windows but failing on the `aarch64-apple-darwin` matrix slot of the v1.0.8 release build — which blocked `github_release` and correctly gated off `publish_crates` (pipeline working as designed — no crates/GH split this time).

### Root cause
`tempfile::tempdir()` returns a path under `/var/folders/...`. On macOS `/var` is a symlink to `/private/var`. The test calls `env::set_current_dir(dir.path())`; then inside `resolve_sync_script_path()` we call `env::current_dir()` which returns the kernel-canonicalized form `/private/var/folders/...`. The assertion compared the canonical path from `resolve_sync_script_path()` against the non-canonical `script` path built from `dir.path()`, so they differed.

```
left:  /private/var/folders/.../ci/sync_schema_docs.sh
right:         /var/folders/.../ci/sync_schema_docs.sh
```

Linux has no `/private/` prefix on its tempdirs, so the assertion passed there.

### Fix
Compare `resolved.canonicalize()` vs `script.canonicalize()`. Test-only change, no production behaviour change.

## Test plan
- [x] `cargo test --bin gtc docs_cmd::tests` — passes locally
- [ ] Release matrix on the next tag passes on `aarch64-apple-darwin`
- [ ] After merge, bump to 1.0.9 to cut a clean release

## Context
- v1.0.8 tag already exists, pinned at the broken commit. Crates.io max stays at 1.0.7 (the gate skipped `publish_crates`). After this fix merges, bump to 1.0.9 and let the new pipeline finish a full release → `cargo binstall gtc` recovers.