### PR TITLE
feat(gtc): support `gtc start` with no bundle (env runtime-config model)

### DIFF
--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -851,9 +851,11 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "Start a bundle from local or remote reference.",
                 ))
                 .arg(
+                    // Optional: with no bundle ref (and no extension handoff),
+                    // `gtc start` boots greentic-start against the operator-
+                    // materialized runtime-config for the active env.
                     Arg::new("bundle-ref")
                         .value_name("BUNDLE_REF")
-                        .required_unless_present("extension-start-handoff")
                         .help_heading(arguments_heading)
                         .help(t_or(
                             locale,

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 
 use clap::ArgMatches;
 use gtc::error::{GtcError, GtcResult};
-use gtc::start_stop_parsing::{parse_start_request, parse_stop_request};
+use gtc::start_stop_parsing::{
+    parse_runtime_config_start_request, parse_start_request, parse_stop_request,
+};
 use serde::Deserialize;
 
 use super::bundle_resolution::resolve_bundle_reference;
@@ -17,19 +19,66 @@ use crate::process::run_binary_checked;
 use crate::router::collect_tail;
 
 pub(crate) fn run_start(sub_matches: &ArgMatches, debug: bool, locale: &str) -> i32 {
-    let Some(bundle_ref) = sub_matches.get_one::<String>("bundle-ref") else {
-        eprintln!(
-            "{}",
-            t_or(
-                locale,
-                "gtc.start.err.bundle_required",
-                "bundle ref is required"
-            )
-        );
-        return 2;
-    };
     let tail = collect_tail(sub_matches);
-    run_start_with_bundle_ref_and_tail(bundle_ref, &tail, debug, locale)
+    match sub_matches.get_one::<String>("bundle-ref") {
+        Some(bundle_ref) => run_start_with_bundle_ref_and_tail(bundle_ref, &tail, debug, locale),
+        // No bundle ref: boot greentic-start against the operator-materialized
+        // runtime-config for the active env (`GREENTIC_ENV`, default `local`).
+        None => run_start_runtime_config(&tail, debug, locale),
+    }
+}
+
+/// Start with no bundle ref: hand off to greentic-start with no `--bundle` so it
+/// boots from the active env's materialized `runtime-config.json` and serves the
+/// deployed revisions. The runtime-config model has no bundle dir, deploy target,
+/// or admin certs to resolve — those are bundle-only concerns handled by
+/// [`run_start_with_bundle_ref_and_tail`].
+fn run_start_runtime_config(tail: &[String], debug: bool, locale: &str) -> i32 {
+    let cli_options = match parse_start_cli_options(tail) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!(
+                "{}: {err}",
+                t_or(
+                    locale,
+                    "gtc.start.err.invalid_args",
+                    "invalid start arguments"
+                )
+            );
+            return 2;
+        }
+    };
+    let request = match parse_runtime_config_start_request(&cli_options.start_args) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!(
+                "{}: {err}",
+                t_or(
+                    locale,
+                    "gtc.start.err.invalid_args",
+                    "invalid start arguments"
+                )
+            );
+            return 2;
+        }
+    };
+    println!("Deployment mode: local runtime (no bundle — env runtime-config)");
+    println!(
+        "Starting tenant={} team={}",
+        request.tenant.as_deref().unwrap_or("demo"),
+        request.team.as_deref().unwrap_or("default")
+    );
+    let args = request.to_runtime_start_args(locale);
+    match run_binary_checked(START_BIN, &args, debug, locale, "start runtime-config") {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!(
+                "{}: {err}",
+                t_or(locale, "gtc.start.err.run_failed", "failed to start bundle")
+            );
+            1
+        }
+    }
 }
 
 pub(crate) fn run_start_with_bundle_ref_and_tail(
@@ -596,9 +645,9 @@ fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> 
 #[cfg(test)]
 mod tests {
     use super::{
-        load_default_deployment_target, parse_start_cli_options, parse_start_request,
-        parse_stop_cli_options, parse_stop_request, select_start_target,
-        select_start_target_with_mode,
+        load_default_deployment_target, parse_runtime_config_start_request,
+        parse_start_cli_options, parse_start_request, parse_stop_cli_options, parse_stop_request,
+        select_start_target, select_start_target_with_mode,
     };
     use crate::deploy::StartTarget;
     use gtc::start_stop_parsing::{
@@ -668,6 +717,30 @@ mod tests {
         assert_eq!(
             request.admin_allowed_clients,
             vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_runtime_config_start_request_has_no_bundle_but_keeps_flags() {
+        // No-bundle path: same flag parsing as the bundle path, but `bundle` is
+        // None so the args emitted to greentic-start omit `--bundle`, letting it
+        // boot from the env's materialized runtime-config.
+        let request = parse_runtime_config_start_request(&[
+            "--tenant=demo".to_string(),
+            "--team=ops".to_string(),
+            "--no-nats".to_string(),
+        ])
+        .expect("request");
+
+        assert_eq!(request.bundle, None);
+        assert_eq!(request.tenant.as_deref(), Some("demo"));
+        assert_eq!(request.team.as_deref(), Some("ops"));
+        assert!(request.no_nats);
+
+        let args = request.to_runtime_start_args("en");
+        assert!(
+            !args.iter().any(|a| a == "--bundle"),
+            "no-bundle start must not pass --bundle: {args:?}"
         );
     }
 

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -182,6 +182,16 @@ impl StopRequest {
     }
 }
 
+/// Build a [`StartRequest`] for the no-bundle runtime-config model: identical
+/// flag parsing to [`parse_start_request`], but with `bundle: None` so
+/// greentic-start boots from the active env's materialized `runtime-config.json`
+/// instead of a bundle dir.
+pub fn parse_runtime_config_start_request(tail: &[String]) -> GtcResult<StartRequest> {
+    let mut request = parse_start_request(tail, PathBuf::new())?;
+    request.bundle = None;
+    Ok(request)
+}
+
 pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<StartRequest> {
     let mut request = StartRequest {
         bundle: Some(bundle_dir.display().to_string()),


### PR DESCRIPTION
## Why

The new no-bundle deployment model (`gtc op bundles add` → `revisions
stage/warm` → `traffic set` → `start`) was **unreachable through `gtc
start`**: the CLI hard-required a `<BUNDLE_REF>` positional, so a bare `gtc
start` failed with `error: the following required arguments were not provided:
<BUNDLE_REF>`. The model was only usable by invoking the `greentic-start`
binary directly. `greentic-start` itself already supports no-bundle serving
(it boots from the env's materialized `runtime-config.json`); only the gtc
wrapper was blocking it.

## What

- **`cli.rs`**: drop the `required_unless_present(...)` on the `start`
  subcommand's `bundle-ref` → it's now optional (`[BUNDLE_REF]`).
- **`deploy/start_stop.rs`**: `run_start` now routes a missing bundle ref to a
  new `run_start_runtime_config`, which hands off to `greentic-start` with no
  `--bundle`. Bundle-only concerns (ref resolution, deploy-target selection,
  admin-cert prep) stay on the existing bundle path.
- **`start_stop_parsing.rs`**: add `parse_runtime_config_start_request` — a
  thin wrapper over `parse_start_request` yielding `bundle: None`, reusing the
  same flag parsing (no duplicated parse loop).

## Behavior

- `gtc start` (no args) → boots `greentic-start` against the active env's
  `runtime-config.json` (env via `GREENTIC_ENV`, default `local`).
- `gtc start <bundle-ref> …` → unchanged.

## Verification

- `cargo build --locked` ✅, `cargo clippy --locked --all-targets --all-features -- -D warnings` ✅, `cargo fmt --check` ✅
- Tests ✅ incl. new `parse_runtime_config_start_request_has_no_bundle_but_keeps_flags` (asserts `bundle: None` and that emitted args omit `--bundle`)
- Manual: bare `gtc start` reaches the new path ("Deployment mode: local runtime (no bundle — env runtime-config)") and execs `greentic-start` with no `--bundle`, instead of the clap `BUNDLE_REF required` error.

## Note

Leading `--flags` without a bundle (e.g. `gtc start --no-nats`) still hit a
clap trailing-arg quirk; not addressed here because the runtime-config model's
canonical invocation is bare `gtc start` (tenant/transport come from the
deployment, not start flags). Pass such flags after a bundle ref or via env as
before.
