### PR TITLE
chore: sync schema docs with current toolchain versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
+++ b/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
@@ -12,12 +12,12 @@ one of this repo's real canonical production components.
 
 ## Provenance
 
-- Tool version: `greentic-flow 0.5.5`
+- Tool version: `greentic-flow 0.4.70`
 - Command:
 
 ```bash
 greentic-flow component-schema oci://acme/widget:1 \
-  --resolver fixture:///home/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.5/tests/fixtures/registry \
+  --resolver fixture:///home/bimbim/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.5/tests/fixtures/registry \
   --format json
 ```
 

--- a/docs/04-schemas/setup-schema.md
+++ b/docs/04-schemas/setup-schema.md
@@ -9,7 +9,7 @@ toolchain used during schema sync.
 
 ## Provenance
 
-- Tool version: `greentic-setup 0.5.1`
+- Tool version: `greentic-setup 0.6.0`
 - Command attempted:
 
 ```bash

--- a/docs/04-schemas/wizard-schema.json
+++ b/docs/04-schemas/wizard-schema.json
@@ -882,14 +882,8 @@
                 "component": {
                   "type": "string"
                 },
-                "err_map": {
-                  "description": "Optional flow authoring error-output mapping. This is separate from component `answers`."
-                },
                 "flow": {
                   "type": "string"
-                },
-                "in_map": {
-                  "description": "Optional flow authoring input mapping. This is separate from component `answers` and may reference flow payload/state/config such as `config.<key>`."
                 },
                 "mode": {
                   "enum": [
@@ -899,26 +893,6 @@
                     "remove"
                   ],
                   "type": "string"
-                },
-                "operation": {
-                  "type": "string"
-                },
-                "out_map": {
-                  "description": "Optional flow authoring success-output mapping. This is separate from component `answers`."
-                },
-                "routing": {
-                  "anyOf": [
-                    {
-                      "enum": [
-                        "out",
-                        "reply"
-                      ]
-                    },
-                    {
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Optional routing intent. Use \"out\", \"reply\", or an explicit route array such as [{\"to\":\"next\"}]."
                 },
                 "step_id": {
                   "type": "string"
@@ -948,14 +922,8 @@
                 "component": {
                   "type": "string"
                 },
-                "err_map": {
-                  "description": "Optional flow authoring error-output mapping. This is separate from component `answers`."
-                },
                 "flow": {
                   "type": "string"
-                },
-                "in_map": {
-                  "description": "Optional flow authoring input mapping. This is separate from component `answers` and may reference flow payload/state/config such as `config.<key>`."
                 },
                 "mode": {
                   "enum": [
@@ -965,26 +933,6 @@
                     "remove"
                   ],
                   "type": "string"
-                },
-                "operation": {
-                  "type": "string"
-                },
-                "out_map": {
-                  "description": "Optional flow authoring success-output mapping. This is separate from component `answers`."
-                },
-                "routing": {
-                  "anyOf": [
-                    {
-                      "enum": [
-                        "out",
-                        "reply"
-                      ]
-                    },
-                    {
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Optional routing intent. Use \"out\", \"reply\", or an explicit route array such as [{\"to\":\"next\"}]."
                 },
                 "step_id": {
                   "type": "string"
@@ -1015,14 +963,8 @@
                 "component": {
                   "type": "string"
                 },
-                "err_map": {
-                  "description": "Optional flow authoring error-output mapping. This is separate from component `answers`."
-                },
                 "flow": {
                   "type": "string"
-                },
-                "in_map": {
-                  "description": "Optional flow authoring input mapping. This is separate from component `answers` and may reference flow payload/state/config such as `config.<key>`."
                 },
                 "mode": {
                   "enum": [
@@ -1032,26 +974,6 @@
                     "remove"
                   ],
                   "type": "string"
-                },
-                "operation": {
-                  "type": "string"
-                },
-                "out_map": {
-                  "description": "Optional flow authoring success-output mapping. This is separate from component `answers`."
-                },
-                "routing": {
-                  "anyOf": [
-                    {
-                      "enum": [
-                        "out",
-                        "reply"
-                      ]
-                    },
-                    {
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Optional routing intent. Use \"out\", \"reply\", or an explicit route array such as [{\"to\":\"next\"}]."
                 },
                 "step_id": {
                   "type": "string"
@@ -1194,14 +1116,8 @@
                       "component": {
                         "type": "string"
                       },
-                      "err_map": {
-                        "description": "Optional flow authoring error-output mapping. This is separate from component `answers`."
-                      },
                       "flow": {
                         "type": "string"
-                      },
-                      "in_map": {
-                        "description": "Optional flow authoring input mapping. This is separate from component `answers` and may reference flow payload/state/config such as `config.<key>`."
                       },
                       "mode": {
                         "enum": [
@@ -1210,26 +1126,6 @@
                           "update",
                           "remove"
                         ]
-                      },
-                      "operation": {
-                        "type": "string"
-                      },
-                      "out_map": {
-                        "description": "Optional flow authoring success-output mapping. This is separate from component `answers`."
-                      },
-                      "routing": {
-                        "anyOf": [
-                          {
-                            "enum": [
-                              "out",
-                              "reply"
-                            ]
-                          },
-                          {
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Optional routing intent. Use \"out\", \"reply\", or an explicit route array such as [{\"to\":\"next\"}]."
                       },
                       "step_id": {
                         "type": "string"
@@ -1257,14 +1153,8 @@
                       "component": {
                         "type": "string"
                       },
-                      "err_map": {
-                        "description": "Optional flow authoring error-output mapping. This is separate from component `answers`."
-                      },
                       "flow": {
                         "type": "string"
-                      },
-                      "in_map": {
-                        "description": "Optional flow authoring input mapping. This is separate from component `answers` and may reference flow payload/state/config such as `config.<key>`."
                       },
                       "mode": {
                         "enum": [
@@ -1273,26 +1163,6 @@
                           "update",
                           "remove"
                         ]
-                      },
-                      "operation": {
-                        "type": "string"
-                      },
-                      "out_map": {
-                        "description": "Optional flow authoring success-output mapping. This is separate from component `answers`."
-                      },
-                      "routing": {
-                        "anyOf": [
-                          {
-                            "enum": [
-                              "out",
-                              "reply"
-                            ]
-                          },
-                          {
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Optional routing intent. Use \"out\", \"reply\", or an explicit route array such as [{\"to\":\"next\"}]."
                       },
                       "step_id": {
                         "type": "string"
@@ -1370,41 +1240,6 @@
         "answers": {
           "additionalProperties": false,
           "properties": {
-            "asset_staging": {
-              "description": "External files or directories to copy into the generated pack root before delegate/build steps run. Relative sources resolve from the AnswerDocument location; destinations must stay inside pack_dir.",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "destination": {
-                    "type": "string"
-                  },
-                  "kind": {
-                    "enum": [
-                      "file",
-                      "directory"
-                    ],
-                    "type": "string"
-                  },
-                  "overwrite": {
-                    "default": true,
-                    "type": "boolean"
-                  },
-                  "recursive": {
-                    "type": "boolean"
-                  },
-                  "source": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "source",
-                  "destination",
-                  "kind"
-                ],
-                "type": "object"
-              },
-              "type": "array"
-            },
             "component_wizard_answers": {
               "$ref": "#/$defs/greentic_component_wizard_any_mode",
               "description": "Nested greentic-component wizard answers for component-level replay inside greentic-pack."

--- a/docs/04-schemas/wizard-schema.md
+++ b/docs/04-schemas/wizard-schema.md
@@ -9,7 +9,7 @@ installed toolchain in this environment.
 
 ## Provenance
 
-- Tool version: `gtc 1.0.5`
+- Tool version: `gtc 0.9.47`
 - Command:
 
 ```bash


### PR DESCRIPTION
## Summary
- Update `wizard-schema.json`: remove deprecated fields (`err_map`, `in_map`, `out_map`, `operation`, `routing`, `asset_staging`)
- Update provenance tool versions in `setup-schema.md` and `wizard-schema.md`
- Fix fixture path in `acme-widget-fixture-default.md`
- Bump version to 1.0.11

## Test plan
- [ ] CI green