### PR TITLE
chore(gtc): bump to 1.1.0-dev.2 and resync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.0-dev.0"
+version = "1.1.0-dev.2"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.0-dev.1"
+version = "1.1.0-dev.2"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary
- PR #168 bumped `Cargo.toml` from `1.1.0-dev.0` to `1.1.0-dev.1` without regenerating `Cargo.lock`, which still records `gtc 1.1.0-dev.0`.
- `dev-publish.yml` binary builds run `cargo build --release --locked`, so the desync now blocks every dev publish (see [run 25052566037](https://github.com/greenticai/greentic/actions/runs/25052566037) — all 6 binary build jobs fail with `cannot update the lock file ... because --locked was passed`).
- Bumps to `1.1.0-dev.2` and regenerates the matching `Cargo.lock` entry so the locked build can resolve. Going to dev.2 (rather than just realigning dev.1) keeps the dev-lane counter monotonic in case anything dev.1 was published partially.

## Test plan
- [x] `cargo build --release --locked --package gtc --bin gtc` succeeds locally on the branch.
- [ ] After merge: `Dev Publish` on develop succeeds, including `Bifurcate gtc (--dual-role)` (now also covered by greenticai/.github#134).