### PR TITLE
Prefer bundled cloud deployer packs in gtc start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "clap",
  "criterion",

--- a/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
@@ -32,6 +32,9 @@ pub(crate) fn resolve_target_provider_pack(
     if let Some(path) = resolve_target_provider_pack_from_metadata(bundle_dir, target)? {
         return Ok(path);
     }
+    if let Some(path) = resolve_target_provider_pack_from_bundle_layout(bundle_dir, target)? {
+        return Ok(path);
+    }
     if let Some(path) = resolve_canonical_target_provider_pack(target) {
         return Ok(path);
     }
@@ -61,6 +64,54 @@ pub(crate) fn resolve_canonical_target_provider_pack_from(
         candidates.push(repo_dir.join("dist").join(filename));
     }
     candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn resolve_target_provider_pack_from_bundle_layout(
+    bundle_dir: &Path,
+    target: StartTarget,
+) -> GtcResult<Option<PathBuf>> {
+    let deployer_dir = bundle_dir.join("providers").join("deployer");
+    if !deployer_dir.is_dir() {
+        return Ok(None);
+    }
+
+    for candidate_name in bundle_layout_provider_pack_candidates(target)? {
+        let candidate = deployer_dir.join(candidate_name);
+        if candidate.is_file() {
+            return Ok(Some(candidate));
+        }
+    }
+
+    Ok(None)
+}
+
+fn bundle_layout_provider_pack_candidates(target: StartTarget) -> GtcResult<Vec<String>> {
+    let mut candidates = Vec::new();
+    if let Some(canonical) = canonical_target_provider_pack_filename(target)? {
+        candidates.push(canonical);
+    }
+
+    match target {
+        StartTarget::Aws => {
+            candidates.push("greentic.deploy.aws.gtpack".to_string());
+            candidates.push("aws.gtpack".to_string());
+            candidates.push("terraform.gtpack".to_string());
+        }
+        StartTarget::Gcp => {
+            candidates.push("greentic.deploy.gcp.gtpack".to_string());
+            candidates.push("gcp.gtpack".to_string());
+            candidates.push("terraform.gtpack".to_string());
+        }
+        StartTarget::Azure => {
+            candidates.push("greentic.deploy.azure.gtpack".to_string());
+            candidates.push("azure.gtpack".to_string());
+            candidates.push("terraform.gtpack".to_string());
+        }
+        StartTarget::SingleVm | StartTarget::Runtime => {}
+    }
+
+    candidates.dedup();
+    Ok(candidates)
 }
 
 fn canonical_target_provider_pack_filename(target: StartTarget) -> GtcResult<Option<String>> {
@@ -230,9 +281,11 @@ fn resolve_app_pack_path_from_bundle_metadata(bundle_dir: &Path) -> GtcResult<Op
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_target_provider_pack_filename, load_deployment_targets_document,
-        resolve_app_pack_path_from_bundle_metadata, resolve_canonical_target_provider_pack_from,
-        resolve_deploy_app_pack_path, resolve_target_provider_pack_from_metadata,
+        bundle_layout_provider_pack_candidates, canonical_target_provider_pack_filename,
+        load_deployment_targets_document, resolve_app_pack_path_from_bundle_metadata,
+        resolve_canonical_target_provider_pack_from, resolve_deploy_app_pack_path,
+        resolve_target_provider_pack, resolve_target_provider_pack_from_bundle_layout,
+        resolve_target_provider_pack_from_metadata,
     };
     use crate::deploy::StartTarget;
     use crate::tests::env_test_lock;
@@ -349,6 +402,49 @@ mod tests {
 
         let resolved = resolve_canonical_target_provider_pack_from(Some(&exe), "terraform.gtpack");
         assert_eq!(resolved.as_deref(), Some(pack.as_path()));
+    }
+
+    #[test]
+    fn bundle_layout_provider_pack_candidates_include_new_and_legacy_aws_names() {
+        let candidates =
+            bundle_layout_provider_pack_candidates(StartTarget::Aws).expect("candidate names");
+        assert!(candidates.contains(&"greentic.deploy.aws.gtpack".to_string()));
+        assert!(candidates.contains(&"aws.gtpack".to_string()));
+        assert!(candidates.contains(&"terraform.gtpack".to_string()));
+    }
+
+    #[test]
+    fn resolve_target_provider_pack_from_bundle_layout_uses_bundled_cloud_pack() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let deployer_dir = dir.path().join("providers").join("deployer");
+        fs::create_dir_all(&deployer_dir).expect("mkdir");
+        let pack = deployer_dir.join("greentic.deploy.aws.gtpack");
+        fs::write(&pack, b"fixture").expect("write pack");
+
+        let resolved =
+            resolve_target_provider_pack_from_bundle_layout(dir.path(), StartTarget::Aws)
+                .expect("resolved");
+        assert_eq!(resolved.as_deref(), Some(pack.as_path()));
+    }
+
+    #[test]
+    fn resolve_target_provider_pack_prefers_bundled_cloud_pack_when_metadata_omits_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let greentic = dir.path().join(".greentic");
+        fs::create_dir_all(&greentic).expect("mkdir");
+        fs::write(
+            greentic.join("deployment-targets.json"),
+            r#"{"targets":[{"target":"aws"}]}"#,
+        )
+        .expect("write metadata");
+        let deployer_dir = dir.path().join("providers").join("deployer");
+        fs::create_dir_all(&deployer_dir).expect("mkdir");
+        let pack = deployer_dir.join("greentic.deploy.aws.gtpack");
+        fs::write(&pack, b"fixture").expect("write pack");
+
+        let resolved = resolve_target_provider_pack(dir.path(), StartTarget::Aws, None)
+            .expect("provider pack");
+        assert_eq!(resolved, pack);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- let `gtc start --target aws|gcp|azure` resolve deployer packs directly from `providers/deployer/` inside the bundle
- support both canonical bundled names like `greentic.deploy.aws.gtpack` and legacy names like `aws.gtpack` / `terraform.gtpack`
- add tests for bundled cloud pack discovery when deployment-target metadata omits `provider_pack`

## Validation
- `cargo fmt --manifest-path greentic/Cargo.toml`
- `cargo test --manifest-path greentic/Cargo.toml resolve_target_provider_pack_prefers_bundled_cloud_pack_when_metadata_omits_path --bin gtc`
- `cargo check --manifest-path greentic/Cargo.toml --bin gtc`