### PR TITLE
chore: force-jump dev lane to 1.1.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,11 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "greentic-config-types"
-version = "0.5.0"
+version = "1.1.0-dev.25380109992"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b57ff54329cc825cc37a5d3f5839b6c45fc2460ef9de12ee9d282f45f9f22e"
+checksum = "3d51b7f01d3e63b082b6116afb5ff01e85e67446450abd262f1ec0c4451b90e7"
 dependencies = [
- "greentic-types",
+ "greentic-types 1.1.0-dev.25376259391",
  "serde",
  "serde_json",
  "toml",
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-distributor-client"
-version = "0.5.3"
+version = "1.1.0-dev.25418356126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987d1f0fb6fabbad071c0d3377112f9470cbde7beb2344a8e0ec80f4229bb101"
+checksum = "7e8a5e1e17db3af5ea3ee263f492687a0359af8370f2b5774649fd79fe5a5890"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1222,7 +1222,7 @@ dependencies = [
  "greentic-config-types",
  "greentic-interfaces-guest",
  "greentic-secrets-lib",
- "greentic-types",
+ "greentic-types 1.1.0-dev.25376259391",
  "oci-distribution",
  "reqwest 0.13.3",
  "rpassword",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-i18n-lib"
-version = "0.5.1"
+version = "1.1.0-dev.25375505278"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c181b9a5fb0beccd9959fb11296572a7802ee1e237d90ca37ff46e8a1fbef3"
+checksum = "a61861d10962625ad96c632c355bd0e99c3d34d4f05fa6572e7cb8dd1a768cff"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -1246,13 +1246,13 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces"
-version = "0.5.0"
+version = "1.1.0-dev.25380112032"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2abe5ccec746bbeb0fbb291e0368096752e2ad31d5dbf70053638b12ec43c8d"
+checksum = "0dd1739e0b520fcf8eeb706094e288572a821572a94bdfb10e7c5a68099f9db4"
 dependencies = [
  "anyhow",
  "constant_time_eq",
- "greentic-types",
+ "greentic-types 1.1.0-dev.25376259391",
  "semver",
  "thiserror 2.0.18",
  "time",
@@ -1264,12 +1264,12 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces-guest"
-version = "0.5.0"
+version = "1.1.0-dev.25380112032"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ae2fd6855448749061b052250c54b29ee8388ea6a81087ce07fdbc671e7eb7"
+checksum = "31869558530be66ec330013f12e47514d15b8c987c45f72b814c99864d88b833"
 dependencies = [
  "greentic-interfaces",
- "greentic-types",
+ "greentic-types 1.1.0-dev.25376259391",
  "wit-bindgen 0.57.1",
  "wit-bindgen-core 0.57.1",
  "wit-bindgen-rust 0.57.1",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-api"
-version = "0.5.0"
+version = "1.1.0-dev.25392427112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b05da6497a5b153592dfa6891db30696e152db755ad31344f867f89d8fd61d"
+checksum = "8918b8f28eea2bfae9be68ad8894d093566682631e23c8b6cd13876af471f2bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-core"
-version = "0.5.0"
+version = "1.1.0-dev.25392427112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163826dfe0ead6553581d8d09bf74f66479570e7433d005bf1a9b566d9d3de6d"
+checksum = "08025f7ea6ff431aec70951b943a777ac28e91684ec555b59ab4c7a8be3c7719"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1298,7 +1298,7 @@ dependencies = [
  "greentic-secrets-api",
  "greentic-secrets-provider-dev",
  "greentic-secrets-spec",
- "greentic-types",
+ "greentic-types 0.5.2",
  "hkdf",
  "lru",
  "once_cell",
@@ -1316,23 +1316,23 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-lib"
-version = "0.5.0"
+version = "1.1.0-dev.25392427112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ae64224552cd7961859c2d04f8a848b268e85dfa0c5e3a3e9c0cbb2656b688"
+checksum = "15d6f7a8c277efb106e541cfcc0c49e9defe3c32540ca56e1ce8b1709b030f3e"
 dependencies = [
  "async-trait",
  "greentic-secrets-api",
  "greentic-secrets-core",
  "greentic-secrets-provider-dev",
  "greentic-secrets-spec",
- "greentic-types",
+ "greentic-types 0.5.2",
 ]
 
 [[package]]
 name = "greentic-secrets-provider-dev"
-version = "0.5.0"
+version = "1.1.0-dev.25392427112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bab04dae2096f0a19c72e27173b67b1b9a29c5f6ab6662bdf3698f995e39fb"
+checksum = "2b95275533d7d58e1e3e48ecb73d2d0aad8abe5c039c0bc78a670b255264236b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1347,12 +1347,12 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-spec"
-version = "0.5.0"
+version = "1.1.0-dev.25392427112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53eae0820853253dc6760c7c7044ec5d97922200e7abc0a57d363432da0993d"
+checksum = "314d081b2862b173e0b55d909ba28bfefd39a27471c5f77dbf7621d4ff1e4b47"
 dependencies = [
  "async-trait",
- "greentic-types",
+ "greentic-types 0.5.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1397,6 +1397,32 @@ dependencies = [
  "greentic-types-macros",
  "indexmap",
  "opentelemetry-otlp",
+ "semver",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_with",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "unic-langid",
+]
+
+[[package]]
+name = "greentic-types"
+version = "1.1.0-dev.25376259391"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20f2d79fd4554b6985d5fd529c88884dec49985c14846bf10b43c9a58ee16e1e"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "chrono",
+ "ciborium",
+ "constant_time_eq",
+ "fnv",
+ "indexmap",
  "schemars",
  "semver",
  "serde",
@@ -1406,9 +1432,6 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "time",
- "tokio",
- "tracing",
- "tracing-subscriber",
  "unic-langid",
 ]
 
@@ -1433,7 +1456,7 @@ dependencies = [
  "flate2",
  "greentic-distributor-client",
  "greentic-i18n-lib",
- "greentic-types",
+ "greentic-types 1.1.0-dev.25376259391",
  "insta",
  "oci-distribution",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ pkg-fmt = "zip"
 [dependencies]
 directories = "6"
 flate2 = "1.1"
-greentic-i18n-lib = "0.5"
-greentic-types = "0.5"
+greentic-i18n-lib = ">=1.1.0-dev, <1.2.0-0"
+greentic-types = ">=1.1.0-dev, <1.2.0-0"
 rcgen = "0.14"
 rpassword = "7.4"
 serde_json = "1.0"
@@ -57,7 +57,7 @@ features = [
 ]
 
 [dependencies.greentic-distributor-client]
-version = "0.5"
+version = ">=1.1.0-dev, <1.2.0-0"
 features = [
     "dist-client",
     "oci-components",

--- a/src/bin/gtc/extensions.rs
+++ b/src/bin/gtc/extensions.rs
@@ -544,9 +544,7 @@ mod tests {
         load_extension_start_handoff, load_registry, resolve_descriptor_path,
         resolve_descriptor_working_directory, write_launcher_handoff,
     };
-    use crate::tests::env_test_lock;
     use clap::{Arg, ArgAction, Command};
-    use std::env;
     use std::fs;
     use std::path::PathBuf;
 
@@ -731,7 +729,6 @@ mod tests {
         );
     }
 
-    #[test]
     #[test]
     fn launcher_handoff_is_written_with_extension_records() {
         let root = tempfile::tempdir().expect("tempdir");

--- a/src/bin/gtc/toolchain.rs
+++ b/src/bin/gtc/toolchain.rs
@@ -1581,6 +1581,21 @@ mod tests {
                     .long("dry-run")
                     .action(ArgAction::SetTrue),
             )
+            .arg(
+                Arg::new("install-binaries-only")
+                    .long("install-binaries-only")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("install-packs-only")
+                    .long("install-packs-only")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("install-components-only")
+                    .long("install-components-only")
+                    .action(ArgAction::SetTrue),
+            )
             .get_matches_from(["toolchain"]);
 
         let options = ToolchainInstallOptions::from_matches(&matches, "stable").expect("options");
@@ -1602,6 +1617,21 @@ mod tests {
             .arg(
                 Arg::new("dry-run")
                     .long("dry-run")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("install-binaries-only")
+                    .long("install-binaries-only")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("install-packs-only")
+                    .long("install-packs-only")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("install-components-only")
+                    .long("install-components-only")
                     .action(ArgAction::SetTrue),
             )
             .get_matches_from([


### PR DESCRIPTION
Force-jumps the dev lane for `greentic` to `1.1.0-dev.0`.

Detected prefixes (each rewritten via a separate `bump_cargo_versions.py` pass):

```
0.5
```

**Stable (`main`) is unaffected.** Only `develop` and `Cargo.toml` change. `REPO_MANIFEST.toml` tracks stable on `main` and is intentionally not updated by this PR (`dev-prepare.yml` stamps versions from `Cargo.toml`, not from the manifest).

Greentic-ecosystem dep reqs are now in pre-release range form `">=1.1.0-dev, <1.2.0-0"`.

Generated by `force-jump-minor.sh`.