### PR TITLE
[codex] Harden install and wizard schema checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -308,9 +308,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -1231,10 +1231,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "greentic-i18n"
-version = "0.4.56"
+name = "greentic-i18n-lib"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44951881c763069e14624cf8cf1dddff706ad4d8132570dc299af0b855cf4458"
+checksum = "e1c181b9a5fb0beccd9959fb11296572a7802ee1e237d90ca37ff46e8a1fbef3"
+dependencies = [
+ "blake3",
+ "data-encoding",
+]
 
 [[package]]
 name = "greentic-interfaces"
@@ -1417,14 +1421,14 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "clap",
  "criterion",
  "directories",
  "flate2",
  "greentic-distributor-client",
- "greentic-i18n",
+ "greentic-i18n-lib",
  "greentic-types",
  "insta",
  "oci-distribution",
@@ -1440,6 +1444,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "which",
  "zeroize",
  "zip",
 ]
@@ -1594,9 +1599,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1978,9 +1983,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2969,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2996,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4484,6 +4489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,9 +5188,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"
@@ -21,7 +21,7 @@ clap = { version = "4.5", features = ["std"] }
 directories = "6"
 flate2 = "1.1"
 greentic-distributor-client = { version = "0.5", features = ["dist-client", "oci-components"] }
-greentic-i18n = "0.4"
+greentic-i18n-lib = "0.5"
 greentic-types = "0.5"
 # `oci-distribution` 0.11.0 is still the newest crates.io release available as
 # of 2026-03-30, so ARCH-017 is tracked as resolved-by-verification rather than
@@ -40,6 +40,7 @@ tar = "0.4"
 tempfile = "3.23"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt"] }
+which = "8"
 zeroize = "1.8"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 

--- a/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
+++ b/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
@@ -17,7 +17,7 @@ one of this repo's real canonical production components.
 
 ```bash
 greentic-flow component-schema oci://acme/widget:1 \
-  --resolver fixture:///home/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.5/tests/fixtures/registry \
+  --resolver fixture:///Users/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.2/tests/fixtures/registry \
   --format json
 ```
 

--- a/docs/04-schemas/wizard-schema.md
+++ b/docs/04-schemas/wizard-schema.md
@@ -9,7 +9,7 @@ installed toolchain in this environment.
 
 ## Provenance
 
