### PR TITLE
chore(gtc): bump to 1.1.0-dev.3 to republish via fixed dev pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.0-dev.2"
+version = "1.1.0-dev.3"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.0-dev.2"
+version = "1.1.0-dev.3"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary

- Bump `gtc` 1.1.0-dev.2 → 1.1.0-dev.3
- Resync `Cargo.lock` so `cargo build --locked` stays green
- Trigger a fresh Dev Publish to ship a corrected `gtc-dev` to crates.io

## Why

The previous dev publish (`gtc-dev v1.1.25053490868`, [run 25052566037](https://github.com/greenticai/greentic/actions/runs/25052566037)) was broken in two ways that root-cause back to `rewrite-binary-name.py` not handling crates that are both a lib and a bin (dual-target):

1. `cargo install gtc-dev` failed with E0432/E0433 because `use gtc::error::...` in the bin source resolved to nothing once the package rename implicitly renamed the auto-discovered lib `gtc → gtc_dev`. Cascading `[u8]`/`str` "size not known" errors were downstream.
2. `cargo binstall gtc-dev` 404'd because the author-supplied `[package.metadata.binstall]` pointed at the stable release archive layout, which the dev pipeline doesn't produce — so binstall fell back to source-build, which then hit (1).

Both bugs are fixed in [greenticai/.github#135](https://github.com/greenticai/.github/pull/135) (now on `.github/main`):
- `_inject_lib_override_if_needed` pins `[lib].name = \"gtc\"` on the staged copy so internal `use gtc::...` keeps resolving after the package rename
- `force_dev_binstall` overwrites the staged copy's binstall metadata with the dev-pipeline-compatible layout (drops author overrides)

This bump just re-runs the dev publish so a corrected `gtc-dev` ships.

## Test plan

- [x] `cargo build --release --locked --package gtc --bin gtc` succeeds locally with the new version
- [ ] After merge: dispatch `Dev Publish` on `develop` and confirm
  - the `Bifurcate gtc (--dual-role)` step now produces a staged copy with `[lib].name = \"gtc\"` and the dev-pipeline binstall block
  - the resulting `gtc-dev v1.1.<run-id>` on crates.io passes `cargo install gtc-dev` (source build)
  - `cargo binstall gtc-dev` finds the prebuilt asset instead of falling back to source
- [ ] Yank broken `gtc-dev v1.1.25053490868` from crates.io once the new publish is live