### PR TITLE
fix: emit .zip for Windows in rc-build.yml

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -51,4 +51,5 @@ jobs:
       binary: gtc
       ref: ${{ inputs.ref }}
       tag: ${{ inputs.tag }}
+      windows-archive-format: zip
     secrets: inherit


### PR DESCRIPTION
## Summary

One-line fix: pass \`windows-archive-format: zip\` to the \`release-binaries-rc.yml\` reusable so RC builds match stable builds (\`release.yml\` lines 101–108) on Windows.

## Why

Without this, the dry-run produced \`.tgz\` archives for Windows targets while \`release.yml\` ships \`.zip\`. Keeping RC and stable aligned simplifies the (forthcoming) E2E install branch in \`nightly-e2e.yml\` — it only forks on RC-vs-stable, not also on archive extension.

## Test plan

- [ ] Auto-merge once green; re-dispatch will pick up the change for next dry-run