### PR TITLE
chore: bump gtc to 1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary
Bumps `gtc` to 1.0.9. Skips 1.0.8 — its tag is pinned at a commit with a macOS-only test bug (fixed in #144 on main, not reachable from the v1.0.8 tag). Crates.io max is 1.0.7; on merge this cuts 1.0.9 through the embedded pipeline.

## Expected flow after merge
1. `tag-on-version-bump` creates `v1.0.9`
2. `release.yml` runs: ci → build_binaries (6 targets) → sbom/checksums → github_release → provenance
3. `publish_crates` fires only after `github_release` and `provenance` succeed

## Test plan
- [ ] CI passes on this PR
- [ ] `aarch64-apple-darwin` build passes (macOS symlink test fix lands via #144's parent chain)
- [ ] GH release `v1.0.9` created
- [ ] Crates.io `gtc 1.0.9` published *after* the GH release
- [ ] `cargo binstall gtc@1.0.9` resolves to GH asset, not source