### PR TITLE
[codex] Fix rustfmt import order

### DIFF
--- a/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
@@ -235,9 +235,9 @@ mod tests {
         resolve_deploy_app_pack_path, resolve_target_provider_pack_from_metadata,
     };
     use crate::deploy::StartTarget;
+    use crate::tests::env_test_lock;
     #[cfg(unix)]
     use crate::tests::fake_deployer_contract;
-    use crate::tests::env_test_lock;
     use std::fs;
     use std::path::Path;
 


### PR DESCRIPTION
## Summary

- Apply rustfmt's import ordering in `provider_packs.rs`.
- Fix the CI failure from `cargo fmt --all -- --check`.

## Validation

- `cargo fmt --all -- --check`