### PR TITLE
Support remote JSON answers on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.25"
+version = "1.0.26"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 clap = { version = "4.5", features = ["std"] }
 directories = "6"
 flate2 = "1.1"
-greentic-distributor-client = { version = "0.5.3", features = ["dist-client", "oci-components"] }
+greentic-distributor-client = { version = "0.5.3", features = ["dist-client", "oci-components", "pack-fetch"] }
 greentic-i18n-lib = "0.5"
 greentic-types = "0.5"
 # `oci-distribution` 0.11.0 is still the newest crates.io release available as

--- a/docs/02-cli/gtc-setup.md
+++ b/docs/02-cli/gtc-setup.md
@@ -61,9 +61,15 @@ This repo does **not** currently own the full semantics of every setup flag.
 For normal setup usage, `gtc` forwards the trailing arguments to
 `greentic-setup`.
 
-That means syntax such as `--answers` or `--no-ui` may be valid in current
-workflows, but the deeper flag behavior is owned by the downstream setup tool,
-not re-parsed by `gtc` itself.
+`gtc` does resolve and validate `--answers` before forwarding. `--answers`
+accepts JSON object documents from plain local paths, `file://...`,
+`http://...`, `https://...`, `oci://...`, `store://...`, and `repo://...`.
+Distributor-backed schemes are resolved through `greentic-distributor-client`
+and forwarded to `greentic-setup` as a temporary local answers file.
+
+Other syntax such as `--no-ui` may be valid in current workflows, but the
+deeper flag behavior is owned by the downstream setup tool, not re-parsed by
+`gtc` itself.
 
 ## Basic Usage
 
@@ -79,8 +85,8 @@ The README also shows:
 gtc setup --no-ui ./cloud-deploy-demo-bundle --answers <setup-answers.json>
 ```
 
-Those forms are passed through to `greentic-setup` in the current
-implementation.
+Those forms are passed through to `greentic-setup` after answer source
+resolution succeeds.
 
 ## Does `./<name>.gtbundle` Work?
 

--- a/docs/02-cli/gtc-wizard.md
+++ b/docs/02-cli/gtc-wizard.md
@@ -88,8 +88,20 @@ Current README and test coverage support the repo-local pattern:
 gtc wizard --answers <answers.json>
 ```
 
-In the current implementation, `gtc` forwards that request to the downstream
-wizard owner rather than validating the answer structure itself.
+`--answers` accepts JSON object documents from:
+
+- plain local paths
+- `file://...`
+- `http://...`
+- `https://...`
+- `oci://...`
+- `store://...`
+- `repo://...`
+
+`gtc` validates that the referenced document is valid JSON with an object at the
+top level before launching the downstream wizard. Distributor-backed schemes are
+resolved through `greentic-distributor-client` and forwarded as a temporary local
+answers file.
 
 That means the safe rule is:
 

--- a/docs/03-authoring/answers-json-patterns.md
+++ b/docs/03-authoring/answers-json-patterns.md
@@ -48,6 +48,10 @@ gtc wizard --emit-answers ./answers.json
 gtc wizard --answers ./answers.json
 ```
 
+`gtc wizard --answers` and `gtc setup --answers` accept the same source forms:
+plain local paths, `file://...`, `http://...`, `https://...`, `oci://...`,
+`store://...`, and `repo://...`. The referenced JSON must parse as an object.
+
 If the downstream wizard does not support `--emit-answers` for your exact flow,
 fall back to using the schema output directly.
 

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -1,5 +1,7 @@
 #[path = "gtc/admin.rs"]
 mod admin;
+#[path = "gtc/answer_resolver.rs"]
+mod answer_resolver;
 #[path = "gtc/archive.rs"]
 mod archive;
 #[path = "gtc/cli.rs"]

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,8 +1,12 @@
 use std::fs;
 use std::path::PathBuf;
 
-use greentic_distributor_client::{CachePolicy, DistClient, DistOptions, ResolvePolicy};
+use greentic_distributor_client::{
+    DistClient, DistOptions, PackFetchOptions, default_pack_layer_media_types,
+    fetch_pack_to_cache_with_options,
+};
 use gtc::error::{GtcError, GtcResult};
