### PR TITLE
Support remote JSON answer artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -238,7 +238,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -246,6 +246,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -286,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,9 +326,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -706,15 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,13 +991,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1211,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-distributor-client"
-version = "1.1.0-dev.25537586660"
+version = "1.1.0-dev.25902983221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eca60a00e35c61d1d6cf98435be3f7a78f3a06d450ad8ec7d15fb2a010b8019"
+checksum = "bf7f91e57590fd63e8ddf40e105b30c439f5cbeee89e983393ba441f459c5e11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1236,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-i18n-lib"
-version = "1.1.0-dev.25375505278"
+version = "1.1.0-dev.25901842811"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61861d10962625ad96c632c355bd0e99c3d34d4f05fa6572e7cb8dd1a768cff"
+checksum = "354fd28b50b17ce020dedfaac6a8eb3fe95841bf5d4f18caad01fd307e8c63ca"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -1246,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces"
-version = "1.1.0-dev.25380112032"
+version = "1.1.0-dev.25540474673"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd1739e0b520fcf8eeb706094e288572a821572a94bdfb10e7c5a68099f9db4"
+checksum = "a6a3bf770f43222971da4c5b32b7b4f8ca2a19f32334e7914ad5683b2a848b84"
 dependencies = [
  "anyhow",
  "constant_time_eq",
@@ -1264,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces-guest"
-version = "1.1.0-dev.25380112032"
+version = "1.1.0-dev.25540474673"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31869558530be66ec330013f12e47514d15b8c987c45f72b814c99864d88b833"
+checksum = "4a9871668ff192398dd4845399c83cca99e11a0411a6381184c9dfd8d696f424"
 dependencies = [
  "greentic-interfaces",
  "greentic-types 1.1.0-dev.25540461571",
@@ -1277,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-api"
-version = "1.1.0-dev.25478204617"
+version = "1.1.0-dev.25781160230"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0039a55cf385c2834a5e4cb1c245dfe6374e8e3f60442af191fe11f97532d"
+checksum = "b6c00382d2f3c4a5551c51229ebc87cd512e308627a7aa7962f9db12ba8bc797"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1288,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-core"
-version = "1.1.0-dev.25478204617"
+version = "1.1.0-dev.25781160230"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f62ca4a043135c9d45c4a25be8d917e7f75d5bf5fe0696ad0c338e12f98faf"
+checksum = "c48c8af56bc9c59a230a5f47af282e0b1fff00c8be080340e46ad6142d76c9db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1316,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-lib"
-version = "1.1.0-dev.25478204617"
+version = "1.1.0-dev.25781160230"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3ced76fbae3cbaf828bcb2a85ab0334b3247a07ad0d6134b58c9ab0868388c"
+checksum = "23921a01488343d09f201d01c19c3bd436f1de9bcbb9a726896f4d35a23f8adb"
 dependencies = [
  "async-trait",
  "greentic-secrets-api",
@@ -1330,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-provider-dev"
-version = "1.1.0-dev.25478204617"
+version = "1.1.0-dev.25781160230"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ed14c49f8f4d95ffde9e0847e334617552f06358684323c3c0ab9462fdea47"
+checksum = "467b3f9c4a3ebad2806cf640db79aab2e55f170c37fdd9f970dbb014dcb21f97"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1347,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-spec"
-version = "1.1.0-dev.25478204617"
+version = "1.1.0-dev.25781160230"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17584de61667605f52bb509a04381aa589bf0a5c0f0796f3bc4c1d4c47aadbdf"
+checksum = "18d3a0df9415b3a1a30001f785e4c7753d0ca83aecd29221b0eb7922a9d824a2"
 dependencies = [
  "async-trait",
  "greentic-types 0.5.2",
@@ -1361,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-telemetry"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc37350fa96d40a0a0806351e0ff637797815008d00dd211002ccd33d8a29e9"
+checksum = "4f52813e6d9117803d3f1f0eb042beb85d62cee60a46bb22a5489582e22e1e2a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1375,7 +1383,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-error",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1448,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.0-dev.4"
+version = "1.0.26"
 dependencies = [
  "clap",
  "criterion",
@@ -1528,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1626,9 +1633,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1852,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2021,10 +2028,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2060,7 +2064,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2373,7 +2377,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2396,18 +2400,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2419,12 +2423,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2516,7 +2514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -2545,7 +2543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2734,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -2751,15 +2749,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2814,7 +2803,7 @@ checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
  "smallvec",
@@ -3273,11 +3262,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "serde_core",
@@ -3288,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3432,12 +3422,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3627,9 +3611,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3821,19 +3805,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4249,7 +4220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
  "bitflags",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -4809,9 +4780,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -4997,7 +4968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
 dependencies = [
  "anyhow",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap",
  "log",
@@ -5045,10 +5016,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
@@ -5097,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.0-dev.4"
+version = "1.0.26"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ version = ">=1.1.0-dev, <1.2.0-0"
 features = [
     "dist-client",
     "oci-components",
+    "pack-fetch",
 ]
 
 [dependencies.oci-distribution]

--- a/docs/02-cli/gtc-setup.md
+++ b/docs/02-cli/gtc-setup.md
@@ -61,9 +61,15 @@ This repo does **not** currently own the full semantics of every setup flag.
 For normal setup usage, `gtc` forwards the trailing arguments to
 `greentic-setup`.
 
-That means syntax such as `--answers` or `--no-ui` may be valid in current
-workflows, but the deeper flag behavior is owned by the downstream setup tool,
-not re-parsed by `gtc` itself.
+`gtc` does resolve and validate `--answers` before forwarding. `--answers`
+accepts JSON object documents from plain local paths, `file://...`,
+`http://...`, `https://...`, `oci://...`, `store://...`, and `repo://...`.
+Distributor-backed schemes are resolved through `greentic-distributor-client`
+and forwarded to `greentic-setup` as a temporary local answers file.
+
+Other syntax such as `--no-ui` may be valid in current workflows, but the
+deeper flag behavior is owned by the downstream setup tool, not re-parsed by
+`gtc` itself.
 
 ## Basic Usage
 
@@ -79,8 +85,8 @@ The README also shows:
 gtc setup --no-ui ./cloud-deploy-demo-bundle --answers <setup-answers.json>
 ```
 
-Those forms are passed through to `greentic-setup` in the current
-implementation.
+Those forms are passed through to `greentic-setup` after answer source
+resolution succeeds.
 
 ## Does `./<name>.gtbundle` Work?
 

--- a/docs/02-cli/gtc-wizard.md
+++ b/docs/02-cli/gtc-wizard.md
@@ -88,8 +88,20 @@ Current README and test coverage support the repo-local pattern:
 gtc wizard --answers <answers.json>
 ```
 
-In the current implementation, `gtc` forwards that request to the downstream
-wizard owner rather than validating the answer structure itself.
+`--answers` accepts JSON object documents from:
+
+- plain local paths
+- `file://...`
+- `http://...`
+- `https://...`
+- `oci://...`
+- `store://...`
+- `repo://...`
+
+`gtc` validates that the referenced document is valid JSON with an object at the
+top level before launching the downstream wizard. Distributor-backed schemes are
+resolved through `greentic-distributor-client` and forwarded as a temporary local
+answers file.
 
 That means the safe rule is:
 

--- a/docs/03-authoring/answers-json-patterns.md
+++ b/docs/03-authoring/answers-json-patterns.md
@@ -48,6 +48,10 @@ gtc wizard --emit-answers ./answers.json
 gtc wizard --answers ./answers.json
 ```
 
+`gtc wizard --answers` and `gtc setup --answers` accept the same source forms:
+plain local paths, `file://...`, `http://...`, `https://...`, `oci://...`,
+`store://...`, and `repo://...`. The referenced JSON must parse as an object.
+
 If the downstream wizard does not support `--emit-answers` for your exact flow,
 fall back to using the schema output directly.
 

--- a/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
+++ b/docs/04-schemas/component-schemas/acme-widget-fixture-default.md
@@ -12,12 +12,12 @@ one of this repo's real canonical production components.
 
 ## Provenance
 
-- Tool version: `greentic-flow 0.5.8`
+- Tool version: `greentic-flow 0.5.10`
 - Command:
 
 ```bash
 greentic-flow component-schema oci://acme/widget:1 \
-  --resolver fixture:///home/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-0.5.10/tests/fixtures/registry \
+  --resolver fixture:///home/maarten/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/greentic-flow-1.1.0-dev.25540621195/tests/fixtures/registry \
   --format json
 ```
 

--- a/docs/04-schemas/drift-report.md
+++ b/docs/04-schemas/drift-report.md
@@ -4,7 +4,11 @@ Implementation owner: repo-local schema sync tooling
 
 # Drift Report
 
-No schema drift was detected during the latest sync run.
+## Generated Status Docs Changed
 
-This means the generated schema artifacts and their markdown wrappers were
-already in sync with the current tool outputs used by the refresh command.
+- `/projects/ai/greentic-ng/greentic/docs/04-schemas/setup-schema.md`
+
+## Docs Likely Needing Manual Review
+
+- `docs/02-cli/gtc-setup.md`
+

--- a/docs/04-schemas/setup-schema.md
+++ b/docs/04-schemas/setup-schema.md
@@ -24,7 +24,6 @@ path.
 Observed stderr:
 
 ```text
-warning: Greentic toolchain release context is 1.0.18 (stable), but the latest stable release is 1.0.15. Run `gtc install` to upgrade.
 error: unexpected argument '--schema' found
 
   tip: to pass '--schema' as a value, use '-- --schema'

--- a/docs/04-schemas/wizard-schema.md
+++ b/docs/04-schemas/wizard-schema.md
@@ -9,7 +9,7 @@ installed toolchain in this environment.
 
 ## Provenance
 
-- Tool version: `gtc 1.0.23`
+- Tool version: `gtc 1.0.25`
 - Command:
 
 ```bash

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -1,5 +1,7 @@
 #[path = "gtc/admin.rs"]
 mod admin;
+#[path = "gtc/answer_resolver.rs"]
+mod answer_resolver;
 #[path = "gtc/archive.rs"]
 mod archive;
 #[path = "gtc/cli.rs"]

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,8 +1,12 @@
 use std::fs;
 use std::path::PathBuf;
 
-use greentic_distributor_client::{CachePolicy, DistClient, DistOptions, ResolvePolicy};
+use greentic_distributor_client::{
+    DistClient, DistOptions, PackFetchOptions, default_pack_layer_media_types,
+    fetch_pack_to_cache_with_options,
+};
 use gtc::error::{GtcError, GtcResult};
+use oci_distribution::Reference;
 use reqwest::blocking::Client;
 use serde_json::{Map, Value};
 
@@ -37,31 +41,71 @@ impl AnswerSourceLoader for DefaultAnswerSourceLoader {
     }
 
     fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
-        let client = DistClient::new(DistOptions::default());
+        let options = DistOptions::default();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(|err| GtcError::message(format!("failed to create runtime: {err}")))?;
-        let artifact_source = client.parse_source(source).map_err(|err| {
-            GtcError::message(format!("failed to parse answers source {source}: {err}"))
-        })?;
-        let descriptor = runtime
-            .block_on(client.resolve(artifact_source, ResolvePolicy))
-            .map_err(|err| {
-                GtcError::message(format!("failed to resolve answers source {source}: {err}"))
-            })?;
-        let artifact = runtime
-            .block_on(client.fetch(&descriptor, CachePolicy))
-            .map_err(|err| {
-                GtcError::message(format!("failed to fetch answers source {source}: {err}"))
-            })?;
-        artifact
-            .wasm_bytes()
-            .map(|bytes| bytes.to_vec())
-            .map_err(|err| {
-                GtcError::message(format!("failed to read resolved answers {source}: {err}"))
-            })
+        let resolved = match classify_answers_source(source)? {
+            AnswerSourceKind::Distributor => {
+                if source.starts_with("store://") {
+                    let client = DistClient::new(options);
+                    let artifact = runtime
+                        .block_on(client.download_store_artifact(source))
+                        .map_err(|err| {
+                            GtcError::message(format!(
+                                "failed to fetch answers source {source}: {err}"
+                            ))
+                        })?;
+                    DistributedAnswerBytes {
+                        bytes: artifact.bytes,
+                        media_type: artifact.media_type,
+                    }
+                } else {
+                    let mapped = map_oci_answers_reference(source, &options)?;
+                    let artifact = runtime
+                        .block_on(fetch_pack_to_cache_with_options(
+                            &mapped,
+                            answer_pack_fetch_options(&options),
+                        ))
+                        .map_err(|err| {
+                            GtcError::message(format!(
+                                "failed to fetch answers source {source}: {err}"
+                            ))
+                        })?;
+                    let bytes = fs::read(&artifact.path).map_err(|err| {
+                        GtcError::io(
+                            format!(
+                                "failed to read resolved answers {}",
+                                artifact.path.display()
+                            ),
+                            err,
+                        )
+                    })?;
+                    DistributedAnswerBytes {
+                        bytes,
+                        media_type: artifact.media_type,
+                    }
+                }
+            }
+            _ => unreachable!("load_distributor is only called for distributor answer sources"),
+        };
+        if !is_json_media_type(&resolved.media_type) {
+            return Err(GtcError::invalid_data(
+                "answers OCI artifact",
+                format!(
+                    "{source} resolved to media type {}; expected application/json or a +json media type",
+                    resolved.media_type
+                ),
+            ));
+        }
+        Ok(resolved.bytes)
     }
+}
+
+struct DistributedAnswerBytes {
+    bytes: Vec<u8>,
+    media_type: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -144,15 +188,98 @@ fn file_url_path(url: &str) -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
+fn map_oci_answers_reference(source: &str, options: &DistOptions) -> GtcResult<String> {
+    if let Some(reference) = source.strip_prefix("oci://") {
+        validate_oci_reference(source, reference)?;
+        return Ok(reference.to_string());
+    }
+
+    if let Some(target) = source.strip_prefix("repo://") {
+        return map_registry_target(source, target, options.repo_registry_base.as_deref());
+    }
+
+    Err(GtcError::invalid_data(
+        "answers source",
+        format!("unsupported distributor answers source {source}"),
+    ))
+}
+
+fn map_registry_target(source: &str, target: &str, base: Option<&str>) -> GtcResult<String> {
+    if Reference::try_from(target).is_ok() {
+        return Ok(target.to_string());
+    }
+    let Some(base) = base else {
+        return Err(GtcError::message(format!(
+            "{source} requires GREENTIC_REPO_REGISTRY_BASE to map to OCI"
+        )));
+    };
+    let mapped = format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        target.trim_start_matches('/')
+    );
+    validate_oci_reference(source, &mapped)?;
+    Ok(mapped)
+}
+
+fn validate_oci_reference(source: &str, reference: &str) -> GtcResult<()> {
+    Reference::try_from(reference).map(|_| ()).map_err(|err| {
+        GtcError::invalid_data(
+            "answers source",
+            format!("{source} is not a valid OCI reference: {err}"),
+        )
+    })
+}
+
+fn answer_pack_fetch_options(options: &DistOptions) -> PackFetchOptions {
+    let mut accepted = vec![
+        "application/json".to_string(),
+        "application/vnd.greentic.answers.v1+json".to_string(),
+        "application/vnd.greentic.answers.create.v1+json".to_string(),
+        "application/vnd.greentic.answers.setup.v1+json".to_string(),
+    ];
+    extend_unique_media_types(&mut accepted, default_pack_layer_media_types());
+    PackFetchOptions {
+        allow_tags: options.allow_tags,
+        offline: options.offline,
+        cache_dir: options.cache_dir.join("answers"),
+        accepted_layer_media_types: accepted,
+        preferred_layer_media_types: vec![
+            "application/vnd.greentic.answers.setup.v1+json".to_string(),
+            "application/vnd.greentic.answers.create.v1+json".to_string(),
+            "application/vnd.greentic.answers.v1+json".to_string(),
+            "application/json".to_string(),
+        ],
+        ..PackFetchOptions::default()
+    }
+}
+
+fn extend_unique_media_types<I>(accepted: &mut Vec<String>, media_types: I)
+where
+    I: IntoIterator<Item = String>,
+{
+    for media_type in media_types {
+        if !accepted.iter().any(|candidate| candidate == &media_type) {
+            accepted.push(media_type);
+        }
+    }
+}
+
+fn is_json_media_type(media_type: &str) -> bool {
+    media_type == "application/json" || media_type.ends_with("+json")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AnswerSourceKind, AnswerSourceLoader, classify_answers_source, load_answer_bytes,
-        load_answers_with,
+        AnswerSourceKind, AnswerSourceLoader, answer_pack_fetch_options, classify_answers_source,
+        is_json_media_type, load_answer_bytes, load_answers_with, map_oci_answers_reference,
     };
+    use greentic_distributor_client::DistOptions;
     use gtc::error::{GtcError, GtcResult};
     use std::cell::RefCell;
     use std::fs;
+    use std::path::PathBuf;
 
     #[derive(Default)]
     struct MockLoader {
@@ -307,5 +434,110 @@ mod tests {
 
         assert!(String::from_utf8(bytes).unwrap().contains("oci://"));
         assert_eq!(loader.dist.borrow().len(), 1);
+    }
+
+    #[test]
+    fn json_media_type_accepts_standard_and_vendor_json() {
+        assert!(is_json_media_type("application/json"));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.v1+json"
+        ));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.create.v1+json"
+        ));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.setup.v1+json"
+        ));
+        assert!(!is_json_media_type("application/wasm"));
+        assert!(!is_json_media_type("application/octet-stream"));
+    }
+
+    #[test]
+    fn answer_pack_fetch_options_prefers_answers_json_layers() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: None,
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        let fetch_options = answer_pack_fetch_options(&options);
+
+        assert_eq!(
+            fetch_options
+                .preferred_layer_media_types
+                .first()
+                .map(String::as_str),
+            Some("application/vnd.greentic.answers.setup.v1+json")
+        );
+        for media_type in [
+            "application/json",
+            "application/vnd.greentic.answers.v1+json",
+            "application/vnd.greentic.answers.create.v1+json",
+            "application/vnd.greentic.answers.setup.v1+json",
+        ] {
+            assert!(
+                fetch_options
+                    .accepted_layer_media_types
+                    .iter()
+                    .any(|accepted| accepted == media_type),
+                "missing accepted media type {media_type}"
+            );
+            assert!(
+                fetch_options
+                    .preferred_layer_media_types
+                    .iter()
+                    .any(|preferred| preferred == media_type),
+                "missing preferred media type {media_type}"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_oci_and_repo_answers_to_oci_references() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: Some("ghcr.io/acme".to_string()),
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        assert_eq!(
+            map_oci_answers_reference("oci://ghcr.io/acme/answers:stable", &options).unwrap(),
+            "ghcr.io/acme/answers:stable"
+        );
+        assert_eq!(
+            map_oci_answers_reference("repo:///answers:stable", &options).unwrap(),
+            "ghcr.io/acme/answers:stable"
+        );
+    }
+
+    #[test]
+    fn repo_answers_require_registry_base_when_target_is_not_oci() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: None,
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        let err = map_oci_answers_reference("repo:///answers:stable", &options).unwrap_err();
+
+        assert!(err.to_string().contains("GREENTIC_REPO_REGISTRY_BASE"));
     }
 }

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,0 +1,311 @@
+use std::fs;
+use std::path::PathBuf;
+
+use greentic_distributor_client::{CachePolicy, DistClient, DistOptions, ResolvePolicy};
+use gtc::error::{GtcError, GtcResult};
+use reqwest::blocking::Client;
+use serde_json::{Map, Value};
+
+pub(super) trait AnswerSourceLoader {
+    fn load_http(&self, source: &str) -> GtcResult<Vec<u8>>;
+    fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>>;
+}
+
+pub(super) struct DefaultAnswerSourceLoader;
+
+impl AnswerSourceLoader for DefaultAnswerSourceLoader {
+    fn load_http(&self, source: &str) -> GtcResult<Vec<u8>> {
+        let client = Client::builder()
+            .build()
+            .map_err(|err| GtcError::message(format!("failed to create HTTP client: {err}")))?;
+        let response = client
+            .get(source)
+            .header("Accept", "application/json")
+            .header("User-Agent", format!("gtc/{}", env!("CARGO_PKG_VERSION")))
+            .send()
+            .map_err(|err| GtcError::message(format!("failed to fetch answers {source}: {err}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(GtcError::message(format!(
+                "failed to fetch answers {source}: HTTP {status}"
+            )));
+        }
+        response
+            .bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|err| GtcError::message(format!("failed to read answers {source}: {err}")))
+    }
+
+    fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
+        let client = DistClient::new(DistOptions::default());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| GtcError::message(format!("failed to create runtime: {err}")))?;
+        let artifact_source = client.parse_source(source).map_err(|err| {
+            GtcError::message(format!("failed to parse answers source {source}: {err}"))
+        })?;
+        let descriptor = runtime
+            .block_on(client.resolve(artifact_source, ResolvePolicy))
+            .map_err(|err| {
+                GtcError::message(format!("failed to resolve answers source {source}: {err}"))
+            })?;
+        let artifact = runtime
+            .block_on(client.fetch(&descriptor, CachePolicy))
+            .map_err(|err| {
+                GtcError::message(format!("failed to fetch answers source {source}: {err}"))
+            })?;
+        artifact
+            .wasm_bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|err| {
+                GtcError::message(format!("failed to read resolved answers {source}: {err}"))
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AnswerSourceKind {
+    LocalPath,
+    FileUrl,
+    Http,
+    Distributor,
+}
+
+pub(super) fn classify_answers_source(source: &str) -> GtcResult<AnswerSourceKind> {
+    match source.split_once("://").map(|(scheme, _)| scheme) {
+        None => Ok(AnswerSourceKind::LocalPath),
+        Some("file") => Ok(AnswerSourceKind::FileUrl),
+        Some("http") | Some("https") => Ok(AnswerSourceKind::Http),
+        Some("oci") | Some("store") | Some("repo") => Ok(AnswerSourceKind::Distributor),
+        Some(scheme) => Err(GtcError::invalid_data(
+            "answers source",
+            format!(
+                "unsupported scheme '{scheme}' for {source}; expected local path, file://, http://, https://, oci://, store://, or repo://"
+            ),
+        )),
+    }
+}
+
+pub(super) fn load_answers(source: &str) -> GtcResult<Map<String, Value>> {
+    load_answers_with(source, &DefaultAnswerSourceLoader)
+}
+
+pub(super) fn load_answers_with(
+    source: &str,
+    loader: &dyn AnswerSourceLoader,
+) -> GtcResult<Map<String, Value>> {
+    let bytes = load_answer_bytes(source, loader)?;
+    parse_answers_bytes(source, &bytes)
+}
+
+pub(super) fn load_answer_bytes(
+    source: &str,
+    loader: &dyn AnswerSourceLoader,
+) -> GtcResult<Vec<u8>> {
+    match classify_answers_source(source)? {
+        AnswerSourceKind::LocalPath => fs::read(source)
+            .map_err(|err| GtcError::io(format!("failed to read answers file {source}"), err)),
+        AnswerSourceKind::FileUrl => {
+            let path = file_url_path(source).ok_or_else(|| {
+                GtcError::invalid_data("answers source", format!("invalid file URL: {source}"))
+            })?;
+            fs::read(&path).map_err(|err| {
+                GtcError::io(
+                    format!("failed to read answers file {}", path.display()),
+                    err,
+                )
+            })
+        }
+        AnswerSourceKind::Http => loader.load_http(source),
+        AnswerSourceKind::Distributor => loader.load_distributor(source),
+    }
+}
+
+pub(super) fn parse_answers_bytes(source: &str, bytes: &[u8]) -> GtcResult<Map<String, Value>> {
+    match serde_json::from_slice::<Value>(bytes) {
+        Ok(Value::Object(object)) => Ok(object),
+        Ok(_) => Err(GtcError::invalid_data(
+            "answers JSON",
+            format!("{source} must contain a JSON object"),
+        )),
+        Err(err) => Err(GtcError::json(
+            format!("failed to parse answers JSON from {source}"),
+            err,
+        )),
+    }
+}
+
+fn file_url_path(url: &str) -> Option<PathBuf> {
+    let path = url.strip_prefix("file://")?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AnswerSourceKind, AnswerSourceLoader, classify_answers_source, load_answer_bytes,
+        load_answers_with,
+    };
+    use gtc::error::{GtcError, GtcResult};
+    use std::cell::RefCell;
+    use std::fs;
+
+    #[derive(Default)]
+    struct MockLoader {
+        http: RefCell<Vec<String>>,
+        dist: RefCell<Vec<String>>,
+    }
+
+    impl AnswerSourceLoader for MockLoader {
+        fn load_http(&self, source: &str) -> GtcResult<Vec<u8>> {
+            self.http.borrow_mut().push(source.to_string());
+            Ok(br#"{"from":"http"}"#.to_vec())
+        }
+
+        fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
+            self.dist.borrow_mut().push(source.to_string());
+            Ok(format!(r#"{{"from":"{source}"}}"#).into_bytes())
+        }
+    }
+
+    #[test]
+    fn classifies_supported_answer_sources() {
+        assert_eq!(
+            classify_answers_source("answers.json").unwrap(),
+            AnswerSourceKind::LocalPath
+        );
+        assert_eq!(
+            classify_answers_source("file:///tmp/answers.json").unwrap(),
+            AnswerSourceKind::FileUrl
+        );
+        assert_eq!(
+            classify_answers_source("https://example.com/answers.json").unwrap(),
+            AnswerSourceKind::Http
+        );
+        assert_eq!(
+            classify_answers_source("oci://ghcr.io/acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+        assert_eq!(
+            classify_answers_source("store://acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+        assert_eq!(
+            classify_answers_source("repo://acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_scheme() {
+        let err = classify_answers_source("ftp://example.com/answers.json").unwrap_err();
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("unsupported scheme"));
+    }
+
+    #[test]
+    fn loads_local_file_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, br#"{"ok":true}"#).expect("write");
+
+        let answers = load_answers_with(path.to_str().expect("utf8"), &MockLoader::default())
+            .expect("answers");
+
+        assert_eq!(
+            answers.get("ok").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn loads_file_url_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, br#"{"ok":"file"}"#).expect("write");
+
+        let answers = load_answers_with(
+            &format!("file://{}", path.display()),
+            &MockLoader::default(),
+        )
+        .expect("answers");
+
+        assert_eq!(
+            answers.get("ok").and_then(serde_json::Value::as_str),
+            Some("file")
+        );
+    }
+
+    #[test]
+    fn loads_https_answers_through_injected_loader() {
+        let loader = MockLoader::default();
+        let answers =
+            load_answers_with("https://example.com/answers.json", &loader).expect("answers");
+
+        assert_eq!(
+            answers.get("from").and_then(serde_json::Value::as_str),
+            Some("http")
+        );
+        assert_eq!(
+            loader.http.borrow().as_slice(),
+            ["https://example.com/answers.json"]
+        );
+    }
+
+    #[test]
+    fn loads_distributor_answer_schemes_through_injected_loader() {
+        let loader = MockLoader::default();
+        for source in [
+            "oci://ghcr.io/acme/answers:stable",
+            "store://acme/answers:stable",
+            "repo://acme/answers:stable",
+        ] {
+            let answers = load_answers_with(source, &loader).expect("answers");
+            assert_eq!(
+                answers.get("from").and_then(serde_json::Value::as_str),
+                Some(source)
+            );
+        }
+        assert_eq!(loader.dist.borrow().len(), 3);
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, b"{not-json").expect("write");
+
+        let err =
+            load_answers_with(path.to_str().expect("utf8"), &MockLoader::default()).unwrap_err();
+
+        assert!(matches!(err, GtcError::Json { .. }));
+        assert!(err.to_string().contains("failed to parse answers JSON"));
+    }
+
+    #[test]
+    fn rejects_non_object_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, b"[]").expect("write");
+
+        let err =
+            load_answers_with(path.to_str().expect("utf8"), &MockLoader::default()).unwrap_err();
+
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("must contain a JSON object"));
+    }
+
+    #[test]
+    fn raw_byte_loader_uses_distributor_for_oci() {
+        let loader = MockLoader::default();
+
+        let bytes = load_answer_bytes("oci://ghcr.io/acme/answers:stable", &loader).expect("bytes");
+
+        assert!(String::from_utf8(bytes).unwrap().contains("oci://"));
+        assert_eq!(loader.dist.borrow().len(), 1);
+    }
+}

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -942,6 +942,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.wizard.about").into_owned())
+                .after_help("Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
                 .arg(
                     Arg::new("extensions")
                         .long("extensions")
@@ -984,6 +985,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.setup.about").into_owned())
+                .after_help("Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
                 .arg(
                     Arg::new("extension-setup-handoff")
                         .long("extension-setup-handoff")

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -5,12 +5,17 @@ use std::path::Path;
 
 use clap::ArgMatches;
 use serde_json::Value;
+use tempfile::TempDir;
 
 use crate::admin::{
     load_admin_registry, remove_admin_registry_entry, run_admin_access, run_admin_add_client,
     run_admin_certs, run_admin_clients, run_admin_health, run_admin_list, run_admin_remove_client,
     run_admin_status, run_admin_stop, run_admin_token, run_admin_tunnel, save_admin_registry,
     upsert_admin_registry_entry,
+};
+use crate::answer_resolver::{
+    AnswerSourceKind, DefaultAnswerSourceLoader, classify_answers_source, load_answer_bytes,
+    load_answers, parse_answers_bytes,
 };
 use crate::cli::build_cli;
 use crate::deploy::{
@@ -161,6 +166,21 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
             } else {
                 tail
             };
+            let mut answers_tempdir = None;
+            let tail = if matches!(name, "wizard" | "setup") {
+                match resolve_answers_args(&tail) {
+                    Ok(resolved) => {
+                        answers_tempdir = resolved.tempdir;
+                        resolved.args
+                    }
+                    Err(err) => {
+                        eprintln!("{err}");
+                        return answers_error_exit_code(&err);
+                    }
+                }
+            } else {
+                tail
+            };
             if name == "wizard" && sub_matches.get_many::<String>("extensions").is_some() {
                 return run_extension_wizard(sub_matches, &tail, debug, &locale);
             }
@@ -178,9 +198,102 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 }
                 return run_wizard_schema(binary, &args, debug, &locale);
             }
+            let _answers_tempdir = answers_tempdir;
             passthrough(binary, &args, debug, &locale)
         }
         _ => 2,
+    }
+}
+
+struct ResolvedAnswersArgs {
+    args: Vec<String>,
+    tempdir: Option<TempDir>,
+}
+
+fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
+    let loader = DefaultAnswerSourceLoader;
+    let mut rewritten = Vec::with_capacity(args.len());
+    let mut tempdir: Option<TempDir> = None;
+    let mut index = 0usize;
+    let mut materialized_count = 0usize;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--answers" {
+            let Some(source) = args.get(index + 1) else {
+                return Err(gtc::error::GtcError::invalid_data(
+                    "answers source",
+                    "--answers requires a value",
+                ));
+            };
+            rewritten.push(arg.clone());
+            rewritten.push(resolve_answers_arg_value(
+                source,
+                &loader,
+                &mut tempdir,
+                &mut materialized_count,
+            )?);
+            index += 2;
+            continue;
+        }
+
+        if let Some(source) = arg.strip_prefix("--answers=") {
+            let resolved =
+                resolve_answers_arg_value(source, &loader, &mut tempdir, &mut materialized_count)?;
+            rewritten.push(format!("--answers={resolved}"));
+            index += 1;
+            continue;
+        }
+
+        rewritten.push(arg.clone());
+        index += 1;
+    }
+
+    Ok(ResolvedAnswersArgs {
+        args: rewritten,
+        tempdir,
+    })
+}
+
+fn resolve_answers_arg_value(
+    source: &str,
+    loader: &DefaultAnswerSourceLoader,
+    tempdir: &mut Option<TempDir>,
+    materialized_count: &mut usize,
+) -> gtc::error::GtcResult<String> {
+    let kind = classify_answers_source(source)?;
+    match kind {
+        AnswerSourceKind::LocalPath | AnswerSourceKind::FileUrl | AnswerSourceKind::Http => {
+            let _answers = load_answers(source)?;
+            Ok(source.to_string())
+        }
+        AnswerSourceKind::Distributor => {
+            let bytes = load_answer_bytes(source, loader)?;
+            let _answers = parse_answers_bytes(source, &bytes)?;
+            if tempdir.is_none() {
+                *tempdir = Some(tempfile::tempdir().map_err(|err| {
+                    gtc::error::GtcError::io("failed to create temporary answers directory", err)
+                })?);
+            }
+            let dir = tempdir.as_ref().expect("temporary answers directory");
+            let path = dir
+                .path()
+                .join(format!("answers-{materialized_count}.json"));
+            *materialized_count += 1;
+            fs::write(&path, bytes).map_err(|err| {
+                gtc::error::GtcError::io(format!("failed to write {}", path.display()), err)
+            })?;
+            Ok(path.display().to_string())
+        }
+    }
+}
+
+fn answers_error_exit_code(err: &gtc::error::GtcError) -> i32 {
+    if matches!(err, gtc::error::GtcError::InvalidData { context, .. } if context == "answers source")
+    {
+        2
+    } else {
+        1
     }
 }
 

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -211,34 +211,56 @@ fn gtc_dev_runner_info_forwards_args() {
 fn wizard_passthrough_routes_to_greentic_dev_with_all_args() {
     let sandbox = TestSandbox::new("wizard_passthrough_routes_to_greentic_dev_with_all_args");
     let log_file = sandbox.path().join("dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
     sandbox.write_exit_tool("greentic-operator", 0);
 
     let status = sandbox.run_gtc(
-        ["wizard", "--locale", "fr", "--answers", "oci://example"],
+        [
+            "wizard",
+            "--locale",
+            "fr",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read dev log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]
 fn wizard_passthrough_preserves_global_locale_for_greentic_dev() {
     let sandbox = TestSandbox::new("wizard_passthrough_preserves_global_locale_for_greentic_dev");
     let log_file = sandbox.path().join("dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
     sandbox.write_exit_tool("greentic-operator", 0);
 
     let status = sandbox.run_gtc(
-        ["--locale", "fr", "wizard", "--answers", "oci://example"],
+        [
+            "--locale",
+            "fr",
+            "wizard",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read dev log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]
@@ -329,6 +351,101 @@ fn setup_ignore_release_context_skips_check_and_strips_flag() {
     let logged = fs::read_to_string(log_file).expect("read setup log");
     assert!(logged.contains("--dry-run"));
     assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn wizard_answers_local_file_is_validated_and_forwarded() {
+    let sandbox = TestSandbox::new("wizard_answers_local_file_is_validated_and_forwarded");
+    let log_file = sandbox.path().join("wizard.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"selected_action":"exit"}"#).expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+
+    let status = sandbox.run_gtc(
+        [
+            "wizard",
+            "--ignore-release-context",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read wizard log");
+    assert!(logged.contains(&format!("--answers {}", answers_file.display())));
+    assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn setup_answers_file_url_is_validated_and_forwarded() {
+    let sandbox = TestSandbox::new("setup_answers_file_url_is_validated_and_forwarded");
+    let log_file = sandbox.path().join("setup.log");
+    let answers_file = sandbox.path().join("setup-answers.json");
+    fs::write(&answers_file, br#"{"setup":true}"#).expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+
+    let answers_url = format!("file://{}", answers_file.display());
+    let status = sandbox.run_gtc(
+        [
+            "setup",
+            "--ignore-release-context",
+            "--answers",
+            answers_url.as_str(),
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    assert!(logged.contains(&format!("--answers {answers_url}")));
+    assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn wizard_answers_invalid_json_errors_before_passthrough() {
+    let sandbox = TestSandbox::new("wizard_answers_invalid_json_errors_before_passthrough");
+    let log_file = sandbox.path().join("wizard.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, b"{not-json").expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "wizard",
+            "--ignore-release-context",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
+        HashMap::new(),
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!log_file.exists(), "wizard should not run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to parse answers JSON"));
+}
+
+#[test]
+fn setup_answers_invalid_scheme_errors_before_passthrough() {
+    let sandbox = TestSandbox::new("setup_answers_invalid_scheme_errors_before_passthrough");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "setup",
+            "--ignore-release-context",
+            "--answers",
+            "ftp://example",
+        ],
+        HashMap::new(),
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!log_file.exists(), "setup should not run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported scheme"));
 }
 
 #[test]
@@ -565,16 +682,27 @@ fn op_help_passthrough_routes_to_greentic_operator() {
 fn gtc_dev_wizard_routes_to_dev_suffixed_greentic_dev() {
     let sandbox = TestSandbox::new("gtc_dev_wizard_routes_to_dev_suffixed_greentic_dev");
     let log_file = sandbox.path().join("wizard-dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev-dev", &log_file, 0);
 
     let output = sandbox.run_gtc_dev_capture(
-        ["wizard", "--locale", "fr", "--answers", "oci://example"],
+        [
+            "wizard",
+            "--locale",
+            "fr",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(output.status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read wizard log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add remote answer loading support for HTTP, file URLs, and distributor schemes
- fetch oci:// and repo:// answers as JSON OCI layers using pack-fetch
- fetch store:// answers and validate JSON media types

## Tests
- cargo test answer_resolver