### PR TITLE
fix(gtc): prepend `op` when routing deploy-spec verbs to greentic-operator

### DIFF
--- a/src/perf_targets.rs
+++ b/src/perf_targets.rs
@@ -45,6 +45,11 @@ pub fn rewrite_legacy_op_args(args: &[String]) -> Vec<String> {
     };
 
     match first.as_str() {
+        // `demo` and `op` are real top-level subcommands of `greentic-operator`
+        // (`demo` is the legacy bundle workflow, `op` is the deploy-spec verb
+        // tree). Forward verbatim — `op` also serves as the documented
+        // double-op workaround.
+        "demo" | "op" => args.to_vec(),
         "setup" => {
             let mut has_tenant = false;
             let mut has_team = false;
@@ -115,7 +120,20 @@ pub fn rewrite_legacy_op_args(args: &[String]) -> Vec<String> {
             }
             out
         }
-        _ => args.to_vec(),
+        _ => {
+            // Leading flag (e.g. `gtc op --help`, `gtc op --store-root …`) — the
+            // operator-level `Op` clap parser owns these globals, so prepend `op`
+            // to route them at the correct level.
+            //
+            // Bare noun (e.g. `gtc op env init`) — `env`, `env-packs`,
+            // `bundles`, `revisions`, `traffic`, `config`, `credentials`,
+            // `secrets` are nouns under `OpCommand`, not direct subcommands of
+            // `greentic-operator`. Prepending `op` makes them resolve.
+            let mut out = Vec::with_capacity(args.len() + 1);
+            out.push("op".to_string());
+            out.extend_from_slice(args);
+            out
+        }
     }
 }
 
