### PR TITLE
test: smoke tests for gtc dev <name> info passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -77,6 +77,113 @@ fn passthrough_dev_uses_greentic_dev_bin_override() {
     assert!(logged.contains("flow list"));
 }
 
+// ---------------------------------------------------------------------------
+// Task F3: cross-CLI smoke tests for `gtc dev <name> info` passthrough.
+//
+// `gtc dev <name> ...` forwards every token after `dev` to `greentic-dev`
+// verbatim (see `router::route_passthrough_subcommand`). The second hop
+// (`greentic-dev <name> info ...` -> `greentic-<name> info ...`) is covered by
+// greentic-dev's own integration tests. Here we only need to confirm that the
+// router hands the right args to `greentic-dev` for each of the 5 downstream
+// CLI names (pack, bundle, flow, component, runner).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gtc_dev_pack_info_forwards_args() {
+    let sandbox = TestSandbox::new("gtc_dev_pack_info_forwards_args");
+    let log_file = sandbox.path().join("dev.log");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(
+        ["dev", "pack", "info", "/tmp/fixture.gtpack"],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read dev log");
+    assert!(
+        logged.contains("pack info /tmp/fixture.gtpack"),
+        "expected forwarded args, got: {logged}"
+    );
+}
+
+#[test]
+fn gtc_dev_bundle_info_forwards_args_with_json() {
+    let sandbox = TestSandbox::new("gtc_dev_bundle_info_forwards_args_with_json");
+    let log_file = sandbox.path().join("dev.log");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(
+        ["dev", "bundle", "info", "/tmp/fixture.gtbundle", "--json"],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read dev log");
+    assert!(
+        logged.contains("bundle info /tmp/fixture.gtbundle --json"),
+        "expected forwarded args, got: {logged}"
+    );
+}
+
+#[test]
+fn gtc_dev_flow_info_forwards_args() {
+    let sandbox = TestSandbox::new("gtc_dev_flow_info_forwards_args");
+    let log_file = sandbox.path().join("dev.log");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(["dev", "flow", "info", "/tmp/fixture.ygtc"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read dev log");
+    assert!(
+        logged.contains("flow info /tmp/fixture.ygtc"),
+        "expected forwarded args, got: {logged}"
+    );
+}
+
+#[test]
+fn gtc_dev_component_info_forwards_args() {
+    let sandbox = TestSandbox::new("gtc_dev_component_info_forwards_args");
+    let log_file = sandbox.path().join("dev.log");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(
+        ["dev", "component", "info", "/tmp/fixture.wasm", "--json"],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read dev log");
+    assert!(
+        logged.contains("component info /tmp/fixture.wasm --json"),
+        "expected forwarded args, got: {logged}"
+    );
+}
+
+#[test]
+fn gtc_dev_runner_info_forwards_args() {
+    let sandbox = TestSandbox::new("gtc_dev_runner_info_forwards_args");
+    let log_file = sandbox.path().join("dev.log");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // `runner info` takes no positional path — it reports on the running
+    // runtime. `--json` is the usual companion flag.
+    let status = sandbox.run_gtc(["dev", "runner", "info", "--json"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read dev log");
+    assert!(
+        logged.contains("runner info --json"),
+        "expected forwarded args, got: {logged}"
+    );
+}
+
 #[test]
 fn wizard_passthrough_routes_to_greentic_dev_with_all_args() {
     let sandbox = TestSandbox::new("wizard_passthrough_routes_to_greentic_dev_with_all_args");


### PR DESCRIPTION
## Summary
- Adds 5 smoke tests in \`tests/gtc_router_integration.rs\` confirming \`gtc dev <name> info ...\` forwards arguments verbatim to a mocked \`greentic-dev\` binary, for all 5 downstream CLIs: \`pack\`, \`bundle\`, \`flow\`, \`component\`, \`runner\`
- Uses the existing \`TestSandbox\` + \`write_arg_logger_tool\` pattern from the same file

## Why
Companion to the \`info\` subcommand landing across the Greentic CLI suite:
- greenticai/greentic-pack#120
- greenticai/greentic-bundle#56
- greenticai/greentic-flow#188
- greenticai/greentic-component#58
- greenticai/greentic-runner#293
- greenticai/greentic-dev#115 (passthrough additions)

Locks the \`gtc dev <name> info\` forwarding contract end-to-end from the router's perspective; second-hop \`greentic-dev\` → \`greentic-<name>\` forwarding is covered by greentic-dev's own test suite.

## Tests
- \`gtc_dev_pack_info_forwards_args\`
- \`gtc_dev_bundle_info_forwards_args_with_json\`
- \`gtc_dev_flow_info_forwards_args\`
- \`gtc_dev_component_info_forwards_args\`
- \`gtc_dev_runner_info_forwards_args\` (no positional; --json flag)
- Full \`cargo test -p gtc\` suite green (29 tests in this file), \`ci/local_check.sh\` exit 0

Spec: docs/superpowers/specs/2026-04-22-pack-bundle-info-design.md
Plan: docs/superpowers/plans/2026-04-23-repo-info.md (Phase F)