### PR TITLE
[codex] fix gtc start .gtbundle SquashFS extraction for 1.0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.27"
+version = "1.0.28"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.27"
+version = "1.0.28"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -226,7 +226,7 @@ fn validate_oci_reference(source: &str, reference: &str) -> GtcResult<()> {
     Reference::try_from(reference).map(|_| ()).map_err(|err| {
         GtcError::invalid_data(
             "answers source",
-            format!("{source} is not a valid OCI reference: {err}"),
+            format!("{} is not a valid OCI reference: {}", source, err),
         )
     })
 }

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -590,7 +590,7 @@ fn prompt_start_target(targets: &[StartTarget], locale: &str) -> GtcResult<Start
 fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {
     args.get(idx)
         .cloned()
-        .ok_or_else(|| GtcError::message(format!("missing value for {flag}")))
+        .ok_or_else(|| GtcError::message(format!("missing value for {}", flag)))
 }
 
 #[cfg(test)]

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -794,7 +794,7 @@ fn install_store_asset_item(
         .map_err(|e| GtcError::message(format!("failed to build tokio runtime: {e}")))?;
     let artifact = rt
         .block_on(client.download_store_artifact(store_url))
-        .map_err(|e| GtcError::message(format!("{}: {e}", t(locale, "gtc.err.pull_failed"))))?;
+        .map_err(|e| GtcError::message(format!("{}: {}", t(locale, "gtc.err.pull_failed"), e)))?;
     let file_name = store_asset_file_name(store_url)
         .ok_or_else(|| GtcError::message(format!("unable to derive filename from {store_url}")))?;
     let target = store_asset_target_path(artifacts_root, &file_name)?;

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -425,7 +425,7 @@ pub fn parse_stop_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<Sto
 fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {
     args.get(idx)
         .cloned()
-        .ok_or_else(|| GtcError::message(format!("missing value for {flag}")))
+        .ok_or_else(|| GtcError::message(format!("missing value for {}", flag)))
 }
 
 fn parse_nats_mode(value: &str) -> GtcResult<NatsModeArg> {


### PR DESCRIPTION
## Summary

Fixes `gtc start <bundle>.gtbundle` for SquashFS-backed `.gtbundle` archives and bumps the `gtc` package version to `1.0.28`.

## Root Cause

`gtc setup` could extract the `.gtbundle` format, but `gtc start` only expanded zip/tar-like archives before handing a directory to `greentic-start`. For SquashFS `.gtbundle` files this left the runtime handoff pointed at a directory without `greentic.demo.yaml`, `bundle.yaml`, or the normalized bundle layout, producing the runtime error about missing bundle config.

## Changes

- Add `backhand` as a direct dependency.
- Detect SquashFS magic bytes when resolving local archive bundle refs.
- Extract SquashFS bundles in-process with `backhand`, including directories, files, symlinks on Unix, and file permissions on Unix.
- Keep the existing fallback archive expansion behavior for zip/tar-style inputs.
- Make refresh tests avoid spawning PATH-dependent shell noops for fake exit statuses.
- Bump `gtc` from `1.0.27` to `1.0.28`.

## Validation

- `cargo test -p gtc bundle_resolution`
- `cargo test -p gtc deploy::refresh::tests::run_refresh_with_root`
- `GREENTIC_START_BIN=/bin/true target/debug/gtc start /home/maarten/tests/welcome-to-greentic.gtbundle --no-browser`