### PR TITLE
feat(deploy): pin local_runtime_secret_env contract

### DIFF
--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -906,4 +906,38 @@ mod tests {
         let target = load_default_deployment_target(dir.path()).expect("target");
         assert_eq!(target, None);
     }
+
+    // PR-08 Phase 5: regression coverage. Local `gtc start` reads the dev
+    // envelope from `<bundle>/.greentic/dev/.dev.secrets.env` via
+    // `GREENTIC_DEV_SECRETS_PATH`. The bake-into-bundle change must not
+    // disturb that contract — the envelope still lives in the source bundle
+    // directory, and `local_runtime_secret_env` still points the runner
+    // subprocess at it.
+
+    #[test]
+    fn local_runtime_secret_env_points_at_bundle_envelope_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let envelope = dir
+            .path()
+            .join(".greentic")
+            .join("dev")
+            .join(".dev.secrets.env");
+        fs::create_dir_all(envelope.parent().expect("parent")).expect("mkdir");
+        fs::write(&envelope, "SECRET=value\n").expect("envelope");
+
+        let env = super::local_runtime_secret_env(dir.path()).expect("env present");
+        let entry = env
+            .vars
+            .iter()
+            .find(|(key, _)| key == "GREENTIC_DEV_SECRETS_PATH")
+            .expect("GREENTIC_DEV_SECRETS_PATH must be set");
+        assert_eq!(entry.1.as_str(), envelope.display().to_string());
+    }
+
+    #[test]
+    fn local_runtime_secret_env_returns_none_when_envelope_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // No `.greentic/dev/.dev.secrets.env` file created on purpose.
+        assert!(super::local_runtime_secret_env(dir.path()).is_none());
+    }
 }

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -907,13 +907,6 @@ mod tests {
         assert_eq!(target, None);
     }
 
-    // PR-08 Phase 5: regression coverage. Local `gtc start` reads the dev
-    // envelope from `<bundle>/.greentic/dev/.dev.secrets.env` via
-    // `GREENTIC_DEV_SECRETS_PATH`. The bake-into-bundle change must not
-    // disturb that contract — the envelope still lives in the source bundle
-    // directory, and `local_runtime_secret_env` still points the runner
-    // subprocess at it.
-
     #[test]
     fn local_runtime_secret_env_points_at_bundle_envelope_when_present() {
         let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Changes:
Adds regression coverage for `local_runtime_secret_env` so the local `gtc start` envelope-path wiring stays locked in while cloud-side secrets work lands in `greentic-deployer`:

- Returns `GREENTIC_DEV_SECRETS_PATH` pointing at `<bundle>/.greentic/dev/.dev.secrets.env` when the envelope is present.
- Returns `None` when the envelope is absent.

Related:
- TBA