### PR TITLE
chore: sync dev-publish caller from REPO_MANIFEST.toml

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -8,15 +8,31 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # Stage 1 — tests + version stamping. Outputs the stamped dev version
+  # {M.m.GITHUB_RUN_ID} consumed by binaries + publish.
+  dev-prepare:
+    uses: greenticai/.github/.github/workflows/dev-prepare.yml@main
+
+  dev-binaries-gtc:
+    needs: dev-prepare
+    uses: greenticai/.github/.github/workflows/dev-release-binaries.yml@main
+    with:
+      package: gtc
+      version: ${{ needs.dev-prepare.outputs.version }}
+
   dev-publish:
+    needs: [dev-prepare, dev-binaries-gtc]
     uses: greenticai/.github/.github/workflows/dev-publish.yml@main
     with:
+      version: ${{ needs.dev-prepare.outputs.version }}
       crates: "gtc"
+      binary-crates: "gtc"
+      dual-role-binary-crates: "gtc"
     secrets: inherit


### PR DESCRIPTION
Syncs `dev-publish.yml` caller workflow from `REPO_MANIFEST.toml`.

Crates: `gtc`
Variant: host (tier 5)

Source: [REPO_MANIFEST.toml](https://github.com/greenticai/.github/blob/main/toolchain/REPO_MANIFEST.toml)