### PR TITLE
[codex] fix gtc start .gtbundle SquashFS extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "backhand"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e7812fe72262dd26c2b4309c8e8f2c028db1ffbeb21054f009f847f09ca92c"
+dependencies = [
+ "deku",
+ "flate2",
+ "liblzma",
+ "lz4_flex",
+ "no_std_io2",
+ "rayon",
+ "solana-nohash-hasher",
+ "thiserror 2.0.18",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +281,18 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake3"
@@ -784,12 +816,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -807,11 +863,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -821,6 +888,31 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deku"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf55291257a2a5c90cf50ae17b6bbaabc3fd13642cf3895a71c412513c19630"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec2a42b511fc5efd9183f4f71c17885d627b17e7fd9a61a92089406caa4397e"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "der-parser"
@@ -1058,6 +1150,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1434,6 +1532,7 @@ dependencies = [
 name = "gtc"
 version = "1.0.27"
 dependencies = [
+ "backhand",
  "clap",
  "criterion",
  "directories",
@@ -1526,6 +1625,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1994,6 +2099,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2175,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 
 [[package]]
 name = "mach2"
@@ -2111,6 +2243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2402,6 +2553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2630,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2631,6 +2797,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3259,7 +3431,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3383,6 +3555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-nohash-hasher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,6 +3608,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3669,6 +3853,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -4760,6 +4956,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -4964,6 +5163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,6 +5198,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yasna"
@@ -5141,4 +5355,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
 ]
 
 [dependencies]
+backhand = "0.25"
 clap = { version = "4.5", features = ["std"] }
 directories = "6"
 flate2 = "1.1"

--- a/src/bin/gtc/deploy/bundle_resolution.rs
+++ b/src/bin/gtc/deploy/bundle_resolution.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{BufReader, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use gtc::config::GtcConfig;
@@ -171,6 +172,27 @@ fn resolve_archive_bundle_path(
         )));
     }
     let temp = tempfile::tempdir().map_err(|e| GtcError::message(e.to_string()))?;