+use oci_distribution::Reference;
 use reqwest::blocking::Client;
 use serde_json::{Map, Value};
 
@@ -37,31 +41,71 @@ impl AnswerSourceLoader for DefaultAnswerSourceLoader {
     }
 
     fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
-        let client = DistClient::new(DistOptions::default());
+        let options = DistOptions::default();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(|err| GtcError::message(format!("failed to create runtime: {err}")))?;
-        let artifact_source = client.parse_source(source).map_err(|err| {
-            GtcError::message(format!("failed to parse answers source {source}: {err}"))
-        })?;
-        let descriptor = runtime
-            .block_on(client.resolve(artifact_source, ResolvePolicy))
-            .map_err(|err| {
-                GtcError::message(format!("failed to resolve answers source {source}: {err}"))
-            })?;
-        let artifact = runtime
-            .block_on(client.fetch(&descriptor, CachePolicy))
-            .map_err(|err| {
-                GtcError::message(format!("failed to fetch answers source {source}: {err}"))
-            })?;
-        artifact
-            .wasm_bytes()
-            .map(|bytes| bytes.to_vec())
-            .map_err(|err| {
-                GtcError::message(format!("failed to read resolved answers {source}: {err}"))
-            })
+        let resolved = match classify_answers_source(source)? {
+            AnswerSourceKind::Distributor => {
+                if source.starts_with("store://") {
+                    let client = DistClient::new(options);
+                    let artifact = runtime
+                        .block_on(client.download_store_artifact(source))
+                        .map_err(|err| {
+                            GtcError::message(format!(
+                                "failed to fetch answers source {source}: {err}"
+                            ))
+                        })?;
+                    DistributedAnswerBytes {
+                        bytes: artifact.bytes,
+                        media_type: artifact.media_type,
+                    }
+                } else {
+                    let mapped = map_oci_answers_reference(source, &options)?;
+                    let artifact = runtime
+                        .block_on(fetch_pack_to_cache_with_options(
+                            &mapped,
+                            answer_pack_fetch_options(&options),
+                        ))
+                        .map_err(|err| {
+                            GtcError::message(format!(
+                                "failed to fetch answers source {source}: {err}"
+                            ))
+                        })?;
+                    let bytes = fs::read(&artifact.path).map_err(|err| {
+                        GtcError::io(
+                            format!(
+                                "failed to read resolved answers {}",
+                                artifact.path.display()
+                            ),
+                            err,
+                        )
+                    })?;
+                    DistributedAnswerBytes {
+                        bytes,
+                        media_type: artifact.media_type,
+                    }
+                }
+            }
+            _ => unreachable!("load_distributor is only called for distributor answer sources"),
+        };
+        if !is_json_media_type(&resolved.media_type) {
+            return Err(GtcError::invalid_data(
+                "answers OCI artifact",
+                format!(
+                    "{source} resolved to media type {}; expected application/json or a +json media type",
+                    resolved.media_type
+                ),
+            ));
+        }
+        Ok(resolved.bytes)
     }
