### PR TITLE
[codex] Install deployer pack tooling in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,12 @@ jobs:
         with:
           toolchain: 1.95.0
 
+      - name: Install deployer pack tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo install greentic-pack greentic-flow --locked
+
       - name: Build and sync deployer pack
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Install `greentic-pack` and `greentic-flow` in the `prepare_deployer_assets` release job before syncing the embedded deployer pack.
- This lets `greentic-deployer` replay pack scaffolds before `build_fixture_gtpacks` validates and copies `terraform.gtpack`.

## Root Cause

`ci/sync_deployer_pack.sh` runs `build_fixture_gtpacks` in a freshly checked out `greentic-deployer` repo. The build expects replayed scaffolds under `target/replayed-pack-scaffolds`, but the release job did not install the external replay tools, so scaffold replay could not materialize the AWS/GCP/Azure fixture pack roots.

## Validation

- Not run locally: full release asset sync would install/rebuild external Greentic CLIs and regenerate deployer fixture packs.
- Verified the branch diff is limited to `.github/workflows/release.yml`.