+    let extracted = temp.path().join("bundle");
+    fs::create_dir_all(&extracted)
+        .map_err(|e| GtcError::io(format!("failed to create {}", extracted.display()), e))?;
+    expand_bundle_archive(&archive_path, &extracted)?;
+    let bundle_dir = detect_bundle_root(&extracted);
+    Ok(StartBundleResolution {
+        bundle_dir,
+        deployment_key,
+        deploy_artifact: Some(archive_path),
+        _hold: Some(temp),
+    })
+}
+
+fn expand_bundle_archive(archive_path: &Path, extracted: &Path) -> GtcResult<()> {
+    let data = fs::read(archive_path)
+        .map_err(|e| GtcError::io(format!("failed to read {}", archive_path.display()), e))?;
+    if looks_like_squashfs(&data) {
+        return extract_squashfs_archive(archive_path, extracted);
+    }
+
+    let temp = tempfile::tempdir().map_err(|e| GtcError::message(e.to_string()))?;
     let staging = temp.path().join("staging");
     fs::create_dir_all(&staging)
         .map_err(|e| GtcError::io(format!("failed to create {}", staging.display()), e))?;
@@ -180,7 +202,7 @@ fn resolve_archive_bundle_path(
         .unwrap_or("bundle.bin")
         .to_string();
     let staged_path = staging.join(file_name);
-    fs::copy(&archive_path, &staged_path).map_err(|e| {
+    fs::copy(archive_path, &staged_path).map_err(|e| {
         GtcError::io(
             format!(
                 "failed to stage bundle artifact {} -> {}",
@@ -191,17 +213,107 @@ fn resolve_archive_bundle_path(
         )
     })?;
 
-    let extracted = temp.path().join("bundle");
-    fs::create_dir_all(&extracted)
+    expand_into_target(&staging, extracted).map_err(|e| GtcError::message(e.to_string()))
+}
+
+fn looks_like_squashfs(data: &[u8]) -> bool {
+    data.starts_with(b"hsqs") || data.starts_with(b"sqsh")
+}
+
+fn extract_squashfs_archive(archive_path: &Path, extracted: &Path) -> GtcResult<()> {
+    let file = fs::File::open(archive_path)
+        .map_err(|e| GtcError::io(format!("failed to open {}", archive_path.display()), e))?;
+    let reader = backhand::FilesystemReader::from_reader(BufReader::new(file)).map_err(|e| {
+        GtcError::message(format!(
+            "failed to read SquashFS bundle {}: {e}",
+            archive_path.display()
+        ))
+    })?;
+
+    fs::create_dir_all(extracted)
         .map_err(|e| GtcError::io(format!("failed to create {}", extracted.display()), e))?;
-    expand_into_target(&staging, &extracted).map_err(|e| GtcError::message(e.to_string()))?;
-    let bundle_dir = detect_bundle_root(&extracted);
-    Ok(StartBundleResolution {
-        bundle_dir,
-        deployment_key,
-        deploy_artifact: Some(archive_path),
-        _hold: Some(temp),
+
+    for node in reader.files() {
+        let path_str = node.fullpath.to_string_lossy();
+        if path_str == "/" || path_str.is_empty() {
+            continue;
+        }
+        if path_str.contains("..") {
+            return Err(GtcError::message(format!(
+                "invalid path in SquashFS bundle: {path_str}"
+            )));
+        }
+
+        let relative_path = path_str.trim_start_matches('/');
+        let out_path = extracted.join(relative_path);
+        match &node.inner {
+            backhand::InnerNode::Dir(_) => fs::create_dir_all(&out_path)
+                .map_err(|e| GtcError::io(format!("failed to create {}", out_path.display()), e))?,
+            backhand::InnerNode::File(file_reader) => {
+                if let Some(parent) = out_path.parent() {
+                    fs::create_dir_all(parent).map_err(|e| {
+                        GtcError::io(format!("failed to create {}", parent.display()), e)
+                    })?;
+                }
+                let mut out_file = fs::File::create(&out_path).map_err(|e| {
+                    GtcError::io(format!("failed to create {}", out_path.display()), e)
+                })?;
+                let content = reader.file(file_reader);
+                let mut decompressed = Vec::new();
+                content
+                    .reader()
+                    .read_to_end(&mut decompressed)
+                    .map_err(|e| {
+                        GtcError::io(
+                            format!("failed to decompress {}", node.fullpath.display()),
+                            e,
+                        )
+                    })?;
+                out_file.write_all(&decompressed).map_err(|e| {
+                    GtcError::io(format!("failed to write {}", out_path.display()), e)
+                })?;
+                set_permissions_from_squashfs_header(&out_path, node.header.permissions)?;
+            }
+            backhand::InnerNode::Symlink(link) => {
+                #[cfg(not(unix))]
+                let _ = link;
+                #[cfg(unix)]
+                {
+                    if let Some(parent) = out_path.parent() {
+                        fs::create_dir_all(parent).map_err(|e| {
+                            GtcError::io(format!("failed to create {}", parent.display()), e)
+                        })?;
+                    }
+                    std::os::unix::fs::symlink(&link.link, &out_path).map_err(|e| {
+                        GtcError::io(
+                            format!("failed to create symlink {}", out_path.display()),
+                            e,
+                        )
+                    })?;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_permissions_from_squashfs_header(path: &Path, permissions: u16) -> GtcResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(u32::from(permissions))).map_err(|e| {
+        GtcError::io(
+            format!("failed to set permissions on {}", path.display()),
+            e,
+        )
     })
+}
+
+#[cfg(not(unix))]
+fn set_permissions_from_squashfs_header(_path: &Path, _permissions: u16) -> GtcResult<()> {
+    Ok(())
 }
 
 pub(crate) fn detect_bundle_root(extracted_root: &Path) -> PathBuf {
@@ -289,9 +401,9 @@ fn map_registry_target(target: &str, base: Option<String>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        deployment_key_for_path, detect_bundle_root, map_registry_target, map_remote_bundle_ref,
-        parse_local_bundle_ref, resolve_bundle_reference, resolve_local_mutable_bundle_dir,
-        sanitize_identifier, should_ignore_fingerprint_path,
+        deployment_key_for_path, detect_bundle_root, looks_like_squashfs, map_registry_target,
+        map_remote_bundle_ref, parse_local_bundle_ref, resolve_bundle_reference,
+        resolve_local_mutable_bundle_dir, sanitize_identifier, should_ignore_fingerprint_path,
     };
     use crate::tests::env_test_lock;
     use std::env;
@@ -333,6 +445,14 @@ mod tests {
             sanitize_identifier("Acme.Dev/Bundle@01"),
             "acme-dev-bundle-01"
         );
+    }
+
+    #[test]
+    fn looks_like_squashfs_detects_squashfs_magic() {
+        assert!(looks_like_squashfs(b"hsqs\x01\x00"));
+        assert!(looks_like_squashfs(b"sqsh\x01\x00"));
+        assert!(!looks_like_squashfs(b"PK\x03\x04"));
+        assert!(!looks_like_squashfs(b""));
     }
 
     #[test]

--- a/src/bin/gtc/deploy/refresh.rs
+++ b/src/bin/gtc/deploy/refresh.rs
@@ -386,13 +386,11 @@ bundle_digest = "sha256:abc"
     }
 
     fn fake_status(success: bool) -> ExitStatus {
-        // Fabricate a real ExitStatus by spawning a noop command. Using
-        // `true`/`false` keeps this portable across POSIX systems.
         #[cfg(unix)]
         {
-            ProcessCommand::new(if success { "true" } else { "false" })
-                .status()
-                .expect("spawn noop command")
+            use std::os::unix::process::ExitStatusExt;
+
+            ExitStatus::from_raw(if success { 0 } else { 1 << 8 })
         }
         #[cfg(not(unix))]
         {


### PR DESCRIPTION
## Summary

Fixes `gtc start <bundle>.gtbundle` for SquashFS-backed `.gtbundle` archives.

## Root Cause

`gtc setup` could extract the `.gtbundle` format, but `gtc start` only expanded zip/tar-like archives before handing a directory to `greentic-start`. For SquashFS `.gtbundle` files this left the runtime handoff pointed at a directory without `greentic.demo.yaml`, `bundle.yaml`, or the normalized bundle layout, producing the runtime error about missing bundle config.

## Changes

- Add `backhand` as a direct dependency.
- Detect SquashFS magic bytes when resolving local archive bundle refs.
- Extract SquashFS bundles in-process with `backhand`, including directories, files, symlinks on Unix, and file permissions on Unix.
- Keep the existing fallback archive expansion behavior for zip/tar-style inputs.
- Add focused coverage for SquashFS magic detection.

## Validation

- `cargo test -p gtc bundle_resolution`
- `GREENTIC_START_BIN=/bin/true target/debug/gtc start /home/maarten/tests/welcome-to-greentic.gtbundle --no-browser`