### PR TITLE
Bump gtc to 1.0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
## Summary
- bump the greentic CLI version from 1.0.17 to 1.0.18

## Notes
- standalone version bump after merging the gtc --no-browser passthrough fix
