### PR TITLE
[codex] Pass bundle root to deployer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.22"
+version = "1.0.23"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
+++ b/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
@@ -12,12 +12,12 @@ one of this repo's real canonical production components.
 
 ## Provenance
 
-- Tool version: `greentic-flow 0.5.7`
+- Tool version: `greentic-flow 0.5.8`
 - Command:
 
 ```bash
 greentic-flow component-schema oci://acme/widget:1 \
-  --resolver fixture:///Users/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.6.24888858655/tests/fixtures/registry \
+  --resolver fixture:///home/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.10/tests/fixtures/registry \
   --format json
 ```
 

--- a/docs/04-schemas/setup-schema.md
+++ b/docs/04-schemas/setup-schema.md
@@ -9,7 +9,7 @@ toolchain used during schema sync.
 
 ## Provenance
 
-- Tool version: `greentic-setup 0.5.7`
+- Tool version: `greentic-setup 0.5.12`
 - Command attempted:
 
 ```bash
@@ -24,6 +24,7 @@ path.
 Observed stderr:
 
 ```text
+warning: Greentic toolchain release context is 1.0.18 (stable), but the latest stable release is 1.0.15. Run `gtc install` to upgrade.
 error: unexpected argument '--schema' found
 
   tip: to pass '--schema' as a value, use '-- --schema'

--- a/docs/04-schemas/wizard-schema.md
+++ b/docs/04-schemas/wizard-schema.md
@@ -9,7 +9,7 @@ installed toolchain in this environment.
 
 ## Provenance
 
-- Tool version: `gtc 1.0.14`
+- Tool version: `gtc 1.0.23`
 - Command:
 
 ```bash

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -370,6 +370,8 @@ fn run_multi_target_deployer_apply(
         app_pack.display().to_string(),
         "--provider-pack".to_string(),
         provider_pack.display().to_string(),
+        "--bundle-root".to_string(),
+        resolved.bundle_dir.display().to_string(),
         "--bundle-source".to_string(),
         deploy_bundle_source.clone(),
         "--bundle-digest".to_string(),
@@ -734,6 +736,7 @@ mod tests {
 
         let logged = fs::read_to_string(log).expect("read");
         assert!(logged.contains("apply --tenant demo"));
+        assert!(logged.contains(&format!("--bundle-root {}", bundle_dir.display())));
         assert!(logged.contains("--bundle-source https://example.com/demo.gtbundle"));
         assert!(logged.contains("--environment prod"));
     }


### PR DESCRIPTION
## Summary

- Pass the resolved local bundle directory to cloud deployer apply calls via `--bundle-root`.
- Assert the cloud deployer invocation includes `--bundle-root` in the existing apply test.
- Include local version/schema documentation updates that were present in the working tree.

## Validation

- `cargo test multi_target_deployer_apply_uses_resolved_packs_and_remote_source`