### PR TITLE
[codex] Fix provider pack tests on Windows

### DIFF
--- a/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
@@ -235,10 +235,13 @@ mod tests {
         resolve_deploy_app_pack_path, resolve_target_provider_pack_from_metadata,
     };
     use crate::deploy::StartTarget;
-    use crate::tests::{env_test_lock, fake_deployer_contract};
+    #[cfg(unix)]
+    use crate::tests::fake_deployer_contract;
+    use crate::tests::env_test_lock;
     use std::fs;
     use std::path::Path;
 
+    #[cfg(unix)]
     #[test]
     fn canonical_target_provider_pack_filename_matches_cloud_targets() {
         let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());


### PR DESCRIPTION
## Summary

- Gate the Unix-only fake deployer test helper import in `provider_packs.rs`.
- Skip the provider pack test that depends on the Unix fake deployer script on non-Unix targets.
- Keep the pure provider pack metadata/path tests compiling and running on Windows.

## Root Cause

`fake_deployer_contract` is defined behind `#[cfg(unix)]`, but `provider_packs.rs` imported it unconditionally in its test module. Windows builds therefore failed before tests could run.

## Validation

- `cargo test -p gtc --bin gtc --no-run`