### PR TITLE
Relax legacy deployer dist-pack install check

### DIFF
--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -54,17 +54,6 @@ pub(super) fn run_install(
         return 0;
     }
 
-    if let Err(err) = ensure_deployer_dist_pack(debug, locale) {
-        eprintln!(
-            "{}: {err}",
-            tf(
-                locale,
-                "gtc.install.item_fail",
-                &[("kind", "asset"), ("name", "deployer dist packs")]
-            )
-        );
-    }
-
     let tenant = sub_matches
         .get_one::<String>("tenant")
         .map(|v| v.trim().to_string())

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -63,7 +63,6 @@ pub(super) fn run_install(
                 &[("kind", "asset"), ("name", "deployer dist packs")]
             )
         );
-        return 1;
     }
 
     let tenant = sub_matches


### PR DESCRIPTION
## Summary
- stop failing Installing public Greentic tools.
Resolved Greentic toolchain manifest from ghcr.io/greenticai/greentic-versions/gtc:stable.
  digest: sha256:3f5acb3d71d2b71d7a5facb2ab28f7daa325bfc38bd566ba3f104b52aae4e592
Installing greentic-dev binary greentic-dev.
 INFO resolve: Resolving package: 'greentic-dev@=0.5.2'
 WARN The package greentic-dev v0.5.2 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-dev => /home/vgrishkyan/.cargo/bin/greentic-dev
 INFO Installing binaries...
 INFO Done in 6.749522847s
Installed greentic-dev binary greentic-dev: OK
Installing greentic-operator binary greentic-operator.
 INFO resolve: Resolving package: 'greentic-operator@=0.4.49'
 WARN The package greentic-operator v0.4.49 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-operator => /home/vgrishkyan/.cargo/bin/greentic-operator
 INFO Installing binaries...
 INFO Done in 12.900740612s
Installed greentic-operator binary greentic-operator: OK
Installing greentic-bundle binary greentic-bundle.
 INFO resolve: Resolving package: 'greentic-bundle@=0.5.2'
 WARN The package greentic-bundle v0.5.2 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-bundle => /home/vgrishkyan/.cargo/bin/greentic-bundle
 INFO Installing binaries...
 INFO Done in 7.641792566s
Installed greentic-bundle binary greentic-bundle: OK
Installing greentic-setup binary greentic-setup.
 INFO resolve: Resolving package: 'greentic-setup@=0.5.2'
 WARN The package greentic-setup v0.5.2 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-setup => /home/vgrishkyan/.cargo/bin/greentic-setup
 INFO Installing binaries...
 INFO Done in 7.899071383s
Installed greentic-setup binary greentic-setup: OK
Installing greentic-start binary greentic-start.
 INFO resolve: Resolving package: 'greentic-start@=0.5.7'
 WARN The package greentic-start v0.5.7 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-start => /home/vgrishkyan/.cargo/bin/greentic-start
 INFO Installing binaries...
 INFO Done in 10.100333303s
Installed greentic-start binary greentic-start: OK
Installing greentic-deployer binary greentic-deployer.
 INFO resolve: Resolving package: 'greentic-deployer@=0.4.52'
 WARN The package greentic-deployer v0.4.52 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-deployer => /home/vgrishkyan/.cargo/bin/greentic-deployer
 INFO Installing binaries...
 INFO Done in 6.263327895s
Installed greentic-deployer binary greentic-deployer: OK
Installing greentic-component binary greentic-component.
 INFO resolve: Resolving package: 'greentic-component@=0.5.2'
 WARN The package greentic-component v0.5.2 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-component => /home/vgrishkyan/.cargo/bin/greentic-component
 INFO Installing binaries...
 INFO Done in 13.935591135s
Installed greentic-component binary greentic-component: OK
Installing greentic-flow binary greentic-flow.
 INFO resolve: Resolving package: 'greentic-flow@=0.5.7'
 WARN The package greentic-flow v0.5.7 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-flow => /home/vgrishkyan/.cargo/bin/greentic-flow
 INFO Installing binaries...
 INFO Done in 8.581355282s
Installed greentic-flow binary greentic-flow: OK
Installing greentic-pack binary greentic-pack.
 INFO resolve: Resolving package: 'greentic-pack@=0.5.5'
 WARN The package greentic-pack v0.5.5 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-pack => /home/vgrishkyan/.cargo/bin/greentic-pack
 INFO Installing binaries...
 INFO Done in 8.742945452s
Installed greentic-pack binary greentic-pack: OK
Installing greentic-runner binary greentic-runner.
 INFO resolve: Resolving package: 'greentic-runner@=0.5.12'
 WARN The package greentic-runner v0.5.12 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-runner => /home/vgrishkyan/.cargo/bin/greentic-runner
 INFO Installing binaries...
 INFO Done in 11.798451124s
Installed greentic-runner binary greentic-runner: OK
Installing greentic-gui binary greentic-gui.
 INFO resolve: Resolving package: 'greentic-gui@=0.5.2'
 WARN The package greentic-gui v0.5.2 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-gui => /home/vgrishkyan/.cargo/bin/greentic-gui
 INFO Installing binaries...
 INFO Done in 8.644466576s
Installed greentic-gui binary greentic-gui: OK
Installing greentic-secrets binary greentic-secrets.
 INFO resolve: Resolving package: 'greentic-secrets@=0.5.0'
 WARN The package greentic-secrets v0.5.0 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-secrets => /home/vgrishkyan/.cargo/bin/greentic-secrets
 INFO Installing binaries...
 INFO Done in 5.648188231s
Installed greentic-secrets binary greentic-secrets: OK
Installing greentic-mcp binary greentic-mcp.
 INFO resolve: Resolving package: 'greentic-mcp@=0.5.1'
 INFO resolve: Verified signature for package 'greentic-mcp-0.5.1-x86_64-unknown-linux-gnu': timestamp:1776963134	file:greentic-mcp-0.5.1-x86_64-unknown-linux-gnu.tar.gz	hashed
 WARN The package greentic-mcp v0.5.1 (x86_64-unknown-linux-gnu) has been downloaded from third-party source QuickInstall
 INFO This will install the following binaries:
 INFO   - greentic-mcp => /home/vgrishkyan/.cargo/bin/greentic-mcp
 INFO Installing binaries...
 INFO Done in 6.423330632s
Installed greentic-mcp binary greentic-mcp: OK when legacy deployer dist packs are missing locally
- keep the warning, but allow install to continue in the newer bundle-driven architecture
- preserve the deployment path where cloud deployer packs are selected by the wizard and materialized from OCI into the bundle

## Validation
- cargo fmt --manifest-path greentic/Cargo.toml
- cargo test --manifest-path greentic/Cargo.toml ensure_deployer_dist_pack_requires_installed_dist_pack --bin gtc
- cargo check --manifest-path greentic/Cargo.toml --bin gtc