+}
+
+struct DistributedAnswerBytes {
+    bytes: Vec<u8>,
+    media_type: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -144,15 +188,98 @@ fn file_url_path(url: &str) -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
+fn map_oci_answers_reference(source: &str, options: &DistOptions) -> GtcResult<String> {
+    if let Some(reference) = source.strip_prefix("oci://") {
+        validate_oci_reference(source, reference)?;
+        return Ok(reference.to_string());
+    }
+
+    if let Some(target) = source.strip_prefix("repo://") {
+        return map_registry_target(source, target, options.repo_registry_base.as_deref());
+    }
+
+    Err(GtcError::invalid_data(
+        "answers source",
+        format!("unsupported distributor answers source {source}"),
+    ))
+}
+
+fn map_registry_target(source: &str, target: &str, base: Option<&str>) -> GtcResult<String> {
+    if Reference::try_from(target).is_ok() {
+        return Ok(target.to_string());
+    }
+    let Some(base) = base else {
+        return Err(GtcError::message(format!(
+            "{source} requires GREENTIC_REPO_REGISTRY_BASE to map to OCI"
+        )));
+    };
+    let mapped = format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        target.trim_start_matches('/')
+    );
+    validate_oci_reference(source, &mapped)?;
+    Ok(mapped)
+}
+
+fn validate_oci_reference(source: &str, reference: &str) -> GtcResult<()> {
+    Reference::try_from(reference).map(|_| ()).map_err(|err| {
+        GtcError::invalid_data(
+            "answers source",
+            format!("{source} is not a valid OCI reference: {err}"),
+        )
+    })
+}
+
+fn answer_pack_fetch_options(options: &DistOptions) -> PackFetchOptions {
+    let mut accepted = vec![
+        "application/json".to_string(),
+        "application/vnd.greentic.answers.v1+json".to_string(),
+        "application/vnd.greentic.answers.create.v1+json".to_string(),
+        "application/vnd.greentic.answers.setup.v1+json".to_string(),
+    ];
+    extend_unique_media_types(&mut accepted, default_pack_layer_media_types());
+    PackFetchOptions {
+        allow_tags: options.allow_tags,
+        offline: options.offline,
+        cache_dir: options.cache_dir.join("answers"),
+        accepted_layer_media_types: accepted,
+        preferred_layer_media_types: vec![
+            "application/vnd.greentic.answers.setup.v1+json".to_string(),
+            "application/vnd.greentic.answers.create.v1+json".to_string(),
+            "application/vnd.greentic.answers.v1+json".to_string(),
+            "application/json".to_string(),
+        ],
+        ..PackFetchOptions::default()
+    }
+}
+
+fn extend_unique_media_types<I>(accepted: &mut Vec<String>, media_types: I)
+where
+    I: IntoIterator<Item = String>,
+{
+    for media_type in media_types {
+        if !accepted.iter().any(|candidate| candidate == &media_type) {
+            accepted.push(media_type);
+        }
+    }
+}
+
+fn is_json_media_type(media_type: &str) -> bool {
+    media_type == "application/json" || media_type.ends_with("+json")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AnswerSourceKind, AnswerSourceLoader, classify_answers_source, load_answer_bytes,
-        load_answers_with,
+        AnswerSourceKind, AnswerSourceLoader, answer_pack_fetch_options, classify_answers_source,
+        is_json_media_type, load_answer_bytes, load_answers_with, map_oci_answers_reference,
     };
+    use greentic_distributor_client::DistOptions;
     use gtc::error::{GtcError, GtcResult};
     use std::cell::RefCell;
     use std::fs;
