### PR TITLE
Fix nightly coverage failures in deploy orchestrators

### DIFF
--- a/src/bin/gtc/deploy/bundle_upload_orchestrator.rs
+++ b/src/bin/gtc/deploy/bundle_upload_orchestrator.rs
@@ -10,8 +10,8 @@ use serde::Deserialize;
 
 use gtc::error::{GtcError, GtcResult};
 
-use crate::DEPLOYER_BIN;
 use crate::process::resolve_companion_command;
+use crate::{BUNDLE_BIN, DEPLOYER_BIN};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadedBundle {
@@ -26,7 +26,8 @@ pub struct UploadedBundle {
 /// `.cache/v1/<engine_profile_id>/...` into the produced .gtbundle so the
 /// operator's `adopt_bundle_cache_dir` picks it up on cold start.
 fn run_bundle_build(bundle_dir: &Path, output_file: &Path) -> GtcResult<()> {
-    let status = ProcessCommand::new("greentic-bundle")
+    let bundle_bin = resolve_companion_command(BUNDLE_BIN);
+    let status = ProcessCommand::new(&bundle_bin)
         .arg("build")
         .arg("--root")
         .arg(bundle_dir)
@@ -262,5 +263,236 @@ exit 1
         assert!(logged.contains("bundle-upload refresh-url"));
         assert!(logged.contains("--object-ref s3://bucket/key"));
         assert!(logged.contains("--presign-expires 456"));
+    }
+
+    #[cfg(unix)]
+    fn write_fake_greentic_bundle_script(script: &Path, log_path: &Path, exit_code: u8) {
+        let body = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "{log}"
+# args are: build --root <dir> --output <file> --warmup
+output_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ "{exit_code}" = "0" ] && [ -n "$output_file" ]; then
+  : > "$output_file"
+fi
+exit {exit_code}
+"#,
+            log = log_path.display(),
+            exit_code = exit_code,
+        );
+        fs::write(script, body).expect("write fake greentic-bundle script");
+        let mut perms = fs::metadata(script).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(script, perms).expect("chmod");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_warmed_bundle_invokes_greentic_bundle_with_warmup() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-bundle");
+        let log_path = dir.path().join("bundle.log");
+        write_fake_greentic_bundle_script(&script, &log_path, 0);
+
+        let bundle_dir = dir.path().join("my-bundle");
+        fs::create_dir(&bundle_dir).expect("bundle dir");
+
+        let original = env::var_os("GREENTIC_BUNDLE_BIN");
+        unsafe {
+            env::set_var("GREENTIC_BUNDLE_BIN", &script);
+        }
+
+        let result = prepare_warmed_bundle(&bundle_dir);
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_BUNDLE_BIN", value),
+                None => env::remove_var("GREENTIC_BUNDLE_BIN"),
+            }
+        }
+
+        let output_file = result.expect("prepare_warmed_bundle");
+        assert!(
+            output_file.is_file(),
+            "expected fake script to materialize {}",
+            output_file.display()
+        );
+        assert!(output_file.extension().and_then(|s| s.to_str()) == Some("gtbundle"));
+        let logged = fs::read_to_string(&log_path).expect("read log");
+        assert!(logged.contains("build"), "log: {logged}");
+        assert!(logged.contains("--warmup"), "log: {logged}");
+        assert!(logged.contains("--root"), "log: {logged}");
+        assert!(logged.contains("--output"), "log: {logged}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_warmed_bundle_propagates_bundle_build_failure() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-bundle");
+        let log_path = dir.path().join("bundle.log");
+        write_fake_greentic_bundle_script(&script, &log_path, 7);
+
+        let bundle_dir = dir.path().join("my-bundle");
+        fs::create_dir(&bundle_dir).expect("bundle dir");
+
+        let original = env::var_os("GREENTIC_BUNDLE_BIN");
+        unsafe {
+            env::set_var("GREENTIC_BUNDLE_BIN", &script);
+        }
+
+        let err = prepare_warmed_bundle(&bundle_dir).unwrap_err();
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_BUNDLE_BIN", value),
+                None => env::remove_var("GREENTIC_BUNDLE_BIN"),
+            }
+        }
+
+        let msg = format!("{err:?}");
+        assert!(msg.contains("greentic-bundle build --warmup"), "{msg}");
+        assert!(msg.contains("status"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    fn write_fake_deployer_script(script: &Path, exit_code: u8, stdout: &str, stderr: &str) {
+        let body = format!(
+            r#"#!/bin/sh
+printf '%s' '{stdout}'
+printf '%s' '{stderr}' >&2
+exit {exit_code}
+"#,
+            stdout = stdout.replace('\'', "'\\''"),
+            stderr = stderr.replace('\'', "'\\''"),
+            exit_code = exit_code,
+        );
+        fs::write(script, body).expect("write fake deployer script");
+        let mut perms = fs::metadata(script).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(script, perms).expect("chmod");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upload_bundle_reports_non_success_exit_with_stderr() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-deployer");
+        let bundle = dir.path().join("demo.gtbundle");
+        write_fake_deployer_script(&script, 9, "", "boom: presign denied");
+        fs::write(&bundle, b"bundle").expect("bundle file");
+
+        let original = env::var_os("GREENTIC_DEPLOYER_BIN");
+        unsafe {
+            env::set_var("GREENTIC_DEPLOYER_BIN", &script);
+        }
+
+        let err = upload_bundle("s3://bucket/x", &bundle, 1).unwrap_err();
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_DEPLOYER_BIN", value),
+                None => env::remove_var("GREENTIC_DEPLOYER_BIN"),
+            }
+        }
+
+        let msg = format!("{err:?}");
+        assert!(msg.contains("bundle-upload upload failed"), "{msg}");
+        assert!(msg.contains("boom: presign denied"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upload_bundle_rejects_invalid_json_payload() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-deployer");
+        let bundle = dir.path().join("demo.gtbundle");
+        write_fake_deployer_script(&script, 0, "not-json", "");
+        fs::write(&bundle, b"bundle").expect("bundle file");
+
+        let original = env::var_os("GREENTIC_DEPLOYER_BIN");
+        unsafe {
+            env::set_var("GREENTIC_DEPLOYER_BIN", &script);
+        }
+
+        let err = upload_bundle("s3://bucket/x", &bundle, 1).unwrap_err();
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_DEPLOYER_BIN", value),
+                None => env::remove_var("GREENTIC_DEPLOYER_BIN"),
+            }
+        }
+
+        let msg = format!("{err:?}");
+        assert!(msg.contains("invalid JSON"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_bundle_url_reports_non_success_exit_with_stderr() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-deployer");
+        write_fake_deployer_script(&script, 4, "", "denied");
+
+        let original = env::var_os("GREENTIC_DEPLOYER_BIN");
+        unsafe {
+            env::set_var("GREENTIC_DEPLOYER_BIN", &script);
+        }
+
+        let err = refresh_bundle_url("s3://bucket/key", 1).unwrap_err();
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_DEPLOYER_BIN", value),
+                None => env::remove_var("GREENTIC_DEPLOYER_BIN"),
+            }
+        }
+
+        let msg = format!("{err:?}");
+        assert!(msg.contains("bundle-upload refresh-url failed"), "{msg}");
+        assert!(msg.contains("denied"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_bundle_url_rejects_invalid_json_payload() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("greentic-deployer");
+        write_fake_deployer_script(&script, 0, "not-json", "");
+
+        let original = env::var_os("GREENTIC_DEPLOYER_BIN");
+        unsafe {
+            env::set_var("GREENTIC_DEPLOYER_BIN", &script);
+        }
+
+        let err = refresh_bundle_url("s3://bucket/key", 1).unwrap_err();
+
+        unsafe {
+            match original {
+                Some(value) => env::set_var("GREENTIC_DEPLOYER_BIN", value),
+                None => env::remove_var("GREENTIC_DEPLOYER_BIN"),
+            }
+        }
+
+        let msg = format!("{err:?}");
+        assert!(msg.contains("invalid JSON from refresh-url"), "{msg}");
     }
 }

--- a/src/bin/gtc/deploy/refresh.rs
+++ b/src/bin/gtc/deploy/refresh.rs
@@ -6,12 +6,12 @@
 //! `terraform-apply.sh` to roll the operator task definition.
 
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command as ProcessCommand;
+use std::path::{Path, PathBuf};
+use std::process::{Command as ProcessCommand, ExitStatus};
 
 use directories::BaseDirs;
 
-use crate::deploy::bundle_upload_orchestrator;
+use crate::deploy::bundle_upload_orchestrator::{self, UploadedBundle};
 use gtc::error::{GtcError, GtcResult};
 
 pub struct RefreshArgs {
@@ -22,7 +22,21 @@ pub struct RefreshArgs {
 }
 
 pub fn run_refresh(args: RefreshArgs) -> i32 {
-    match run_refresh_inner(args) {
+    let base = match BaseDirs::new() {
+        Some(b) => b,
+        None => {
+            eprintln!("error: home dir not found");
+            return 1;
+        }
+    };
+    let deploy_root = base.home_dir().join(".greentic").join("deploy");
+
+    match run_refresh_with_root(
+        &args,
+        &deploy_root,
+        &mut bundle_upload_orchestrator::refresh_bundle_url,
+        &mut spawn_terraform_apply,
+    ) {
         Ok(()) => 0,
         Err(err) => {
             eprintln!("error: {err}");
@@ -31,9 +45,25 @@ pub fn run_refresh(args: RefreshArgs) -> i32 {
     }
 }
 
-fn run_refresh_inner(args: RefreshArgs) -> GtcResult<()> {
-    let deploy_state =
-        resolve_deploy_state(&args.bundle_ref, args.cloud.as_deref(), &args.environment)?;
+fn spawn_terraform_apply(script: &Path) -> std::io::Result<ExitStatus> {
+    ProcessCommand::new(script).status()
+}
+
+/// Orchestrate the refresh against a caller-provided deploy root, presign refresher,
+/// and terraform-apply spawner. Splitting these out keeps the body unit-testable
+/// without touching the user's home directory or spawning real subprocesses.
+fn run_refresh_with_root(
+    args: &RefreshArgs,
+    deploy_root: &Path,
+    refresh_url: &mut dyn FnMut(&str, u64) -> GtcResult<UploadedBundle>,
+    spawn_apply: &mut dyn FnMut(&Path) -> std::io::Result<ExitStatus>,
+) -> GtcResult<()> {
+    let deploy_state = resolve_deploy_state_in(
+        deploy_root,
+        &args.bundle_ref,
+        args.cloud.as_deref(),
+        &args.environment,
+    )?;
     let tfvars_path = deploy_state.join("terraform").join("dev.tfvars");
     let tfvars_text = fs::read_to_string(&tfvars_path)
         .map_err(|e| GtcError::message(format!("read tfvars {}: {e}", tfvars_path.display())))?;
@@ -50,8 +80,7 @@ fn run_refresh_inner(args: RefreshArgs) -> GtcResult<()> {
         ))
     })?;
 
-    let refreshed =
-        bundle_upload_orchestrator::refresh_bundle_url(&object_ref, args.presign_expires)?;
+    let refreshed = refresh_url(&object_ref, args.presign_expires)?;
 
     let updated = replace_tfvars_value(&tfvars_text, "bundle_source", &refreshed.url);
     fs::write(&tfvars_path, updated)
@@ -68,8 +97,7 @@ fn run_refresh_inner(args: RefreshArgs) -> GtcResult<()> {
         "Running {} (ECS task replacement; ~5 min)...",
         apply_script.display()
     );
-    let status = ProcessCommand::new(&apply_script)
-        .status()
+    let status = spawn_apply(&apply_script)
         .map_err(|e| GtcError::message(format!("spawn terraform-apply.sh: {e}")))?;
     if !status.success() {
         return Err(GtcError::message(format!(
@@ -80,15 +108,13 @@ fn run_refresh_inner(args: RefreshArgs) -> GtcResult<()> {
     Ok(())
 }
 
-/// Resolve the deploy state directory under `~/.greentic/deploy/<cloud>/<env>/<bundle-fingerprint>/`.
-fn resolve_deploy_state(
+/// Resolve the deploy state directory under `<deploy_root>/<cloud>/<env>/<bundle-fingerprint>/`.
+fn resolve_deploy_state_in(
+    deploy_root: &Path,
     bundle_ref: &str,
     cloud: Option<&str>,
     environment: &str,
 ) -> GtcResult<PathBuf> {
-    let base =
-        BaseDirs::new().ok_or_else(|| GtcError::message("home dir not found".to_string()))?;
-    let deploy_root = base.home_dir().join(".greentic").join("deploy");
     let fingerprint = mangle_bundle_ref_to_fingerprint(bundle_ref);
 
     let candidates: Vec<PathBuf> = if let Some(c) = cloud {
@@ -246,5 +272,287 @@ bundle_digest = "sha256:abc"
     fn mangle_bundle_ref_replaces_slashes_and_dots() {
         let r = mangle_bundle_ref_to_fingerprint("/home/user/foo/bar.gtbundle");
         assert!(!r.contains('/'));
+    }
+
+    #[test]
+    fn extract_tfvars_value_returns_none_for_missing_key() {
+        let text = "cloud = \"aws\"\n";
+        assert!(extract_tfvars_value(text, "bundle_source").is_none());
+    }
+
+    #[test]
+    fn extract_tfvars_value_returns_none_for_unquoted_value() {
+        let text = "bundle_source = oops\n";
+        assert!(extract_tfvars_value(text, "bundle_source").is_none());
+    }
+
+    #[test]
+    fn extract_tfvars_value_returns_none_when_no_equals() {
+        // The value lookup hinges on `<key> = "<value>"`; without `=` it
+        // must not return a stray match. Regression guard for prefix-only matches.
+        let text = "bundle_source\n";
+        assert!(extract_tfvars_value(text, "bundle_source").is_none());
+    }
+
+    #[test]
+    fn replace_tfvars_value_appends_when_key_absent() {
+        let text = "cloud = \"aws\"\n";
+        let updated = replace_tfvars_value(text, "bundle_source", "https://new");
+        // Key is missing — function leaves the input unchanged save for a
+        // trailing newline, since it only replaces the first match.
+        assert_eq!(updated, "cloud = \"aws\"\n");
+    }
+
+    #[test]
+    fn derive_object_ref_from_global_endpoint_url() {
+        // Virtual-hosted-style without an explicit region: `<bucket>.s3.amazonaws.com`.
+        let url = "https://my-bucket.s3.amazonaws.com/path/to/key.gtbundle";
+        assert_eq!(
+            derive_object_ref_from_url(url).as_deref(),
+            Some("s3://my-bucket/path/to/key.gtbundle")
+        );
+    }
+
+    #[test]
+    fn derive_object_ref_returns_none_for_non_https_scheme() {
+        assert!(derive_object_ref_from_url("http://my-bucket.s3.amazonaws.com/x").is_none());
+    }
+
+    #[test]
+    fn mangle_bundle_ref_strips_leading_separators() {
+        let r = mangle_bundle_ref_to_fingerprint("/foo");
+        assert!(!r.starts_with('-'));
+        assert!(!r.starts_with('/'));
+    }
+
+    #[test]
+    fn mangle_bundle_ref_normalises_parent_traversal() {
+        let r = mangle_bundle_ref_to_fingerprint("a/../b");
+        assert!(!r.contains("/"));
+        assert!(!r.contains(".."));
+    }
+
+    fn make_state(
+        deploy_root: &Path,
+        cloud: &str,
+        env: &str,
+        bundle_ref: &str,
+    ) -> std::path::PathBuf {
+        let fp = mangle_bundle_ref_to_fingerprint(bundle_ref);
+        let dir = deploy_root.join(cloud).join(env).join(fp);
+        std::fs::create_dir_all(&dir).expect("create state dir");
+        dir
+    }
+
+    #[test]
+    fn resolve_deploy_state_in_returns_single_match_without_cloud() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = make_state(tmp.path(), "aws", "dev", "/home/u/demo.gtbundle");
+        let resolved = resolve_deploy_state_in(tmp.path(), "/home/u/demo.gtbundle", None, "dev")
+            .expect("expected single match");
+        assert_eq!(resolved, target);
+    }
+
+    #[test]
+    fn resolve_deploy_state_in_honours_explicit_cloud() {
+        let tmp = tempfile::tempdir().unwrap();
+        let aws = make_state(tmp.path(), "aws", "dev", "/home/u/demo.gtbundle");
+        let _gcp = make_state(tmp.path(), "gcp", "dev", "/home/u/demo.gtbundle");
+        let resolved =
+            resolve_deploy_state_in(tmp.path(), "/home/u/demo.gtbundle", Some("aws"), "dev")
+                .expect("expected aws match");
+        assert_eq!(resolved, aws);
+    }
+
+    #[test]
+    fn resolve_deploy_state_in_errors_when_no_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_deploy_state_in(tmp.path(), "/home/u/missing.gtbundle", None, "dev")
+            .expect_err("expected no-match error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("no deploy state found"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_deploy_state_in_errors_when_ambiguous() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _aws = make_state(tmp.path(), "aws", "dev", "/home/u/demo.gtbundle");
+        let _azure = make_state(tmp.path(), "azure", "dev", "/home/u/demo.gtbundle");
+        let err = resolve_deploy_state_in(tmp.path(), "/home/u/demo.gtbundle", None, "dev")
+            .expect_err("expected ambiguous error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("deploy states match"), "{msg}");
+        assert!(msg.contains("--cloud to disambiguate"), "{msg}");
+    }
+
+    fn fake_status(success: bool) -> ExitStatus {
+        // Fabricate a real ExitStatus by spawning a noop command. Using
+        // `true`/`false` keeps this portable across POSIX systems.
+        #[cfg(unix)]
+        {
+            ProcessCommand::new(if success { "true" } else { "false" })
+                .status()
+                .expect("spawn noop command")
+        }
+        #[cfg(not(unix))]
+        {
+            ProcessCommand::new("cmd")
+                .args(["/c", if success { "exit 0" } else { "exit 1" }])
+                .status()
+                .expect("spawn noop command")
+        }
+    }
+
+    fn write_deploy_state_with_tfvars(deploy_root: &Path, bundle_ref: &str, bundle_source: &str) {
+        let state = make_state(deploy_root, "aws", "dev", bundle_ref);
+        let tf_dir = state.join("terraform");
+        std::fs::create_dir_all(&tf_dir).unwrap();
+        let body = format!(
+            "cloud = \"aws\"\nbundle_source = \"{bundle_source}\"\nbundle_digest = \"sha256:abc\"\n"
+        );
+        std::fs::write(tf_dir.join("dev.tfvars"), body).unwrap();
+    }
+
+    #[test]
+    fn run_refresh_with_root_rewrites_tfvars_and_runs_apply() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_ref = "/home/u/demo.gtbundle";
+        let initial_url = "https://my-bucket.s3.eu-north-1.amazonaws.com/key?old-sig";
+        write_deploy_state_with_tfvars(tmp.path(), bundle_ref, initial_url);
+
+        let mut refresh_calls: Vec<(String, u64)> = Vec::new();
+        let mut apply_calls: Vec<std::path::PathBuf> = Vec::new();
+        let mut refresh_url = |obj: &str, exp: u64| -> GtcResult<UploadedBundle> {
+            refresh_calls.push((obj.to_string(), exp));
+            Ok(UploadedBundle {
+                url: "https://my-bucket.s3.eu-north-1.amazonaws.com/key?new-sig".to_string(),
+                digest: "sha256:abc".to_string(),
+                expires_at: Some("2026-12-31T00:00:00Z".to_string()),
+                object_ref: "s3://my-bucket/key".to_string(),
+            })
+        };
+        let mut spawn_apply = |script: &Path| -> std::io::Result<ExitStatus> {
+            apply_calls.push(script.to_path_buf());
+            Ok(fake_status(true))
+        };
+
+        let args = RefreshArgs {
+            bundle_ref: bundle_ref.to_string(),
+            cloud: Some("aws".to_string()),
+            environment: "dev".to_string(),
+            presign_expires: 900,
+        };
+        run_refresh_with_root(&args, tmp.path(), &mut refresh_url, &mut spawn_apply)
+            .expect("refresh should succeed");
+
+        assert_eq!(refresh_calls.len(), 1);
+        assert_eq!(refresh_calls[0].0, "s3://my-bucket/key");
+        assert_eq!(refresh_calls[0].1, 900);
+
+        assert_eq!(apply_calls.len(), 1);
+        assert!(
+            apply_calls[0].ends_with("terraform-apply.sh"),
+            "{:?}",
+            apply_calls[0]
+        );
+
+        let fp = mangle_bundle_ref_to_fingerprint(bundle_ref);
+        let written = std::fs::read_to_string(
+            tmp.path()
+                .join("aws/dev")
+                .join(fp)
+                .join("terraform/dev.tfvars"),
+        )
+        .unwrap();
+        assert!(
+            written.contains(
+                r#"bundle_source = "https://my-bucket.s3.eu-north-1.amazonaws.com/key?new-sig""#
+            ),
+            "tfvars not rewritten: {written}"
+        );
+    }
+
+    #[test]
+    fn run_refresh_with_root_propagates_apply_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_ref = "/home/u/demo.gtbundle";
+        write_deploy_state_with_tfvars(
+            tmp.path(),
+            bundle_ref,
+            "https://my-bucket.s3.eu-north-1.amazonaws.com/key?old-sig",
+        );
+
+        let mut refresh_url = |_obj: &str, _exp: u64| -> GtcResult<UploadedBundle> {
+            Ok(UploadedBundle {
+                url: "https://my-bucket.s3.eu-north-1.amazonaws.com/key?new-sig".to_string(),
+                digest: "sha256:abc".to_string(),
+                expires_at: None,
+                object_ref: "s3://my-bucket/key".to_string(),
+            })
+        };
+        let mut spawn_apply =
+            |_script: &Path| -> std::io::Result<ExitStatus> { Ok(fake_status(false)) };
+
+        let args = RefreshArgs {
+            bundle_ref: bundle_ref.to_string(),
+            cloud: Some("aws".to_string()),
+            environment: "dev".to_string(),
+            presign_expires: 60,
+        };
+        let err = run_refresh_with_root(&args, tmp.path(), &mut refresh_url, &mut spawn_apply)
+            .expect_err("expected apply failure");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("terraform-apply.sh exited"), "{msg}");
+    }
+
+    #[test]
+    fn run_refresh_with_root_errors_when_tfvars_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_ref = "/home/u/demo.gtbundle";
+        // Create the deploy state directory but no tfvars file.
+        let _ = make_state(tmp.path(), "aws", "dev", bundle_ref);
+
+        let mut refresh_url = |_: &str, _: u64| -> GtcResult<UploadedBundle> {
+            unreachable!("refresh should not be called when tfvars is missing");
+        };
+        let mut spawn_apply = |_: &Path| -> std::io::Result<ExitStatus> {
+            unreachable!("apply should not be called when tfvars is missing");
+        };
+
+        let args = RefreshArgs {
+            bundle_ref: bundle_ref.to_string(),
+            cloud: Some("aws".to_string()),
+            environment: "dev".to_string(),
+            presign_expires: 60,
+        };
+        let err = run_refresh_with_root(&args, tmp.path(), &mut refresh_url, &mut spawn_apply)
+            .expect_err("expected read error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("read tfvars"), "{msg}");
+    }
+
+    #[test]
+    fn run_refresh_with_root_errors_when_bundle_source_unparseable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_ref = "/home/u/demo.gtbundle";
+        write_deploy_state_with_tfvars(tmp.path(), bundle_ref, "https://example.com/not-s3");
+
+        let mut refresh_url = |_: &str, _: u64| -> GtcResult<UploadedBundle> {
+            unreachable!("refresh should not be called when URL parse fails");
+        };
+        let mut spawn_apply = |_: &Path| -> std::io::Result<ExitStatus> {
+            unreachable!("apply should not be called when URL parse fails");
+        };
+
+        let args = RefreshArgs {
+            bundle_ref: bundle_ref.to_string(),
+            cloud: Some("aws".to_string()),
+            environment: "dev".to_string(),
+            presign_expires: 60,
+        };
+        let err = run_refresh_with_root(&args, tmp.path(), &mut refresh_url, &mut spawn_apply)
+            .expect_err("expected url parse error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("could not derive object_ref"), "{msg}");
     }
 }


### PR DESCRIPTION
## Summary

- Nightly Coverage workflow ([run 25538145915](https://github.com/greenticai/greentic/actions/runs/25538145915)) failed because two deploy-orchestrator modules dipped below the 60% per-file line-coverage floor:
  - `src/bin/gtc/deploy/bundle_upload_orchestrator.rs` — 56.18%
  - `src/bin/gtc/deploy/refresh.rs` — 45.66%
- Both files are thin subprocess-wiring layers (greentic-bundle, greentic-deployer, terraform-apply.sh). Reached coverage by making the IO injectable, then adding focused unit tests; no behavior changes outside the splits required for injection.

### Refactors (test-only impact)
- `run_bundle_build` now resolves `greentic-bundle` via `resolve_companion_command(BUNDLE_BIN)`, so tests can override it with `GREENTIC_BUNDLE_BIN` (mirrors how `greentic-deployer` is already overridden).
- `run_refresh` splits into `run_refresh_with_root(args, deploy_root, refresh_url, spawn_apply)`. The user-facing entry point still derives the deploy root from `BaseDirs` and plugs in the real refresh + apply hooks.
- `resolve_deploy_state` becomes `resolve_deploy_state_in(deploy_root, …)` so multi-cloud / ambiguous / missing-state branches can be exercised against a tempdir.

### New tests
- `prepare_warmed_bundle` happy path + bundle-build failure propagation.
- `upload_bundle` / `refresh_bundle_url`: non-zero exit (with stderr surfaced) and invalid-JSON branches.
- `resolve_deploy_state_in`: single match without `--cloud`, explicit cloud wins, no match, ambiguous match across clouds.
- `run_refresh_with_root`: tfvars rewrite + apply spawn, apply failure, missing tfvars, unparseable bundle URL.
- Edge cases for `extract_tfvars_value`, `replace_tfvars_value`, `derive_object_ref_from_url` (global endpoint, non-https), `mangle_bundle_ref_to_fingerprint`.

### Coverage after
| File | Before | After |
|---|---|---|
| `bundle_upload_orchestrator.rs` | 56.18% | **88.44%** |
| `refresh.rs` | 45.66% | **90.77%** |

`greentic-dev coverage` locally: workspace 77.54%, policy check passes.

## Test plan

- [x] `cargo nextest run --no-fail-fast` — 352 passed, 3 skipped
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `greentic-dev coverage` (matches Nightly Coverage workflow)
- [ ] Nightly Coverage workflow on `main` after merge