@@ -327,6 +345,52 @@ mod tests {
         assert!(rewritten.iter().any(|arg| arg == "--tenant"));
         assert!(rewritten.iter().any(|arg| arg == "--team"));
         assert!(rewritten.iter().any(|arg| arg == "--cloudflared"));
+    }
+
+    #[test]
+    fn rewrite_legacy_op_args_prepends_op_for_deploy_spec_nouns() {
+        for noun in [
+            "env",
+            "env-packs",
+            "bundles",
+            "revisions",
+            "traffic",
+            "config",
+            "credentials",
+            "secrets",
+        ] {
+            let args = vec![noun.to_string(), "init".to_string()];
+            let rewritten = rewrite_legacy_op_args(&args);
+            assert_eq!(
+                rewritten,
+                vec!["op".to_string(), noun.to_string(), "init".to_string()],
+                "noun `{noun}` should be routed under `op`"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_legacy_op_args_passes_demo_and_op_through() {
+        let demo = vec!["demo".to_string(), "build".to_string()];
+        assert_eq!(rewrite_legacy_op_args(&demo), demo);
+
+        let double_op = vec!["op".to_string(), "env".to_string(), "init".to_string()];
+        assert_eq!(rewrite_legacy_op_args(&double_op), double_op);
+    }
+
+    #[test]
+    fn rewrite_legacy_op_args_prepends_op_for_leading_flag() {
+        let args = vec!["--help".to_string()];
+        assert_eq!(
+            rewrite_legacy_op_args(&args),
+            vec!["op".to_string(), "--help".to_string()],
+        );
+    }
+
+    #[test]
+    fn rewrite_legacy_op_args_passes_empty_through() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(rewrite_legacy_op_args(&empty), empty);
     }
 
     #[test]

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -675,7 +675,70 @@ fn op_help_passthrough_routes_to_greentic_operator() {
     assert_eq!(status.code(), Some(0));
 
     let logged = fs::read_to_string(log_file).expect("read op log");
-    assert!(logged.contains("--help"));
+    assert!(
+        logged.split_whitespace().eq(["op", "--help"]),
+        "expected greentic-operator to receive `op --help`, got: {logged}"
+    );
+}
+
+// `gtc op env init` must forward as `greentic-operator op env init` — `env` is
+// a noun under `OpCommand`, not a top-level operator subcommand. Regression
+// guard for the routing bug where the leading `op` was stripped before
+// forwarding, leaving `greentic-operator env init` and "unrecognized
+// subcommand 'env'".
+#[test]
+fn op_deploy_spec_noun_routes_under_op() {
+    let sandbox = TestSandbox::new("op_deploy_spec_noun_routes_under_op");
+    let log_file = sandbox.path().join("op.log");
+    sandbox.write_arg_logger_tool("greentic-operator", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+
+    let status = sandbox.run_gtc(["op", "env", "init"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read op log");
+    assert!(
+        logged.split_whitespace().eq(["op", "env", "init"]),
+        "expected greentic-operator to receive `op env init`, got: {logged}"
+    );
+}
+
+// Legacy `gtc op demo build` must still forward as-is (the operator's `Demo`
+// top-level subcommand handles it directly).
+#[test]
+fn op_demo_subcommand_passes_through_unchanged() {
+    let sandbox = TestSandbox::new("op_demo_subcommand_passes_through_unchanged");
+    let log_file = sandbox.path().join("op.log");
+    sandbox.write_arg_logger_tool("greentic-operator", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+
+    let status = sandbox.run_gtc(["op", "demo", "build"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read op log");
+    assert!(
+        logged.split_whitespace().eq(["demo", "build"]),
+        "expected greentic-operator to receive `demo build`, got: {logged}"
+    );
+}
+
+// Documented `gtc op op env init` double-op workaround must keep working — the
+// leading `op` is the user-typed explicit selector, not a strip target.
+#[test]
+fn op_double_op_workaround_passes_through_unchanged() {
+    let sandbox = TestSandbox::new("op_double_op_workaround_passes_through_unchanged");
+    let log_file = sandbox.path().join("op.log");
+    sandbox.write_arg_logger_tool("greentic-operator", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+
+    let status = sandbox.run_gtc(["op", "op", "env", "init"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read op log");
+    assert!(
+        logged.split_whitespace().eq(["op", "env", "init"]),
+        "expected greentic-operator to receive `op env init`, got: {logged}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `gtc op env init` (and any other deploy-spec verb under `OpCommand`) used to fail with `error: unrecognized subcommand 'env'` because the gtc router stripped `op` (consumed as gtc's own subcommand name) and forwarded only `env init` to `greentic-operator`.
- `greentic-operator` only exposes two top-level subcommands: `demo` (legacy bundle workflow) and `op` (the deploy-spec verb tree from `greentic-deployer`'s `OpCommand`). All of `env`, `env-packs`, `bundles`, `revisions`, `traffic`, `config`, `credentials`, `secrets` live under `op`.
- Documented workaround was the double-op (`gtc op op env init`). This PR makes the single-op form work.

## Fix

In `rewrite_legacy_op_args` (`src/perf_targets.rs`), default to prepending `op` to the forwarded tail. Existing rewrites preserved:

| Input                  | Forwarded args                          |
|------------------------|-----------------------------------------|
| `gtc op setup …`       | `demo setup … --tenant default …`       |
| `gtc op start …`       | `demo start … --tenant default …`       |
| `gtc op demo build`    | `demo build`                            |
| `gtc op op env init`   | `op env init` (double-op preserved)     |
| `gtc op env init`      | `op env init` ✅ (was: `env init`)      |
| `gtc op --help`        | `op --help` ✅ (was: `--help`)          |

## Test plan

- [x] `cargo test --lib rewrite_legacy_op_args` — 5 unit tests pass
- [x] `cargo test --test gtc_router_integration op_` — 8 integration tests pass (4 new + 4 pre-existing)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Full `cargo test --tests`: 437 passed, 0 failed

Pre-existing perf-bench linker error (`alloca::with_alloca` missing `c_with_alloca`) is unrelated infra and reproduces on `origin/develop`.
