### PR TITLE
chore: start 1.1 pre-release lane (1.1.0-dev.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.26"
+version = "1.1.0-dev.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.0.26"
+version = "1.1.0-dev.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
Kicks off the 1.1 pre-release lane for `greentic`.

**Changes:**
- Package version: `1.0.26` → `1.1.0-dev.0`
- Greentic-ecosystem dep reqs rewritten to pre-release range form: `">=1.1.0-dev, <1.2.0-0"`

**Firewall note:** Cargo's pre-release matching means `^1.0` in consumer repos does NOT resolve `1.1.0-dev.0`. Consumers opt in by updating their own dep reqs. See the cascade plan at `.github/cascade-plans/greentic-1.1.0-dev.0.md` for tier-ordered adoption.

**Follow-up:**
- [ ] Update `REPO_MANIFEST.toml` entry for `greentic`: `version-track = { from = "1.0", to = "1.1" }`
- [ ] Smoke-test dev-publish workflow picks up `-dev.N` version
- [ ] Begin tier-ordered consumer adoption per cascade plan

Generated by `start-next-minor.sh`.