### PR TITLE
fix: windows path str issue and acquire lock in concurrent file r/w test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.26"
+version = "1.0.27"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/deploy/cloud_deploy.rs
+++ b/src/bin/gtc/deploy/cloud_deploy.rs
@@ -941,6 +941,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn require_tool_in_path_uses_current_path() {
+        let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().expect("tempdir");
         let tool = dir.path().join("terraform");
         fs::write(&tool, "#!/bin/sh\nexit 0\n").expect("write");

--- a/src/bin/gtc/extensions.rs
+++ b/src/bin/gtc/extensions.rs
@@ -1088,14 +1088,21 @@ mod tests {
     fn resolve_descriptor_path_returns_absolute_unchanged() {
         let root = tempfile::tempdir().expect("tempdir");
         let registry_path = root.path().join("registry.json");
+        let absolute = if cfg!(windows) {
+            "C:/abs/path.json"
+        } else {
+            "/abs/path.json"
+        };
         fs::write(
             &registry_path,
-            r#"{"schema_version":"1","extensions":[{"id":"alpha","descriptor":"/abs/path.json"}]}"#,
+            format!(
+                r#"{{"schema_version":"1","extensions":[{{"id":"alpha","descriptor":"{absolute}"}}]}}"#
+            ),
         )
         .expect("write");
         let registry = load_registry(&registry_path).expect("registry");
         let resolved = resolve_descriptor_path(&registry, &registry_path, "alpha").expect("path");
-        assert_eq!(resolved, std::path::PathBuf::from("/abs/path.json"));
+        assert_eq!(resolved, std::path::PathBuf::from(absolute));
     }
 
     #[cfg(unix)]

--- a/src/bin/gtc/toolchain.rs
+++ b/src/bin/gtc/toolchain.rs
@@ -1945,7 +1945,7 @@ mod tests {
                 None => env::remove_var("GTC_RELEASE_ARTIFACT_MOCK_ROOT"),
             }
         }
-        assert_eq!(resolved, target.display().to_string());
+        assert_eq!(PathBuf::from(&resolved), target);
         assert!(missing.is_err());
     }
 


### PR DESCRIPTION
Changes:
- Windows test fixes: pick a drive-prefixed absolute path on Windows so is_absolute() is true, and compare via PathBuf instead of string so / and \ separators are treated as equivalent.
- macOS flaky test fix: acquire env_test_lock() before mutating the global PATH, matching every other env-mutating test in the module and closing a parallel-test race.