+    use std::path::PathBuf;
 
     #[derive(Default)]
     struct MockLoader {
@@ -307,5 +434,110 @@ mod tests {
 
         assert!(String::from_utf8(bytes).unwrap().contains("oci://"));
         assert_eq!(loader.dist.borrow().len(), 1);
+    }
+
+    #[test]
+    fn json_media_type_accepts_standard_and_vendor_json() {
+        assert!(is_json_media_type("application/json"));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.v1+json"
+        ));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.create.v1+json"
+        ));
+        assert!(is_json_media_type(
+            "application/vnd.greentic.answers.setup.v1+json"
+        ));
+        assert!(!is_json_media_type("application/wasm"));
+        assert!(!is_json_media_type("application/octet-stream"));
+    }
+
+    #[test]
+    fn answer_pack_fetch_options_prefers_answers_json_layers() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: None,
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        let fetch_options = answer_pack_fetch_options(&options);
+
+        assert_eq!(
+            fetch_options
+                .preferred_layer_media_types
+                .first()
+                .map(String::as_str),
+            Some("application/vnd.greentic.answers.setup.v1+json")
+        );
+        for media_type in [
+            "application/json",
+            "application/vnd.greentic.answers.v1+json",
+            "application/vnd.greentic.answers.create.v1+json",
+            "application/vnd.greentic.answers.setup.v1+json",
+        ] {
+            assert!(
+                fetch_options
+                    .accepted_layer_media_types
+                    .iter()
+                    .any(|accepted| accepted == media_type),
+                "missing accepted media type {media_type}"
+            );
+            assert!(
+                fetch_options
+                    .preferred_layer_media_types
+                    .iter()
+                    .any(|preferred| preferred == media_type),
+                "missing preferred media type {media_type}"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_oci_and_repo_answers_to_oci_references() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: Some("ghcr.io/acme".to_string()),
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        assert_eq!(
+            map_oci_answers_reference("oci://ghcr.io/acme/answers:stable", &options).unwrap(),
+            "ghcr.io/acme/answers:stable"
+        );
+        assert_eq!(
+            map_oci_answers_reference("repo:///answers:stable", &options).unwrap(),
+            "ghcr.io/acme/answers:stable"
+        );
+    }
+
+    #[test]
+    fn repo_answers_require_registry_base_when_target_is_not_oci() {
+        let options = DistOptions {
+            cache_dir: PathBuf::from("/tmp/gtc-answer-test-cache"),
+            allow_tags: true,
+            offline: false,
+            allow_insecure_local_http: false,
+            cache_max_bytes: 42,
+            repo_registry_base: None,
+            store_registry_base: None,
+            store_auth_path: PathBuf::from("/tmp/store-auth.json"),
+            store_state_path: PathBuf::from("/tmp/store-state.json"),
+        };
+
+        let err = map_oci_answers_reference("repo:///answers:stable", &options).unwrap_err();
+
+        assert!(err.to_string().contains("GREENTIC_REPO_REGISTRY_BASE"));
     }
 }

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,0 +1,311 @@
+use std::fs;
+use std::path::PathBuf;
+
+use greentic_distributor_client::{CachePolicy, DistClient, DistOptions, ResolvePolicy};
+use gtc::error::{GtcError, GtcResult};
+use reqwest::blocking::Client;
+use serde_json::{Map, Value};
+
+pub(super) trait AnswerSourceLoader {
+    fn load_http(&self, source: &str) -> GtcResult<Vec<u8>>;
+    fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>>;
+}
+
+pub(super) struct DefaultAnswerSourceLoader;
+
+impl AnswerSourceLoader for DefaultAnswerSourceLoader {
+    fn load_http(&self, source: &str) -> GtcResult<Vec<u8>> {
+        let client = Client::builder()
+            .build()
+            .map_err(|err| GtcError::message(format!("failed to create HTTP client: {err}")))?;
+        let response = client
+            .get(source)
+            .header("Accept", "application/json")
+            .header("User-Agent", format!("gtc/{}", env!("CARGO_PKG_VERSION")))
+            .send()
+            .map_err(|err| GtcError::message(format!("failed to fetch answers {source}: {err}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(GtcError::message(format!(
+                "failed to fetch answers {source}: HTTP {status}"
+            )));
+        }
+        response
+            .bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|err| GtcError::message(format!("failed to read answers {source}: {err}")))
+    }
+
+    fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
+        let client = DistClient::new(DistOptions::default());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| GtcError::message(format!("failed to create runtime: {err}")))?;
+        let artifact_source = client.parse_source(source).map_err(|err| {
+            GtcError::message(format!("failed to parse answers source {source}: {err}"))
+        })?;
+        let descriptor = runtime
+            .block_on(client.resolve(artifact_source, ResolvePolicy))
+            .map_err(|err| {
+                GtcError::message(format!("failed to resolve answers source {source}: {err}"))
+            })?;
+        let artifact = runtime
+            .block_on(client.fetch(&descriptor, CachePolicy))
+            .map_err(|err| {
+                GtcError::message(format!("failed to fetch answers source {source}: {err}"))
+            })?;
+        artifact
+            .wasm_bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|err| {
+                GtcError::message(format!("failed to read resolved answers {source}: {err}"))
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AnswerSourceKind {
+    LocalPath,
+    FileUrl,
+    Http,
+    Distributor,
+}
+
+pub(super) fn classify_answers_source(source: &str) -> GtcResult<AnswerSourceKind> {
+    match source.split_once("://").map(|(scheme, _)| scheme) {
+        None => Ok(AnswerSourceKind::LocalPath),
+        Some("file") => Ok(AnswerSourceKind::FileUrl),
+        Some("http") | Some("https") => Ok(AnswerSourceKind::Http),
+        Some("oci") | Some("store") | Some("repo") => Ok(AnswerSourceKind::Distributor),
+        Some(scheme) => Err(GtcError::invalid_data(
+            "answers source",
+            format!(
+                "unsupported scheme '{scheme}' for {source}; expected local path, file://, http://, https://, oci://, store://, or repo://"
+            ),
+        )),
+    }
+}
+
+pub(super) fn load_answers(source: &str) -> GtcResult<Map<String, Value>> {
+    load_answers_with(source, &DefaultAnswerSourceLoader)
+}
+
+pub(super) fn load_answers_with(
+    source: &str,
+    loader: &dyn AnswerSourceLoader,
+) -> GtcResult<Map<String, Value>> {
+    let bytes = load_answer_bytes(source, loader)?;
+    parse_answers_bytes(source, &bytes)
+}
+
+pub(super) fn load_answer_bytes(
+    source: &str,
+    loader: &dyn AnswerSourceLoader,
+) -> GtcResult<Vec<u8>> {
+    match classify_answers_source(source)? {
+        AnswerSourceKind::LocalPath => fs::read(source)
+            .map_err(|err| GtcError::io(format!("failed to read answers file {source}"), err)),
+        AnswerSourceKind::FileUrl => {
+            let path = file_url_path(source).ok_or_else(|| {
+                GtcError::invalid_data("answers source", format!("invalid file URL: {source}"))
+            })?;
+            fs::read(&path).map_err(|err| {
+                GtcError::io(
+                    format!("failed to read answers file {}", path.display()),
+                    err,
+                )
+            })
+        }
+        AnswerSourceKind::Http => loader.load_http(source),
+        AnswerSourceKind::Distributor => loader.load_distributor(source),
+    }
+}
+
+pub(super) fn parse_answers_bytes(source: &str, bytes: &[u8]) -> GtcResult<Map<String, Value>> {
+    match serde_json::from_slice::<Value>(bytes) {
+        Ok(Value::Object(object)) => Ok(object),
+        Ok(_) => Err(GtcError::invalid_data(
+            "answers JSON",
+            format!("{source} must contain a JSON object"),
+        )),
+        Err(err) => Err(GtcError::json(
+            format!("failed to parse answers JSON from {source}"),
+            err,
+        )),
+    }
+}
+
+fn file_url_path(url: &str) -> Option<PathBuf> {
+    let path = url.strip_prefix("file://")?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AnswerSourceKind, AnswerSourceLoader, classify_answers_source, load_answer_bytes,
+        load_answers_with,
+    };
+    use gtc::error::{GtcError, GtcResult};
+    use std::cell::RefCell;
+    use std::fs;
+
+    #[derive(Default)]
+    struct MockLoader {
+        http: RefCell<Vec<String>>,
+        dist: RefCell<Vec<String>>,
+    }
+
+    impl AnswerSourceLoader for MockLoader {
+        fn load_http(&self, source: &str) -> GtcResult<Vec<u8>> {
+            self.http.borrow_mut().push(source.to_string());
+            Ok(br#"{"from":"http"}"#.to_vec())
+        }
+
+        fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
+            self.dist.borrow_mut().push(source.to_string());
+            Ok(format!(r#"{{"from":"{source}"}}"#).into_bytes())
+        }
+    }
+
+    #[test]
+    fn classifies_supported_answer_sources() {
+        assert_eq!(
+            classify_answers_source("answers.json").unwrap(),
+            AnswerSourceKind::LocalPath
+        );
+        assert_eq!(
+            classify_answers_source("file:///tmp/answers.json").unwrap(),
+            AnswerSourceKind::FileUrl
+        );
+        assert_eq!(
+            classify_answers_source("https://example.com/answers.json").unwrap(),
+            AnswerSourceKind::Http
+        );
+        assert_eq!(
+            classify_answers_source("oci://ghcr.io/acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+        assert_eq!(
+            classify_answers_source("store://acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+        assert_eq!(
+            classify_answers_source("repo://acme/answers:stable").unwrap(),
+            AnswerSourceKind::Distributor
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_scheme() {
+        let err = classify_answers_source("ftp://example.com/answers.json").unwrap_err();
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("unsupported scheme"));
+    }
+
+    #[test]
+    fn loads_local_file_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, br#"{"ok":true}"#).expect("write");
+
+        let answers = load_answers_with(path.to_str().expect("utf8"), &MockLoader::default())
+            .expect("answers");
+
+        assert_eq!(
+            answers.get("ok").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn loads_file_url_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, br#"{"ok":"file"}"#).expect("write");
+
+        let answers = load_answers_with(
+            &format!("file://{}", path.display()),
+            &MockLoader::default(),
+        )
+        .expect("answers");
+
+        assert_eq!(
+            answers.get("ok").and_then(serde_json::Value::as_str),
+            Some("file")
+        );
+    }
+
+    #[test]
+    fn loads_https_answers_through_injected_loader() {
+        let loader = MockLoader::default();
+        let answers =
+            load_answers_with("https://example.com/answers.json", &loader).expect("answers");
+
+        assert_eq!(
+            answers.get("from").and_then(serde_json::Value::as_str),
+            Some("http")
+        );
+        assert_eq!(
+            loader.http.borrow().as_slice(),
+            ["https://example.com/answers.json"]
+        );
+    }
+
+    #[test]
+    fn loads_distributor_answer_schemes_through_injected_loader() {
+        let loader = MockLoader::default();
+        for source in [
+            "oci://ghcr.io/acme/answers:stable",
+            "store://acme/answers:stable",
+            "repo://acme/answers:stable",
+        ] {
+            let answers = load_answers_with(source, &loader).expect("answers");
+            assert_eq!(
+                answers.get("from").and_then(serde_json::Value::as_str),
+                Some(source)
+            );
+        }
+        assert_eq!(loader.dist.borrow().len(), 3);
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, b"{not-json").expect("write");
+
+        let err =
+            load_answers_with(path.to_str().expect("utf8"), &MockLoader::default()).unwrap_err();
+
+        assert!(matches!(err, GtcError::Json { .. }));
+        assert!(err.to_string().contains("failed to parse answers JSON"));
+    }
+
+    #[test]
+    fn rejects_non_object_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("answers.json");
+        fs::write(&path, b"[]").expect("write");
+
+        let err =
+            load_answers_with(path.to_str().expect("utf8"), &MockLoader::default()).unwrap_err();
+
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("must contain a JSON object"));
+    }
+
+    #[test]
+    fn raw_byte_loader_uses_distributor_for_oci() {
+        let loader = MockLoader::default();
+
+        let bytes = load_answer_bytes("oci://ghcr.io/acme/answers:stable", &loader).expect("bytes");
+
+        assert!(String::from_utf8(bytes).unwrap().contains("oci://"));
+        assert_eq!(loader.dist.borrow().len(), 1);
+    }
+}

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -942,6 +942,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.wizard.about").into_owned())
+                .after_help("Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
                 .arg(
                     Arg::new("extensions")
                         .long("extensions")
@@ -984,6 +985,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.setup.about").into_owned())
+                .after_help("Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
                 .arg(
                     Arg::new("extension-setup-handoff")
                         .long("extension-setup-handoff")

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -5,12 +5,17 @@ use std::path::Path;
 
 use clap::ArgMatches;
 use serde_json::Value;
+use tempfile::TempDir;
 
 use crate::admin::{
     load_admin_registry, remove_admin_registry_entry, run_admin_access, run_admin_add_client,
     run_admin_certs, run_admin_clients, run_admin_health, run_admin_list, run_admin_remove_client,
     run_admin_status, run_admin_stop, run_admin_token, run_admin_tunnel, save_admin_registry,
     upsert_admin_registry_entry,
+};
+use crate::answer_resolver::{
+    AnswerSourceKind, DefaultAnswerSourceLoader, classify_answers_source, load_answer_bytes,
+    load_answers, parse_answers_bytes,
 };
 use crate::cli::build_cli;
 use crate::deploy::{
@@ -161,6 +166,21 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
             } else {
                 tail
             };
+            let mut answers_tempdir = None;
+            let tail = if matches!(name, "wizard" | "setup") {
+                match resolve_answers_args(&tail) {
+                    Ok(resolved) => {
+                        answers_tempdir = resolved.tempdir;
+                        resolved.args
+                    }
+                    Err(err) => {
+                        eprintln!("{err}");
+                        return answers_error_exit_code(&err);
+                    }
+                }
+            } else {
+                tail
+            };
             if name == "wizard" && sub_matches.get_many::<String>("extensions").is_some() {
                 return run_extension_wizard(sub_matches, &tail, debug, &locale);
             }
@@ -178,9 +198,102 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 }
                 return run_wizard_schema(binary, &args, debug, &locale);
             }
+            let _answers_tempdir = answers_tempdir;
             passthrough(binary, &args, debug, &locale)
         }
         _ => 2,
+    }
+}
+
+struct ResolvedAnswersArgs {
+    args: Vec<String>,
+    tempdir: Option<TempDir>,
+}
+
+fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
+    let loader = DefaultAnswerSourceLoader;
+    let mut rewritten = Vec::with_capacity(args.len());
+    let mut tempdir: Option<TempDir> = None;
+    let mut index = 0usize;
+    let mut materialized_count = 0usize;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--answers" {
+            let Some(source) = args.get(index + 1) else {
+                return Err(gtc::error::GtcError::invalid_data(
+                    "answers source",
+                    "--answers requires a value",
+                ));
+            };
+            rewritten.push(arg.clone());
+            rewritten.push(resolve_answers_arg_value(
+                source,
+                &loader,
+                &mut tempdir,
+                &mut materialized_count,
+            )?);
+            index += 2;
+            continue;
+        }
+
+        if let Some(source) = arg.strip_prefix("--answers=") {
+            let resolved =
+                resolve_answers_arg_value(source, &loader, &mut tempdir, &mut materialized_count)?;
+            rewritten.push(format!("--answers={resolved}"));
+            index += 1;
+            continue;
+        }
+
+        rewritten.push(arg.clone());
+        index += 1;
+    }
+
+    Ok(ResolvedAnswersArgs {
+        args: rewritten,
+        tempdir,
+    })
+}
+
+fn resolve_answers_arg_value(
+    source: &str,
+    loader: &DefaultAnswerSourceLoader,
+    tempdir: &mut Option<TempDir>,
+    materialized_count: &mut usize,
+) -> gtc::error::GtcResult<String> {
+    let kind = classify_answers_source(source)?;
+    match kind {
+        AnswerSourceKind::LocalPath | AnswerSourceKind::FileUrl | AnswerSourceKind::Http => {
+            let _answers = load_answers(source)?;
+            Ok(source.to_string())
+        }
+        AnswerSourceKind::Distributor => {
+            let bytes = load_answer_bytes(source, loader)?;
+            let _answers = parse_answers_bytes(source, &bytes)?;
+            if tempdir.is_none() {
+                *tempdir = Some(tempfile::tempdir().map_err(|err| {
+                    gtc::error::GtcError::io("failed to create temporary answers directory", err)
+                })?);
+            }
+            let dir = tempdir.as_ref().expect("temporary answers directory");
+            let path = dir
+                .path()
+                .join(format!("answers-{materialized_count}.json"));
+            *materialized_count += 1;
+            fs::write(&path, bytes).map_err(|err| {
+                gtc::error::GtcError::io(format!("failed to write {}", path.display()), err)
+            })?;
+            Ok(path.display().to_string())
+        }
+    }
+}
+
+fn answers_error_exit_code(err: &gtc::error::GtcError) -> i32 {
+    if matches!(err, gtc::error::GtcError::InvalidData { context, .. } if context == "answers source")
+    {
+        2
+    } else {
+        1
     }
 }
 

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -211,34 +211,56 @@ fn gtc_dev_runner_info_forwards_args() {
 fn wizard_passthrough_routes_to_greentic_dev_with_all_args() {
     let sandbox = TestSandbox::new("wizard_passthrough_routes_to_greentic_dev_with_all_args");
     let log_file = sandbox.path().join("dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
     sandbox.write_exit_tool("greentic-operator", 0);
 
     let status = sandbox.run_gtc(
-        ["wizard", "--locale", "fr", "--answers", "oci://example"],
+        [
+            "wizard",
+            "--locale",
+            "fr",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read dev log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]
 fn wizard_passthrough_preserves_global_locale_for_greentic_dev() {
     let sandbox = TestSandbox::new("wizard_passthrough_preserves_global_locale_for_greentic_dev");
     let log_file = sandbox.path().join("dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
     sandbox.write_exit_tool("greentic-operator", 0);
 
     let status = sandbox.run_gtc(
-        ["--locale", "fr", "wizard", "--answers", "oci://example"],
+        [
+            "--locale",
+            "fr",
+            "wizard",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read dev log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]
@@ -329,6 +351,101 @@ fn setup_ignore_release_context_skips_check_and_strips_flag() {
     let logged = fs::read_to_string(log_file).expect("read setup log");
     assert!(logged.contains("--dry-run"));
     assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn wizard_answers_local_file_is_validated_and_forwarded() {
+    let sandbox = TestSandbox::new("wizard_answers_local_file_is_validated_and_forwarded");
+    let log_file = sandbox.path().join("wizard.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"selected_action":"exit"}"#).expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+
+    let status = sandbox.run_gtc(
+        [
+            "wizard",
+            "--ignore-release-context",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read wizard log");
+    assert!(logged.contains(&format!("--answers {}", answers_file.display())));
+    assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn setup_answers_file_url_is_validated_and_forwarded() {
+    let sandbox = TestSandbox::new("setup_answers_file_url_is_validated_and_forwarded");
+    let log_file = sandbox.path().join("setup.log");
+    let answers_file = sandbox.path().join("setup-answers.json");
+    fs::write(&answers_file, br#"{"setup":true}"#).expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+
+    let answers_url = format!("file://{}", answers_file.display());
+    let status = sandbox.run_gtc(
+        [
+            "setup",
+            "--ignore-release-context",
+            "--answers",
+            answers_url.as_str(),
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    assert!(logged.contains(&format!("--answers {answers_url}")));
+    assert!(!logged.contains("--ignore-release-context"));
+}
+
+#[test]
+fn wizard_answers_invalid_json_errors_before_passthrough() {
+    let sandbox = TestSandbox::new("wizard_answers_invalid_json_errors_before_passthrough");
+    let log_file = sandbox.path().join("wizard.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, b"{not-json").expect("write answers");
+    sandbox.write_arg_logger_tool("greentic-dev", &log_file, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "wizard",
+            "--ignore-release-context",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
+        HashMap::new(),
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!log_file.exists(), "wizard should not run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to parse answers JSON"));
+}
+
+#[test]
+fn setup_answers_invalid_scheme_errors_before_passthrough() {
+    let sandbox = TestSandbox::new("setup_answers_invalid_scheme_errors_before_passthrough");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "setup",
+            "--ignore-release-context",
+            "--answers",
+            "ftp://example",
+        ],
+        HashMap::new(),
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!log_file.exists(), "setup should not run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported scheme"));
 }
 
 #[test]
@@ -565,16 +682,27 @@ fn op_help_passthrough_routes_to_greentic_operator() {
 fn gtc_dev_wizard_routes_to_dev_suffixed_greentic_dev() {
     let sandbox = TestSandbox::new("gtc_dev_wizard_routes_to_dev_suffixed_greentic_dev");
     let log_file = sandbox.path().join("wizard-dev.log");
+    let answers_file = sandbox.path().join("answers.json");
+    fs::write(&answers_file, br#"{"ok":true}"#).expect("write answers");
     sandbox.write_arg_logger_tool("greentic-dev-dev", &log_file, 0);
 
     let output = sandbox.run_gtc_dev_capture(
-        ["wizard", "--locale", "fr", "--answers", "oci://example"],
+        [
+            "wizard",
+            "--locale",
+            "fr",
+            "--answers",
+            answers_file.to_str().expect("answers path"),
+        ],
         HashMap::new(),
     );
     assert_eq!(output.status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read wizard log");
-    assert!(logged.contains("wizard --locale fr --answers oci://example"));
+    assert!(logged.contains(&format!(
+        "wizard --locale fr --answers {}",
+        answers_file.display()
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add gtc answer source resolution for local, file, HTTP(S), OCI, store, and repo JSON answer documents.
- Materialize remote --answers inputs to temporary JSON files before forwarding to downstream wizard/setup commands.
- Add distributor-backed answer artifact support and bump gtc to 1.0.26 for the main release line.

## Validation

- cargo check
- cargo test answer_resolver --bin gtc

## Notes

This is the main-targeted PR for the remote answers work that was previously merged into develop via PR #214.