### PR TITLE
chore(gtc): bump to 1.1.0-dev.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.0-dev.3"
+version = "1.1.0-dev.4"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.0-dev.3"
+version = "1.1.0-dev.4"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary

Bump gtc to 1.1.0-dev.4 to trigger a fresh dev-pipeline publish.

v1.1.0-dev.3 was published before the binstall metadata fix in greenticai/.github#135 fully propagated to all dev-publish runners. This bump produces a new `gtc-dev` artefact whose Cargo.toml carries the correct dev-pipeline binstall layout (`{ name }-v{ version }-{ target }.tgz`), so `cargo binstall gtc-dev` should resolve a prebuilt asset instead of falling back to source.

## Test plan

- [x] `cargo build --release --locked --package gtc --bin gtc` clean
- [ ] After merge: dispatch greentic Dev Publish on `develop`, confirm crates.io shows `gtc-dev v1.1.0-dev.4`
- [ ] `cargo binstall gtc-dev` finds prebuilt asset (no source fallback)
- [ ] Yank `gtc-dev v1.1.25053490868` once the new publish is live

## Related

- greenticai/.github#135 — binstall metadata force-rewrite + lib name pin
- greenticai/greentic#172 — previous bump (1.1.0-dev.3, merged)
- greenticai/greentic-dev#124 — toolchain manifest publisher fix (separate track)