### PR TITLE
feat(wizard): --schema=full + sub-schema discovery docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/docs/04-schemas/wizard-schema.md
+++ b/docs/04-schemas/wizard-schema.md
@@ -9,7 +9,7 @@ installed toolchain in this environment.
 
 ## Provenance
 
-- Tool version: `gtc 1.0.10`
+- Tool version: `gtc 1.0.11`
 - Command:
 
 ```bash
@@ -31,17 +31,41 @@ gtc wizard --schema
 ## What This Schema Represents
 
 The emitted schema is the launcher-level answer contract exposed by the current
-installed `gtc` toolchain.
+installed `gtc` toolchain. Its `$defs` include `greentic_bundle_wizard_answers`
+and `greentic_pack_wizard_answers`, which cover the bundle and pack delegate
+paths end-to-end.
 
 It is not only a tiny top-level wrapper. The raw JSON also embeds nested schema
 material for delegated pack and bundle answers, which is why the captured raw
 artifact is substantially larger than a simple launcher contract.
+
+## Component And Flow Sub-Schemas
+
+The launcher schema deliberately does not inline component-level or flow-level
+wizard answer shapes — those contracts live with the tools that own them, and
+each is a self-contained schema document with its own top-level identity. To
+validate nested `component_wizard_answers` or `flow_wizard_answers` blocks
+inside an `answers.json`, fetch the relevant sub-schema directly from the
+companion binary:
+
+```bash
+greentic-component wizard --schema   # qa-answers envelope (schema: component-wizard-run/v1)
+greentic-flow wizard --schema        # flow plan answers
+```
+
+Both return flat schemas (no nested `$defs`). Validate each nested answers
+block against its own sub-schema in addition to validating the outer
+`answers.json` against the launcher schema documented above. `gtc wizard
+--schema` alone will not detect mistakes inside the nested component or flow
+blocks.
 
 ## How To Use It
 
 - Use this schema before creating or validating wizard `answers.json` input for
   the launcher path.
 - Treat the raw JSON artifact as the canonical machine-derived reference.
+- For nested `component_wizard_answers` and `flow_wizard_answers` blocks, also
+  validate against the per-tool sub-schemas described above.
 - Use prose docs such as [`../02-cli/gtc-wizard.md`](../02-cli/gtc-wizard.md)
   only as interpretation and guidance around the emitted contract.
 

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -89,6 +89,8 @@ const BUNDLE_BIN: &str = "greentic-bundle";
 const DEPLOYER_BIN: &str = "greentic-deployer";
 const SETUP_BIN: &str = "greentic-setup";
 const START_BIN: &str = "greentic-start";
+const COMPONENT_BIN: &str = "greentic-component";
+const FLOW_BIN: &str = "greentic-flow";
 fn main() {
     let raw_args: Vec<String> = std::env::args().collect();
     let exit_code = run(raw_args);

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -213,9 +213,7 @@ fn capture_companion_schema(binary: &str, debug: bool, locale: &str) -> Option<V
         Ok(raw) => match serde_json::from_str(&raw) {
             Ok(value) => Some(value),
             Err(err) => {
-                eprintln!(
-                    "warning: companion schema from {binary} is not valid JSON: {err}"
-                );
+                eprintln!("warning: companion schema from {binary} is not valid JSON: {err}");
                 None
             }
         },

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -106,6 +106,9 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
             }
             let (binary, args) = route_passthrough_subcommand(name, &tail, &locale).expect("route");
             if name == "wizard" && has_schema_flag(&args) {
+                if has_schema_full_flag(&args) {
+                    return run_wizard_schema_full(binary, &args, debug, &locale);
+                }
                 return run_wizard_schema(binary, &args, debug, &locale);
             }
             passthrough(binary, &args, debug, &locale)
@@ -145,6 +148,82 @@ fn run_wizard_schema(binary: &str, args: &[String], debug: bool, locale: &str) -
 fn has_schema_flag(args: &[String]) -> bool {
     args.iter()
         .any(|arg| arg == "--schema" || arg.starts_with("--schema="))
+}
+
+fn has_schema_full_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--schema=full")
+}
+
+fn strip_schema_full(args: &[String]) -> Vec<String> {
+    args.iter()
+        .map(|arg| {
+            if arg == "--schema=full" {
+                "--schema".to_string()
+            } else {
+                arg.clone()
+            }
+        })
+        .collect()
+}
+
+fn run_wizard_schema_full(binary: &str, args: &[String], debug: bool, locale: &str) -> i32 {
+    let stripped = strip_schema_full(args);
+
+    let launcher_raw = match run_binary_capture(binary, &stripped, debug, locale) {
+        Ok(raw) => raw,
+        Err(err) => {
+            eprintln!("{err}");
+            return 1;
+        }
+    };
+    let mut launcher: Value = match serde_json::from_str(&launcher_raw) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("invalid wizard schema JSON from {binary}: {err}");
+            return 1;
+        }
+    };
+    rewrite_nested_schema_refs(&mut launcher);
+
+    let component =
+        capture_companion_schema(super::COMPONENT_BIN, debug, locale).unwrap_or(Value::Null);
+    let flow = capture_companion_schema(super::FLOW_BIN, debug, locale).unwrap_or(Value::Null);
+
+    let aggregated = serde_json::json!({
+        "launcher": launcher,
+        "component": component,
+        "flow": flow,
+    });
+
+    match serde_json::to_string_pretty(&aggregated) {
+        Ok(rendered) => {
+            println!("{rendered}");
+            0
+        }
+        Err(err) => {
+            eprintln!("failed to render wizard schema JSON: {err}");
+            1
+        }
+    }
+}
+
+fn capture_companion_schema(binary: &str, debug: bool, locale: &str) -> Option<Value> {
+    let args = vec!["wizard".to_string(), "--schema".to_string()];
+    match run_binary_capture(binary, &args, debug, locale) {
+        Ok(raw) => match serde_json::from_str(&raw) {
+            Ok(value) => Some(value),
+            Err(err) => {
+                eprintln!(
+                    "warning: companion schema from {binary} is not valid JSON: {err}"
+                );
+                None
+            }
+        },
+        Err(err) => {
+            eprintln!("warning: companion schema from {binary} unavailable: {err}");
+            None
+        }
+    }
 }
 
 fn rewrite_nested_schema_refs(schema: &mut Value) {


### PR DESCRIPTION
## Summary

- Add `gtc wizard --schema=full` mode that aggregates the launcher schema with `greentic-component wizard --schema` and `greentic-flow wizard --schema` into a single `{launcher, component, flow}` JSON document.
- Document the per-binary sub-schema discovery path in `docs/04-schemas/wizard-schema.md` and bump the documented tool version stub to `gtc 1.0.11`.

## Why

Paul (3Point.ai) running `gtc wizard --schema` to validate `answers.json` saw 14 internal `$ref`s but only 2 `$defs` entries — 12 nested refs (component/flow wizard answer shapes) were unresolvable. The launcher schema deliberately defers component/flow shapes to companion binaries; that contract was undocumented and undiscoverable without reading source.

`--schema=full` closes the discovery gap programmatically; the doc patch closes it for humans following the existing schema-first authoring rule. Plain `--schema` (without `=full`) is unchanged — backward compatible.

## Implementation notes

- Companion captures are best-effort: a missing or non-JSON output emits a warning to stderr but the document still returns with the remaining sub-schemas, so the command does not hard-fail when one binary is unavailable.
- New `COMPONENT_BIN`/`FLOW_BIN` constants in `src/bin/gtc.rs` mirror existing `BUNDLE_BIN`/`SETUP_BIN` style.

## Test plan

- [x] `cargo test --lib --bins` → 206 passed, 0 failed, 2 ignored
- [x] `cargo build --bin gtc` clean
- [x] Live: `./target/debug/gtc wizard --schema=full | jq 'keys'` → `["component", "flow", "launcher"]`, all valid objects
- [x] Live: `./target/debug/gtc wizard --schema` (no `=full`) still returns existing single-document schema