-- Tool version: `gtc 1.0.5`
+- Tool version: `gtc 1.0.9`
 - Command:
 
 ```bash

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{self, Write};
 
 use clap::ArgMatches;
+use serde_json::Value;
 
 use crate::admin::{
     load_admin_registry, remove_admin_registry_entry, run_admin_access, run_admin_add_client,
@@ -16,7 +17,7 @@ use crate::docs_cmd::run_docs;
 use crate::extensions::{run_extension_setup, run_extension_start, run_extension_wizard};
 use crate::i18n_support::i18n;
 use crate::install::{run_install, run_update};
-use crate::process::{passthrough, run_doctor};
+use crate::process::{passthrough, run_binary_capture, run_doctor};
 use crate::router::{
     collect_tail, detect_locale, locale_from_args, parse_raw_passthrough, passthrough_help_request,
     route_passthrough_subcommand,
@@ -104,10 +105,131 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 return run_extension_setup(sub_matches, &tail, debug, &locale);
             }
             let (binary, args) = route_passthrough_subcommand(name, &tail, &locale).expect("route");
+            if name == "wizard" && has_schema_flag(&args) {
+                return run_wizard_schema(binary, &args, debug, &locale);
+            }
             passthrough(binary, &args, debug, &locale)
         }
         _ => 2,
     }
+}
+
+fn run_wizard_schema(binary: &str, args: &[String], debug: bool, locale: &str) -> i32 {
+    let raw = match run_binary_capture(binary, args, debug, locale) {
+        Ok(raw) => raw,
+        Err(err) => {
+            eprintln!("{err}");
+            return 1;
+        }
+    };
+    let mut schema: Value = match serde_json::from_str(&raw) {
+        Ok(schema) => schema,
+        Err(err) => {
+            eprintln!("invalid wizard schema JSON from {binary}: {err}");
+            return 1;
+        }
+    };
+    rewrite_nested_schema_refs(&mut schema);
+    match serde_json::to_string_pretty(&schema) {
+        Ok(rendered) => {
+            println!("{rendered}");
+            0
+        }
+        Err(err) => {
+            eprintln!("failed to render wizard schema JSON: {err}");
+            1
+        }
+    }
+}
+
+fn has_schema_flag(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--schema" || arg.starts_with("--schema="))
+}
+
+fn rewrite_nested_schema_refs(schema: &mut Value) {
+    rewrite_nested_schema_refs_at(schema, &[], &[], &[], false);
+}
+
+fn rewrite_nested_schema_refs_at(
+    value: &mut Value,
+    value_path: &[String],
+    defs_path: &[String],
+    def_names: &[String],
+    nested_defs: bool,
+) {
+    match value {
+        Value::Object(object) => {
+            let mut current_defs_path = defs_path.to_vec();
+            let mut current_def_names = def_names.to_vec();
+            let mut current_nested_defs = nested_defs;
+            if let Some(Value::Object(defs)) = object.get("$defs") {
+                current_defs_path = value_path.to_vec();
+                current_defs_path.push("$defs".to_string());
+                current_def_names = defs.keys().cloned().collect();
+                current_nested_defs = current_defs_path != ["$defs".to_string()];
+            }
+
+            if current_nested_defs
+                && let Some(Value::String(reference)) = object.get_mut("$ref")
+                && let Some(rewritten) =
+                    rewrite_local_ref(reference, &current_defs_path, &current_def_names)
+            {
+                *reference = rewritten;
+            }
+
+            for (key, child) in object.iter_mut() {
+                let mut child_path = value_path.to_vec();
+                child_path.push(key.clone());
+                rewrite_nested_schema_refs_at(
+                    child,
+                    &child_path,
+                    &current_defs_path,
+                    &current_def_names,
+                    current_nested_defs,
+                );
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let mut item_path = value_path.to_vec();
+                item_path.push(index.to_string());
+                rewrite_nested_schema_refs_at(item, &item_path, defs_path, def_names, nested_defs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_local_ref(
+    reference: &str,
+    defs_path: &[String],
+    def_names: &[String],
+) -> Option<String> {
+    let remaining = reference.strip_prefix("#/$defs/")?;
+    let (name, suffix) = remaining.split_once('/').unwrap_or((remaining, ""));
+    if !def_names.iter().any(|def_name| def_name == name) {
+        return None;
+    }
+    let mut pointer = format!("#/{}", json_pointer_path(defs_path));
+    pointer.push('/');
+    pointer.push_str(&escape_json_pointer_segment(name));
+    if !suffix.is_empty() {
+        pointer.push('/');
+        pointer.push_str(suffix);
+    }
+    Some(pointer)
+}
+
+fn json_pointer_path(path: &[String]) -> String {
+    path.iter()
+        .map(|segment| escape_json_pointer_segment(segment))
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn escape_json_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
 }
 
 fn run_help(sub_matches: &ArgMatches, locale: &str) -> i32 {

--- a/src/bin/gtc/i18n.rs
+++ b/src/bin/gtc/i18n.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 
-use greentic_i18n::normalize_locale;
+use greentic_i18n_lib::normalize_tag;
 use gtc::error::{GtcError, GtcResult};
 use serde_json::Value;
 
@@ -38,6 +38,23 @@ pub(super) fn tf(locale: &str, key: &'static str, replacements: &[(&str, &str)])
 // these localized strings alive for the whole CLI process.
 pub(super) fn leak_str(value: String) -> &'static str {
     Box::leak(value.into_boxed_str())
+}
+
+fn normalize_locale(value: &str) -> String {
+    let cleaned = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .replace('_', "-")
+        .to_ascii_lowercase();
+    let lower = normalize_tag(&cleaned)
+        .map(|tag| tag.as_str().to_string())
+        .unwrap_or(cleaned);
+    match lower.split('-').next() {
+        Some("en") => "en".to_string(),
+        Some(primary) if !primary.is_empty() => primary.to_string(),
+        _ => "en".to_string(),
+    }
 }
 
 pub(super) fn i18n() -> &'static I18nCatalog {

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -307,7 +307,39 @@ pub(super) fn run_update(debug: bool, locale: &str) -> i32 {
     }
 }
 
-fn ensure_install_prereqs(debug: bool, locale: &str) -> i32 {
+pub(crate) fn ensure_install_prereqs(debug: bool, locale: &str) -> i32 {
+    if which::which("mksquashfs").is_err() {
+        eprintln!(
+            "Missing required tool: mksquashfs (install via `brew install squashfs` or `apt install squashfs-tools`)"
+        );
+        return 1;
+    }
+
+    if !rust_version_satisfies("1.95", debug, locale) {
+        eprintln!("Rust 1.95+ required");
+        return 1;
+    }
+
+    if !wasm32_wasip2_target_installed(debug, locale) {
+        println!("Installing wasm32-wasip2...");
+        let status = run_command("rustup", &["target", "add", "wasm32-wasip2"], debug, locale);
+        if status != 0 {
+            return status;
+        }
+    }
+
+    if which::which("cargo-component").is_err() {
+        println!("Installing cargo-component...");
+        let status = run_cargo(
+            &["install".to_string(), "cargo-component".to_string()],
+            debug,
+            locale,
+        );
+        if status != 0 {
+            return status;
+        }
+    }
+
     let installed_binstall = detect_binstall_version(debug, locale);
     let latest_binstall = latest_binstall_version(debug, locale);
 
@@ -684,23 +716,54 @@ fn parse_numeric_version(raw: &str) -> Vec<u64> {
         .collect()
 }
 
-fn run_cargo_capture(args: &[&str], debug: bool, locale: &str) -> Option<std::process::Output> {
-    if debug {
-        eprintln!("{} cargo {:?}", t(locale, "gtc.debug.exec"), args);
+fn rust_version_satisfies(required: &str, debug: bool, locale: &str) -> bool {
+    let Some(output) = run_command_capture("rustc", &["--version"], debug, locale) else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
     }
-    ProcessCommand::new("cargo")
+    parse_first_semver(&String::from_utf8_lossy(&output.stdout))
+        .map(|installed| semver_compare(&installed, required).is_ge())
+        .unwrap_or(false)
+}
+
+fn wasm32_wasip2_target_installed(debug: bool, locale: &str) -> bool {
+    let Some(output) = run_command_capture("rustup", &["target", "list"], debug, locale) else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout).contains("wasm32-wasip2 (installed)")
+}
+
+fn run_command_capture(
+    command: &str,
+    args: &[&str],
+    debug: bool,
+    locale: &str,
+) -> Option<std::process::Output> {
+    if debug {
+        eprintln!("{} {command} {:?}", t(locale, "gtc.debug.exec"), args);
+    }
+    ProcessCommand::new(command)
         .args(args)
         .env("GREENTIC_LOCALE", locale)
         .output()
         .ok()
 }
 
-fn run_cargo(args: &[String], debug: bool, locale: &str) -> i32 {
+fn run_cargo_capture(args: &[&str], debug: bool, locale: &str) -> Option<std::process::Output> {
+    run_command_capture("cargo", args, debug, locale)
+}
+
+fn run_command(command: &str, args: &[&str], debug: bool, locale: &str) -> i32 {
     if debug {
-        eprintln!("{} cargo {:?}", t(locale, "gtc.debug.exec"), args);
+        eprintln!("{} {command} {:?}", t(locale, "gtc.debug.exec"), args);
     }
 
-    match ProcessCommand::new("cargo")
+    match ProcessCommand::new(command)
         .args(args)
         .env("GREENTIC_LOCALE", locale)
         .stdin(Stdio::inherit())
@@ -714,6 +777,11 @@ fn run_cargo(args: &[String], debug: bool, locale: &str) -> i32 {
             1
         }
     }
+}
+
+fn run_cargo(args: &[String], debug: bool, locale: &str) -> i32 {
+    let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_command("cargo", &borrowed, debug, locale)
 }
 
 fn install_tenant_tool_reference(
@@ -2325,6 +2393,16 @@ mod tests {
                 log.display()
             ),
         );
+        write_executable(&dir.path().join("mksquashfs"), "#!/bin/sh\nexit 0\n");
+        write_executable(
+            &dir.path().join("rustc"),
+            "#!/bin/sh\necho 'rustc 1.95.0'\n",
+        );
+        write_executable(
+            &dir.path().join("rustup"),
+            "#!/bin/sh\nif [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n  echo 'wasm32-wasip2 (installed)'\n  exit 0\nfi\nexit 0\n",
+        );
+        write_executable(&dir.path().join("cargo-component"), "#!/bin/sh\nexit 0\n");
 
         let original_path = env::var_os("PATH");
         unsafe {
@@ -2342,6 +2420,56 @@ mod tests {
         assert!(logged.contains("binstall -y --disable-strategies compile greentic-setup"));
         assert!(logged.contains("binstall -y --disable-strategies compile greentic-start"));
         assert!(logged.contains("binstall -y --disable-strategies compile greentic-deployer"));
+
+        unsafe {
+            match original_path {
+                Some(value) => env::set_var("PATH", value),
+                None => env::remove_var("PATH"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_install_prereqs_installs_missing_wasm_target_and_cargo_component() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = executable_tempdir();
+        let cargo_log = dir.path().join("cargo.log");
+        let rustup_log = dir.path().join("rustup.log");
+        let cargo = dir.path().join("cargo");
+        let rustup = dir.path().join("rustup");
+        write_executable(
+            &cargo,
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"binstall\" ] && [ \"$2\" = \"-V\" ]; then\n  echo 'cargo-binstall 1.8.1'\n  exit 0\nfi\nif [ \"$1\" = \"search\" ] && [ \"$2\" = \"cargo-binstall\" ]; then\n  echo 'cargo-binstall = \"1.8.1\"'\n  exit 0\nfi\nexit 0\n",
+                cargo_log.display()
+            ),
+        );
+        write_executable(
+            &rustup,
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n  echo 'wasm32-wasip1 (installed)'\n  exit 0\nfi\nexit 0\n",
+                rustup_log.display()
+            ),
+        );
+        write_executable(&dir.path().join("mksquashfs"), "#!/bin/sh\nexit 0\n");
+        write_executable(
+            &dir.path().join("rustc"),
+            "#!/bin/sh\necho 'rustc 1.95.0'\n",
+        );
+
+        let original_path = env::var_os("PATH");
+        unsafe {
+            env::set_var("PATH", dir.path());
+        }
+
+        assert_eq!(ensure_install_prereqs(false, "en"), 0);
+
+        let cargo_logged = fs::read_to_string(cargo_log).expect("read cargo log");
+        let rustup_logged = fs::read_to_string(rustup_log).expect("read rustup log");
+        assert!(rustup_logged.contains("target list"));
+        assert!(rustup_logged.contains("target add wasm32-wasip2"));
+        assert!(cargo_logged.contains("install cargo-component"));
 
         unsafe {
             match original_path {
@@ -2415,6 +2543,16 @@ mod tests {
                 log.display()
             ),
         );
+        write_executable(&dir.path().join("mksquashfs"), "#!/bin/sh\nexit 0\n");
+        write_executable(
+            &dir.path().join("rustc"),
+            "#!/bin/sh\necho 'rustc 1.95.0'\n",
+        );
+        write_executable(
+            &dir.path().join("rustup"),
+            "#!/bin/sh\nif [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n  echo 'wasm32-wasip2 (installed)'\n  exit 0\nfi\nexit 0\n",
+        );
+        write_executable(&dir.path().join("cargo-component"), "#!/bin/sh\nexit 0\n");
 
         let original_path = env::var_os("PATH");
         unsafe {

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -37,6 +37,70 @@ use std::thread;
 use tempfile::TempDir;
 use tempfile::tempdir;
 
+#[cfg(unix)]
+fn write_test_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write executable");
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[test]
+fn install_fails_fast_if_mksquashfs_missing() {
+    let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+    let original = std::env::var("PATH").unwrap_or_default();
+    unsafe {
+        std::env::set_var("PATH", "/tmp");
+    }
+
+    let status = super::install::ensure_install_prereqs(false, "en");
+
+    unsafe {
+        std::env::set_var("PATH", original);
+    }
+
+    assert_ne!(status, 0, "install should fail if mksquashfs is missing");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_checks_rust_and_targets() {
+    let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempdir().expect("tempdir");
+
+    write_test_executable(&dir.path().join("mksquashfs"), "#!/bin/sh\nexit 0\n");
+    write_test_executable(
+        &dir.path().join("rustc"),
+        "#!/bin/sh\necho 'rustc 1.95.0'\n",
+    );
+    write_test_executable(
+        &dir.path().join("rustup"),
+        "#!/bin/sh\nif [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n  echo 'wasm32-wasip2 (installed)'\n  exit 0\nfi\nexit 0\n",
+    );
+    write_test_executable(&dir.path().join("cargo-component"), "#!/bin/sh\nexit 0\n");
+    write_test_executable(
+        &dir.path().join("cargo"),
+        "#!/bin/sh\nif [ \"$1\" = \"binstall\" ] && [ \"$2\" = \"-V\" ]; then\n  echo 'cargo-binstall 1.8.1'\n  exit 0\nfi\nif [ \"$1\" = \"search\" ] && [ \"$2\" = \"cargo-binstall\" ]; then\n  echo 'cargo-binstall = \"1.8.1\"'\n  exit 0\nfi\nexit 0\n",
+    );
+
+    let original = env::var_os("PATH");
+    unsafe {
+        env::set_var("PATH", dir.path());
+    }
+
+    let status = super::install::ensure_install_prereqs(false, "en");
+
+    unsafe {
+        match original {
+            Some(value) => env::set_var("PATH", value),
+            None => env::remove_var("PATH"),
+        }
+    }
+
+    assert_eq!(status, 0);
+}
+
 #[test]
 fn locale_arg_is_detected_from_equals_flag() {
     let args = vec!["gtc".to_string(), "--locale=nl-NL".to_string()];

--- a/src/perf_targets.rs
+++ b/src/perf_targets.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::time::UNIX_EPOCH;
 
 use crate::config::GtcConfig;
-use greentic_i18n::{normalize_locale, select_locale_with_sources};
+use greentic_i18n_lib::normalize_tag;
 use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
@@ -163,6 +163,41 @@ pub fn detect_locale(
     );
 
     normalize_locale(&selected)
+}
+
+fn normalize_locale(value: &str) -> String {
+    let cleaned = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .replace('_', "-")
+        .to_ascii_lowercase();
+    let lower = normalize_tag(&cleaned)
+        .map(|tag| tag.as_str().to_string())
+        .unwrap_or(cleaned);
+    match lower.split('-').next() {
+        Some("en") => "en".to_string(),
+        Some(primary) if !primary.is_empty() => primary.to_string(),
+        _ => "en".to_string(),
+    }
+}
+
+fn select_locale_with_sources(
+    cli_locale: Option<&str>,
+    explicit: Option<&str>,
+    env_locale: Option<&str>,
+    system_locale: Option<&str>,
+) -> String {
+    for value in [cli_locale, explicit, env_locale, system_locale]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+    {
+        if !value.is_empty() {
+            return normalize_locale(value);
+        }
+    }
+    "en".to_string()
 }
 
 pub fn locale_from_args(raw_args: &[String]) -> Option<String> {

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -3,6 +3,8 @@ use std::env;
 use std::fs;
 #[cfg(unix)]
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -243,7 +245,25 @@ fn wizard_schema_passthrough_emits_dev_schema() {
             "answers": {
                 "type": "object",
                 "properties": {
-                    "selected_action": { "enum": ["pack", "bundle"] }
+                    "selected_action": { "enum": ["pack", "bundle"] },
+                    "delegate_answer_document": {
+                        "$ref": "#/$defs/greentic_pack_wizard_answers"
+                    }
+                }
+            }
+        },
+        "$defs": {
+            "greentic_pack_wizard_answers": {
+                "type": "object",
+                "$defs": {
+                    "greentic_component_wizard_any_mode": {
+                        "type": "object"
+                    }
+                },
+                "properties": {
+                    "component_wizard_answers": {
+                        "$ref": "#/$defs/greentic_component_wizard_any_mode"
+                    }
                 }
             }
         }
@@ -286,6 +306,62 @@ fn wizard_schema_passthrough_emits_dev_schema() {
             .collect::<Vec<_>>(),
         vec!["pack", "bundle"]
     );
+    assert_all_local_refs_exist(&emitted);
+    assert_eq!(
+        emitted
+            .pointer("/$defs/greentic_pack_wizard_answers/properties/component_wizard_answers/$ref")
+            .and_then(serde_json::Value::as_str),
+        Some("#/$defs/greentic_pack_wizard_answers/$defs/greentic_component_wizard_any_mode")
+    );
+}
+
+fn assert_all_local_refs_exist(schema: &serde_json::Value) {
+    let mut missing = Vec::new();
+    collect_missing_local_refs(schema, schema, "", &mut missing);
+    assert!(
+        missing.is_empty(),
+        "schema contains missing local refs: {missing:?}"
+    );
+}
+
+fn collect_missing_local_refs(
+    root: &serde_json::Value,
+    value: &serde_json::Value,
+    path: &str,
+    missing: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(serde_json::Value::as_str)
+                && reference.starts_with("#/")
+                && !json_pointer_exists(root, reference)
+            {
+                missing.push(format!("{path} -> {reference}"));
+            }
+            for (key, child) in object {
+                let child_path = format!("{path}/{}", escape_json_pointer_segment(key));
+                collect_missing_local_refs(root, child, &child_path, missing);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                let child_path = format!("{path}/{index}");
+                collect_missing_local_refs(root, child, &child_path, missing);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_pointer_exists(root: &serde_json::Value, reference: &str) -> bool {
+    let Some(pointer) = reference.strip_prefix('#') else {
+        return false;
+    };
+    root.pointer(pointer).is_some()
+}
+
+fn escape_json_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
 }
 
 #[test]
@@ -513,6 +589,8 @@ fn install_public_mode_calls_greentic_dev_install_tools() {
     sandbox.write_exit_tool("greentic-operator", 0);
     sandbox.write_contract_deployer_tool("greentic-deployer");
     sandbox.write_cargo_binstall_tool(&cargo_log_file, None);
+    #[cfg(unix)]
+    sandbox.write_install_prereq_tools();
     fs::create_dir_all(&cargo_home).expect("cargo_home");
 
     let mut extra = HashMap::new();
@@ -547,6 +625,7 @@ fn install_tenant_mode_uses_env_key_and_installs_tools_and_docs() {
     sandbox.write_exit_tool("greentic-operator", 0);
     sandbox.write_contract_deployer_tool("greentic-deployer");
     sandbox.write_cargo_binstall_tool(&cargo_log_file, None);
+    sandbox.write_install_prereq_tools();
 
     let mock_root = sandbox.path().join("mock-dist");
     fs::create_dir_all(&mock_root).expect("mock root");
@@ -709,6 +788,8 @@ fn install_skips_tenant_when_public_install_fails() {
     sandbox.write_exit_tool("greentic-dev", 23);
     sandbox.write_exit_tool("greentic-operator", 0);
     sandbox.write_cargo_binstall_tool(&cargo_log_file, None);
+    #[cfg(unix)]
+    sandbox.write_install_prereq_tools();
 
     let mock_root = sandbox.path().join("mock-dist");
     fs::create_dir_all(&mock_root).expect("mock root");
@@ -1189,6 +1270,24 @@ impl TestSandbox {
             &path,
             &rust_cargo_binstall_tool_program(log_file, fail_on_contains),
         );
+    }
+
+    #[cfg(unix)]
+    fn write_shell_tool(&self, name: &str, body: &str) {
+        let path = self.binary_path(name);
+        fs::write(&path, body).expect("write shell tool");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod shell tool");
+    }
+
+    #[cfg(unix)]
+    fn write_install_prereq_tools(&self) {
+        self.write_shell_tool("mksquashfs", "#!/bin/sh\nexit 0\n");
+        self.write_shell_tool("rustc", "#!/bin/sh\necho 'rustc 1.95.0'\n");
+        self.write_shell_tool(
+            "rustup",
+            "#!/bin/sh\nif [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n  echo 'wasm32-wasip2 (installed)'\n  exit 0\nfi\nexit 0\n",
+        );
+        self.write_shell_tool("cargo-component", "#!/bin/sh\nexit 0\n");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Add install preflight checks for mksquashfs, Rust 1.95+, wasm32-wasip2, and cargo-component.
- Keep install tests hermetic with sandboxed prerequisite shims.
- Fix gtc wizard --schema so nested local refs resolve after embedded schema composition.
- Move locale normalization call sites onto greentic-i18n-lib while preserving existing behavior.
- Refresh generated schema docs for updated schema output.

## Validation

- cargo test install_
- cargo test wizard_schema_passthrough_emits_dev_schema
- target/debug/gtc wizard --schema with local ref validation: refs=16 missing=0
- cargo clippy --all-targets --all-features