### PR TITLE
[codex] Bump gtc to 1.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "clap",
  "criterion",
@@ -1550,7 +1550,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2934,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.1"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -3321,7 +3321,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary

- Bump the `gtc` crate version from `1.0.16` to `1.0.17`.
- Refresh `Cargo.lock` for the version update and dependency lockfile changes.

## Validation

- `cargo check -p gtc`