### PR TITLE
ci: make perf nightly-only (remove push trigger)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,13 +1,11 @@
 name: Perf (lightweight)
-# Moved off pull_request onto a nightly schedule. See plans/binary-bifurcation.md
-# Phase A (heavy-job sweep). Manual runs remain via workflow_dispatch.
+# Nightly-only. See plans/binary-bifurcation.md Phase A.8: push-trigger removed
+# because post-merge perf runs were burning 15+ min without actionable signal.
 
 on:
   schedule:
     - cron: "39 3 * * *"
   workflow_dispatch:
-  push:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Drop `push: branches: [main]` from `perf.yml`; keep `schedule` + `workflow_dispatch`.
- Post-merge perf runs were burning 15+ min per commit-to-main without actionable signal — any regression surfaces at the next nightly anyway.

Ref: `plans/binary-bifurcation.md` Phase A.8.

## Test plan
- [ ] Confirm `gh workflow list` still shows perf active.
- [ ] Next nightly (03:XX UTC) runs as scheduled.