### PR TITLE
chore: start 1.1 pre-release lane (1.1.0-dev.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
+bin = [
+    { name = "gtc", path = "src/bin/gtc.rs" },
+]
+bench = [
+    { name = "perf", harness = false },
+]
+
 [package]
 name = "gtc"
-version = "1.0.11"
+version = "1.1.0-dev.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"
@@ -9,53 +16,12 @@ repository = "https://github.com/greenticai/greentic"
 homepage = "https://greentic.ai"
 build = "build.rs"
 exclude = [
-  "greentic_readme_assets/**",
-  ".i18n/translator-state.json",
-  ".greentic/**",
-  ".codex/**",
-  "myfirst.gtbundle/**",
+    "greentic_readme_assets/**",
+    ".i18n/translator-state.json",
+    ".greentic/**",
+    ".codex/**",
+    "myfirst.gtbundle/**",
 ]
-
-[dependencies]
-clap = { version = "4.5", features = ["std"] }
-directories = "6"
-flate2 = "1.1"
-greentic-distributor-client = { version = "0.5", features = ["dist-client", "oci-components"] }
-greentic-i18n-lib = "0.5"
-greentic-types = "0.5"
-# `oci-distribution` 0.11.0 is still the newest crates.io release available as
-# of 2026-03-30, so ARCH-017 is tracked as resolved-by-verification rather than
-# by a version bump from this repo.
-oci-distribution = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-rcgen = "0.14"
-rpassword = "7.4"
-# `gtc` currently uses the blocking client in its CLI download/auth flows, so
-# we keep the feature explicitly until those code paths move off blocking HTTP.
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml_bw = "2.5"
-sha2 = "0.11"
-tar = "0.4"
-tempfile = "3.23"
-thiserror = "2.0"
-tokio = { version = "1.52", features = ["rt"] }
-which = "8"
-zeroize = "1.8"
-zip = { version = "8", default-features = false, features = ["deflate"] }
-
-[dev-dependencies]
-criterion = "0.8"
-insta = "1.43"
-proptest = "1.7"
-
-[[bin]]
-name = "gtc"
-path = "src/bin/gtc.rs"
-
-[[bench]]
-name = "perf"
-harness = false
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
@@ -67,3 +33,71 @@ pkg-fmt = "zip"
 
 [package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
 pkg-fmt = "zip"
+
+[dependencies]
+directories = "6"
+flate2 = "1.1"
+greentic-i18n-lib = "0.5"
+greentic-types = "0.5"
+rcgen = "0.14"
+rpassword = "7.4"
+serde_json = "1.0"
+serde_yaml_bw = "2.5"
+sha2 = "0.11"
+tar = "0.4"
+tempfile = "3.23"
+thiserror = "2.0"
+which = "8"
+zeroize = "1.8"
+
+[dependencies.clap]
+version = "4.5"
+features = [
+    "std",
+]
+
+[dependencies.greentic-distributor-client]
+version = "0.5"
+features = [
+    "dist-client",
+    "oci-components",
+]
+
+[dependencies.oci-distribution]
+version = "0.11"
+default-features = false
+features = [
+    "rustls-tls",
+]
+
+[dependencies.reqwest]
+version = "0.13"
+default-features = false
+features = [
+    "blocking",
+    "rustls",
+]
+
+[dependencies.serde]
+version = "1.0"
+features = [
+    "derive",
+]
+
+[dependencies.tokio]
+version = "1.52"
+features = [
+    "rt",
+]
+
+[dependencies.zip]
+version = "8"
+default-features = false
+features = [
+    "deflate",
+]
+
+[dev-dependencies]
+criterion = "0.8"
+insta = "1.43"
+proptest = "1.7"


### PR DESCRIPTION
Kicks off the 1.1 pre-release lane for `greentic`.

**Changes:**
- Package version: `1.0.11` → `1.1.0-dev.0`
- Greentic-ecosystem dep reqs rewritten to pre-release range form: `">=1.1.0-dev, <1.2.0-0"`

**Firewall note:** Cargo's pre-release matching means `^1.0` in consumer repos does NOT resolve `1.1.0-dev.0`. Consumers opt in by updating their own dep reqs. See the cascade plan at `.github/cascade-plans/greentic-1.1.0-dev.0.md` for tier-ordered adoption.

**Follow-up:**
- [ ] Update `REPO_MANIFEST.toml` entry for `greentic`: `version-track = { from = "1.0", to = "1.1" }`
- [ ] Smoke-test dev-publish workflow picks up `-dev.N` version
- [ ] Begin tier-ordered consumer adoption per cascade plan

Generated by `start-next-minor.sh`.