### PR TITLE
feat(cli): one tail parser owns the start/stop surface + --env forwarding

### DIFF
--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -3,25 +3,6 @@ use clap::{Arg, ArgAction, Command};
 use crate::i18n_support::{leak_str, t, t_or};
 use crate::router::passthrough_args;
 
-fn upload_bundle_args(options_heading: &'static str, locale: &str) -> Vec<Arg> {
-    vec![
-        Arg::new("upload-bundle")
-            .long("upload-bundle")
-            .value_name("URL")
-            .num_args(1)
-            .help_heading(options_heading)
-            .help(t(locale, "gtc.arg.upload_bundle.help").into_owned())
-            .conflicts_with("deploy-bundle-source"),
-        Arg::new("upload-bundle-presign-expires")
-            .long("upload-bundle-presign-expires")
-            .value_name("SECONDS")
-            .num_args(1)
-            .default_value("604800")
-            .help_heading(options_heading)
-            .help(t(locale, "gtc.arg.upload_bundle_presign_expires.help").into_owned()),
-    ]
-}
-
 pub(super) fn build_cli(locale: &str) -> Command {
     let cmd_args = passthrough_args();
     let options_heading = leak_str(t(locale, "gtc.help.options.heading").into_owned());
@@ -840,6 +821,11 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 ),
         )
         .subcommand(
+            // Pure catch-all (the `op` pattern): ONE tail parser owns the
+            // whole start surface — positional bundle ref, gtc-specific
+            // flags, and every forwarded greentic-start flag — so a leading
+            // flag with no bundle ref (`gtc start --cloudflared on`) parses
+            // instead of dying at the clap layer.
             Command::new("start")
                 .help_template(help_template)
                 .subcommand_help_heading(commands_heading)
@@ -850,38 +836,6 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.start.about",
                     "Start a bundle from local or remote reference.",
                 ))
-                .arg(
-                    // Optional: with no bundle ref (and no extension handoff),
-                    // `gtc start` boots greentic-start against the operator-
-                    // materialized runtime-config for the active env.
-                    Arg::new("bundle-ref")
-                        .value_name("BUNDLE_REF")
-                        .help_heading(arguments_heading)
-                        .help(t_or(
-                            locale,
-                            "gtc.arg.bundle_ref.help",
-                            "Bundle path/ref: local path, file://, oci://, repo://, store://",
-                        )),
-                )
-                .arg(
-                    Arg::new("extension-start-handoff")
-                        .long("extension-start-handoff")
-                        .value_name("PATH")
-                        .num_args(1)
-                        .help_heading(options_heading)
-                        .help(
-                            "Path to a normalized extension start handoff JSON document.",
-                        ),
-                )
-                .arg(
-                    Arg::new("deploy-bundle-source")
-                        .long("deploy-bundle-source")
-                        .value_name("BUNDLE_SOURCE")
-                        .num_args(1)
-                        .help_heading(options_heading)
-                        .help(t(locale, "gtc.arg.deploy_bundle_source.help").into_owned()),
-                )
-                .args(upload_bundle_args(options_heading, locale))
                 .arg(cmd_args.clone()),
         )
         .subcommand(
@@ -895,17 +849,6 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.stop.about",
                     "Stop a bundle runtime or destroy a deployed environment.",
                 ))
-                .arg(
-                    Arg::new("bundle-ref")
-                        .value_name("BUNDLE_REF")
-                        .required(true)
-                        .help_heading(arguments_heading)
-                        .help(t_or(
-                            locale,
-                            "gtc.arg.bundle_ref.help",
-                            "Bundle path/ref: local path, file://, oci://, repo://, store://",
-                        )),
-                )
                 .arg(cmd_args.clone()),
         )
         .subcommand(

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -22,7 +22,9 @@ use crate::deploy::{
     RefreshArgs, resolve_local_mutable_bundle_dir, run_refresh, run_start, run_stop,
 };
 use crate::docs_cmd::run_docs;
-use crate::extensions::{run_extension_setup, run_extension_start, run_extension_wizard};
+use crate::extensions::{
+    run_extension_setup, run_extension_start, run_extension_wizard, take_extension_start_handoff,
+};
 use crate::i18n_support::i18n;
 use crate::install::{run_install, run_update};
 use crate::process::{passthrough, run_binary_capture, run_doctor};
@@ -101,17 +103,23 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
             }
         },
         Some(("start", sub_matches)) => {
-            if sub_matches
-                .get_one::<String>("extension-start-handoff")
-                .is_some()
-            {
-                let tail = collect_tail(sub_matches);
-                run_extension_start(sub_matches, &tail, debug, &locale)
-            } else {
-                run_start(sub_matches, debug, &locale)
+            // `start` is a pure catch-all at the clap layer — every flag
+            // (including gtc-internal ones) is parsed from the tail by one
+            // parser, so any greentic-start flag works with or without a
+            // bundle ref.
+            let tail = collect_tail(sub_matches);
+            match take_extension_start_handoff(&tail) {
+                Ok(Some((handoff_path, rest))) => {
+                    run_extension_start(&handoff_path, &rest, debug, &locale)
+                }
+                Ok(None) => run_start(&tail, debug, &locale),
+                Err(err) => {
+                    eprintln!("{err}");
+                    2
+                }
             }
         }
-        Some(("stop", sub_matches)) => run_stop(sub_matches, debug, &locale),
+        Some(("stop", sub_matches)) => run_stop(&collect_tail(sub_matches), debug, &locale),
         Some(("deploy", deploy_matches)) => match deploy_matches.subcommand() {
             Some(("refresh-bundle-url", m)) => {
                 let args = RefreshArgs {

--- a/src/bin/gtc/deploy.rs
+++ b/src/bin/gtc/deploy.rs
@@ -70,6 +70,9 @@ impl StartTarget {
 
 #[derive(Debug)]
 pub(super) struct StartCliOptions {
+    /// Positional bundle ref extracted from the tail (the clap layer no
+    /// longer declares it — the tail parser owns the whole start surface).
+    pub(super) bundle_ref: Option<String>,
     pub(super) start_args: Vec<String>,
     pub(super) explicit_target: Option<StartTarget>,
     pub(super) environment: Option<String>,
@@ -82,6 +85,10 @@ pub(super) struct StartCliOptions {
 
 #[derive(Debug)]
 pub(super) struct StopCliOptions {
+    /// Positional bundle ref extracted from the tail; `None` targets the
+    /// bundle-less env runtime (forwarded to greentic-start's new-model
+    /// stop).
+    pub(super) bundle_ref: Option<String>,
     pub(super) stop_args: Vec<String>,
     pub(super) explicit_target: Option<StartTarget>,
     pub(super) environment: Option<String>,

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -562,6 +562,7 @@ mod tests {
 
         let request = StartRequest {
             bundle: Some(bundle_dir.display().to_string()),
+            env: None,
             tenant: Some("demo".to_string()),
             team: Some("ops".to_string()),
             no_nats: false,
@@ -585,6 +586,7 @@ mod tests {
             tunnel_explicit: true,
         };
         let cli_options = StartCliOptions {
+            bundle_ref: None,
             start_args: Vec::new(),
             explicit_target: Some(StartTarget::Gcp),
             environment: Some("prod".to_string()),
@@ -685,11 +687,13 @@ mod tests {
 
         let request = StopRequest {
             bundle: Some(bundle_dir.display().to_string()),
+            env: None,
             state_dir: None,
             tenant: "demo".to_string(),
             team: "ops".to_string(),
         };
         let cli_options = StopCliOptions {
+            bundle_ref: None,
             stop_args: Vec::new(),
             explicit_target: Some(StartTarget::Aws),
             environment: Some("prod".to_string()),

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{
     parse_runtime_config_start_request, parse_runtime_config_stop_request, parse_start_request,
-    parse_stop_request, start_flag_takes_value, stop_flag_takes_value,
+    parse_stop_request, required_value, start_flag_takes_value, stop_flag_takes_value,
 };
 use serde::Deserialize;
 
@@ -496,6 +496,17 @@ pub(crate) fn run_stop(tail: &[String], debug: bool, locale: &str) -> i32 {
     }
 }
 
+fn accept_positional(bundle_ref: &mut Option<String>, arg: &str) -> GtcResult<()> {
+    if let Some(existing) = bundle_ref {
+        return Err(GtcError::message(format!(
+            "unexpected positional argument `{arg}` (bundle ref already \
+             given as `{existing}`)"
+        )));
+    }
+    *bundle_ref = Some(arg.to_string());
+    Ok(())
+}
+
 pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOptions> {
     let mut bundle_ref: Option<String> = None;
     let mut start_args = Vec::new();
@@ -563,13 +574,7 @@ pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOpti
                     // Bare token = the positional bundle ref. Values of
                     // greentic-start flags never land here: the arity
                     // branch below consumes them with their flag.
-                    if let Some(existing) = &bundle_ref {
-                        return Err(GtcError::message(format!(
-                            "unexpected positional argument `{arg}` (bundle ref already \
-                             given as `{existing}`)"
-                        )));
-                    }
-                    bundle_ref = Some(arg.clone());
+                    accept_positional(&mut bundle_ref, arg)?;
                 } else {
                     start_args.push(arg.clone());
                     if start_flag_takes_value(arg.as_str()) {
@@ -640,13 +645,7 @@ pub(crate) fn parse_stop_cli_options(tail: &[String]) -> GtcResult<StopCliOption
                 } else if let Some(value) = arg.strip_prefix("--app-pack=") {
                     app_pack = Some(PathBuf::from(value));
                 } else if !arg.starts_with('-') {
-                    if let Some(existing) = &bundle_ref {
-                        return Err(GtcError::message(format!(
-                            "unexpected positional argument `{arg}` (bundle ref already \
-                             given as `{existing}`)"
-                        )));
-                    }
-                    bundle_ref = Some(arg.clone());
+                    accept_positional(&mut bundle_ref, arg)?;
                 } else {
                     stop_args.push(arg.clone());
                     if stop_flag_takes_value(arg.as_str()) {
@@ -817,13 +816,6 @@ fn prompt_start_target(targets: &[StartTarget], locale: &str) -> GtcResult<Start
         .get(choice.saturating_sub(1))
         .copied()
         .ok_or_else(|| GtcError::message("invalid target selection"))
-}
-
-fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {
-    let flag_name = flag.to_string();
-    args.get(idx)
-        .cloned()
-        .ok_or_else(|| GtcError::message(format!("missing value for {flag_name}")))
 }
 
 #[cfg(test)]
@@ -1194,6 +1186,78 @@ mod tests {
         }
         for flag in ["--env", "--tenant", "--team", "--state-dir", "--bundle"] {
             assert!(stop_flag_takes_value(flag), "{flag} takes a value");
+        }
+    }
+
+    #[test]
+    fn flag_arity_helpers_match_parser_behavior() {
+        // Behavioral probe: for every value-taking flag, passing it as the
+        // final token (no value after) must produce a parser error; for
+        // every boolean flag, the same invocation must NOT fail with the
+        // missing-value error. This closes the chain parser-arms →
+        // arity-helper → hardcoded-list that the lockstep test above pins.
+        let bundle = PathBuf::from("/tmp/probe");
+
+        let start_value_flags: &[&str] = &[
+            "--env",
+            "--tenant",
+            "--team",
+            "--nats",
+            "--nats-url",
+            "--config",
+            "--cloudflared",
+            "--cloudflared-binary",
+            "--ngrok",
+            "--ngrok-binary",
+            "--runner-binary",
+            "--restart",
+            "--log-dir",
+            "--admin-port",
+            "--admin-certs-dir",
+            "--admin-allowed-clients",
+            "--bundle",
+        ];
+        for flag in start_value_flags {
+            let err = parse_start_request(&args(&[flag]), bundle.clone())
+                .expect_err(&format!("bare {flag} should fail"));
+            // --bundle rejects with a different message but is still Err.
+            if *flag != "--bundle" {
+                assert!(
+                    err.contains("missing value for"),
+                    "{flag}: expected missing-value error, got: {err}"
+                );
+            }
+        }
+        let start_bool_flags: &[&str] = &[
+            "--no-nats",
+            "--no-browser",
+            "--verbose",
+            "--quiet",
+            "--admin",
+        ];
+        for flag in start_bool_flags {
+            let result = parse_start_request(&args(&[flag]), bundle.clone());
+            match &result {
+                Ok(_) => {}
+                Err(e) => {
+                    assert!(
+                        !e.contains("missing value for"),
+                        "{flag}: boolean flag produced missing-value error: {e}"
+                    );
+                }
+            }
+        }
+
+        let stop_value_flags: &[&str] = &["--env", "--tenant", "--team", "--state-dir", "--bundle"];
+        for flag in stop_value_flags {
+            let err = parse_stop_request(&args(&[flag]), bundle.clone())
+                .expect_err(&format!("bare {flag} should fail"));
+            if *flag != "--bundle" {
+                assert!(
+                    err.contains("missing value for"),
+                    "{flag}: expected missing-value error, got: {err}"
+                );
+            }
         }
     }
 

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -2,10 +2,10 @@ use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
-use clap::ArgMatches;
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{
-    parse_runtime_config_start_request, parse_start_request, parse_stop_request,
+    parse_runtime_config_start_request, parse_runtime_config_stop_request, parse_start_request,
+    parse_stop_request, start_flag_takes_value, stop_flag_takes_value,
 };
 use serde::Deserialize;
 
@@ -17,16 +17,52 @@ use crate::START_BIN;
 use crate::admin::ensure_admin_certs_ready;
 use crate::i18n_support::t_or;
 use crate::process::{run_binary_checked, run_binary_checked_with_target_and_env};
-use crate::router::collect_tail;
 
-pub(crate) fn run_start(sub_matches: &ArgMatches, debug: bool, locale: &str) -> i32 {
-    let tail = collect_tail(sub_matches);
-    match sub_matches.get_one::<String>("bundle-ref") {
-        Some(bundle_ref) => run_start_with_bundle_ref_and_tail(bundle_ref, &tail, debug, locale),
-        // No bundle ref: boot greentic-start against the operator-materialized
-        // runtime-config for the active env (`GREENTIC_ENV`, default `local`).
-        None => run_start_runtime_config(&tail, debug, locale),
+const START_USAGE: &str = "usage: gtc start [BUNDLE_REF] [start flags...]\n\
+  BUNDLE_REF: local path, file://, oci://, repo://, store:// (omit to serve the active env's deployed revisions)\n\
+  gtc flags:  --target <runtime|aws|gcp|azure> --environment <id> --provider-pack <path> --app-pack <path>\n\
+              --deploy-bundle-source <src> --upload-bundle <url> --upload-bundle-presign-expires <secs>\n\
+              --extension-start-handoff <path>\n\
+  runtime flags are forwarded to greentic-start (e.g. --env, --tenant, --team, --nats, --cloudflared, --ngrok,\n\
+  --admin, --restart, --verbose, --quiet); see `greentic-start start --help` for the full list";
+
+const STOP_USAGE: &str = "usage: gtc stop [BUNDLE_REF] [stop flags...]\n\
+  BUNDLE_REF: bundle to stop (omit to stop the active env's serving runtime)\n\
+  gtc flags:  --target <runtime|aws|gcp|azure> --destroy --environment <id> --provider-pack <path> --app-pack <path>\n\
+  runtime flags are forwarded to greentic-start (--env, --tenant, --team, --state-dir)";
+
+pub(crate) fn run_start(tail: &[String], debug: bool, locale: &str) -> i32 {
+    if wants_help(tail) {
+        println!("{START_USAGE}");
+        return 0;
     }
+    // One tail parser owns the whole surface (the clap layer is a pure
+    // catch-all): the positional bundle ref only routes here — the
+    // downstream functions re-parse the same tail.
+    let bundle_ref = match parse_start_cli_options(tail) {
+        Ok(value) => value.bundle_ref,
+        Err(err) => {
+            eprintln!(
+                "{}: {err}",
+                t_or(
+                    locale,
+                    "gtc.start.err.invalid_args",
+                    "invalid start arguments"
+                )
+            );
+            return 2;
+        }
+    };
+    match bundle_ref {
+        Some(bundle_ref) => run_start_with_bundle_ref_and_tail(&bundle_ref, tail, debug, locale),
+        // No bundle ref: boot greentic-start against the operator-materialized
+        // runtime-config for the active env (`--env` > `GREENTIC_ENV` > `local`).
+        None => run_start_runtime_config(tail, debug, locale),
+    }
+}
+
+fn wants_help(tail: &[String]) -> bool {
+    tail.iter().any(|arg| arg == "--help" || arg == "-h")
 }
 
 /// Start with no bundle ref: hand off to greentic-start with no `--bundle` so it
@@ -282,20 +318,12 @@ fn local_runtime_secret_env(bundle_dir: &Path) -> Option<ChildProcessEnv> {
     Some(env)
 }
 
-pub(crate) fn run_stop(sub_matches: &ArgMatches, debug: bool, locale: &str) -> i32 {
-    let Some(bundle_ref) = sub_matches.get_one::<String>("bundle-ref") else {
-        eprintln!(
-            "{}",
-            t_or(
-                locale,
-                "gtc.stop.err.bundle_required",
-                "bundle ref is required"
-            )
-        );
-        return 2;
-    };
-    let tail = collect_tail(sub_matches);
-    let cli_options = match parse_stop_cli_options(&tail) {
+pub(crate) fn run_stop(tail: &[String], debug: bool, locale: &str) -> i32 {
+    if wants_help(tail) {
+        println!("{STOP_USAGE}");
+        return 0;
+    }
+    let cli_options = match parse_stop_cli_options(tail) {
         Ok(value) => value,
         Err(err) => {
             eprintln!(
@@ -309,6 +337,59 @@ pub(crate) fn run_stop(sub_matches: &ArgMatches, debug: bool, locale: &str) -> i
             return 2;
         }
     };
+    let Some(bundle_ref) = cli_options.bundle_ref.clone() else {
+        // No bundle ref: stop the active env's serving runtime through
+        // greentic-start's bundle-less stop. Deploy-target concerns are
+        // bundle-only.
+        if cli_options.destroy {
+            eprintln!(
+                "{}",
+                t_or(
+                    locale,
+                    "gtc.stop.err.destroy_needs_bundle",
+                    "--destroy requires a bundle ref"
+                )
+            );
+            return 2;
+        }
+        if cli_options.explicit_target.is_some() {
+            eprintln!(
+                "{}",
+                t_or(
+                    locale,
+                    "gtc.stop.err.target_needs_bundle",
+                    "--target requires a bundle ref"
+                )
+            );
+            return 2;
+        }
+        let request = match parse_runtime_config_stop_request(&cli_options.stop_args) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!(
+                    "{}: {err}",
+                    t_or(
+                        locale,
+                        "gtc.stop.err.invalid_args",
+                        "invalid stop arguments"
+                    )
+                );
+                return 2;
+            }
+        };
+        let args = request.to_runtime_stop_args(locale);
+        return match run_binary_checked(START_BIN, &args, debug, locale, "stop runtime") {
+            Ok(()) => 0,
+            Err(err) => {
+                eprintln!(
+                    "{}: {err}",
+                    t_or(locale, "gtc.stop.err.run_failed", "failed to stop bundle")
+                );
+                1
+            }
+        };
+    };
+    let bundle_ref = bundle_ref.as_str();
     let resolved = match resolve_bundle_reference(bundle_ref, locale) {
         Ok(value) => value,
         Err(err) => {
@@ -416,6 +497,7 @@ pub(crate) fn run_stop(sub_matches: &ArgMatches, debug: bool, locale: &str) -> i
 }
 
 pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOptions> {
+    let mut bundle_ref: Option<String> = None;
     let mut start_args = Vec::new();
     let mut explicit_target = None;
     let mut environment = None;
@@ -477,8 +559,23 @@ pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOpti
                     upload_bundle_presign_expires = Some(value.parse::<u64>().map_err(|e| {
                         GtcError::message(format!("invalid --upload-bundle-presign-expires: {e}"))
                     })?);
+                } else if !arg.starts_with('-') {
+                    // Bare token = the positional bundle ref. Values of
+                    // greentic-start flags never land here: the arity
+                    // branch below consumes them with their flag.
+                    if let Some(existing) = &bundle_ref {
+                        return Err(GtcError::message(format!(
+                            "unexpected positional argument `{arg}` (bundle ref already \
+                             given as `{existing}`)"
+                        )));
+                    }
+                    bundle_ref = Some(arg.clone());
                 } else {
                     start_args.push(arg.clone());
+                    if start_flag_takes_value(arg.as_str()) {
+                        idx += 1;
+                        start_args.push(required_value(tail, idx, arg)?);
+                    }
                 }
             }
         }
@@ -491,6 +588,7 @@ pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOpti
         ));
     }
     Ok(StartCliOptions {
+        bundle_ref,
         start_args,
         explicit_target,
         environment,
@@ -503,6 +601,7 @@ pub(crate) fn parse_start_cli_options(tail: &[String]) -> GtcResult<StartCliOpti
 }
 
 pub(crate) fn parse_stop_cli_options(tail: &[String]) -> GtcResult<StopCliOptions> {
+    let mut bundle_ref: Option<String> = None;
     let mut stop_args = Vec::new();
     let mut explicit_target = None;
     let mut environment = None;
@@ -540,14 +639,27 @@ pub(crate) fn parse_stop_cli_options(tail: &[String]) -> GtcResult<StopCliOption
                     provider_pack = Some(PathBuf::from(value));
                 } else if let Some(value) = arg.strip_prefix("--app-pack=") {
                     app_pack = Some(PathBuf::from(value));
+                } else if !arg.starts_with('-') {
+                    if let Some(existing) = &bundle_ref {
+                        return Err(GtcError::message(format!(
+                            "unexpected positional argument `{arg}` (bundle ref already \
+                             given as `{existing}`)"
+                        )));
+                    }
+                    bundle_ref = Some(arg.clone());
                 } else {
                     stop_args.push(arg.clone());
+                    if stop_flag_takes_value(arg.as_str()) {
+                        idx += 1;
+                        stop_args.push(required_value(tail, idx, arg)?);
+                    }
                 }
             }
         }
         idx += 1;
     }
     Ok(StopCliOptions {
+        bundle_ref,
         stop_args,
         explicit_target,
         environment,
@@ -724,9 +836,14 @@ mod tests {
     use crate::deploy::StartTarget;
     use gtc::start_stop_parsing::{
         CloudflaredModeArg, NatsModeArg, NgrokModeArg, RestartTarget, StartRequest, StopRequest,
+        parse_runtime_config_stop_request, start_flag_takes_value, stop_flag_takes_value,
     };
     use std::fs;
     use std::path::PathBuf;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
 
     #[test]
     fn parse_start_cli_options_extracts_deploy_specific_flags() {
@@ -837,6 +954,7 @@ mod tests {
     fn build_runtime_start_args_serializes_request() {
         let request = StartRequest {
             bundle: Some("/tmp/bundle".to_string()),
+            env: Some("staging".to_string()),
             tenant: Some("demo".to_string()),
             team: Some("ops".to_string()),
             no_nats: false,
@@ -866,6 +984,8 @@ mod tests {
         assert_eq!(args[2], "start");
         assert!(args.contains(&"--bundle".to_string()));
         assert!(args.contains(&"/tmp/bundle".to_string()));
+        assert!(args.contains(&"--env".to_string()));
+        assert!(args.contains(&"staging".to_string()));
         assert!(args.contains(&"--nats".to_string()));
         assert!(args.contains(&"external".to_string()));
         assert!(args.contains(&"--cloudflared".to_string()));
@@ -883,6 +1003,7 @@ mod tests {
     fn build_runtime_stop_args_serializes_request() {
         let request = StopRequest {
             bundle: Some("/tmp/bundle".to_string()),
+            env: Some("staging".to_string()),
             state_dir: Some(PathBuf::from("/tmp/state")),
             tenant: "demo".to_string(),
             team: "ops".to_string(),
@@ -897,6 +1018,8 @@ mod tests {
                 "stop".to_string(),
                 "--bundle".to_string(),
                 "/tmp/bundle".to_string(),
+                "--env".to_string(),
+                "staging".to_string(),
                 "--state-dir".to_string(),
                 "/tmp/state".to_string(),
                 "--tenant".to_string(),
@@ -935,6 +1058,143 @@ mod tests {
 
         let target = select_start_target(dir.path(), Some(StartTarget::Aws), "en").expect("target");
         assert_eq!(target, StartTarget::Aws);
+    }
+
+    // --- operator-surface PR-3: one tail parser owns the start/stop surface ---
+
+    #[test]
+    fn parse_start_cli_options_extracts_positional_in_any_position() {
+        // Positional first (the historical clap shape)…
+        let opts =
+            parse_start_cli_options(&args(&["bundle.gtbundle", "--tenant", "demo"])).expect("opts");
+        assert_eq!(opts.bundle_ref.as_deref(), Some("bundle.gtbundle"));
+        assert_eq!(opts.start_args, args(&["--tenant", "demo"]));
+
+        // …and positional after flags: `demo` is `--tenant`'s VALUE, never
+        // the bundle ref.
+        let opts =
+            parse_start_cli_options(&args(&["--tenant", "demo", "bundle.gtbundle"])).expect("opts");
+        assert_eq!(opts.bundle_ref.as_deref(), Some("bundle.gtbundle"));
+        assert_eq!(opts.start_args, args(&["--tenant", "demo"]));
+    }
+
+    #[test]
+    fn parse_start_cli_options_rejects_second_positional() {
+        let err = parse_start_cli_options(&args(&["a.gtbundle", "b.gtbundle"])).unwrap_err();
+        assert!(err.contains("unexpected positional"), "{err}");
+    }
+
+    #[test]
+    fn leading_flag_without_bundle_ref_parses_runtime_config_request() {
+        // The 2026-06-10 repro: `gtc start --cloudflared on` used to die at
+        // the clap layer (trailing_var_arg only activates after the
+        // positional). One tail parser owns the surface now.
+        let opts = parse_start_cli_options(&args(&["--cloudflared", "on"])).expect("opts");
+        assert_eq!(opts.bundle_ref, None);
+        let request = parse_runtime_config_start_request(&opts.start_args).expect("request");
+        assert_eq!(request.cloudflared, CloudflaredModeArg::On);
+        assert!(request.tunnel_explicit);
+        assert_eq!(request.bundle, None);
+    }
+
+    #[test]
+    fn parse_start_cli_options_extracts_gtc_flags_after_positional() {
+        // Pre-collapse these only worked in this position because the tail
+        // parser duplicated the clap layer; pin the single-parser behavior.
+        let opts = parse_start_cli_options(&args(&[
+            "bundle.gtbundle",
+            "--deploy-bundle-source",
+            "https://example.com/b.gtbundle",
+            "--target=aws",
+        ]))
+        .expect("opts");
+        assert_eq!(opts.bundle_ref.as_deref(), Some("bundle.gtbundle"));
+        assert_eq!(
+            opts.deploy_bundle_source.as_deref(),
+            Some("https://example.com/b.gtbundle")
+        );
+        assert_eq!(opts.explicit_target, Some(StartTarget::Aws));
+        assert!(opts.start_args.is_empty());
+    }
+
+    #[test]
+    fn parse_start_request_maps_env_flag() {
+        let request =
+            parse_start_request(&args(&["--env", "staging"]), PathBuf::from("/tmp/bundle"))
+                .expect("request");
+        assert_eq!(request.env.as_deref(), Some("staging"));
+
+        let request = parse_start_request(&args(&["--env=demo2"]), PathBuf::from("/tmp/bundle"))
+            .expect("request");
+        assert_eq!(request.env.as_deref(), Some("demo2"));
+    }
+
+    #[test]
+    fn stop_without_bundle_ref_builds_runtime_stop_request() {
+        let opts = parse_stop_cli_options(&args(&["--env", "demo2"])).expect("opts");
+        assert_eq!(opts.bundle_ref, None);
+        assert!(!opts.destroy);
+        let request = parse_runtime_config_stop_request(&opts.stop_args).expect("request");
+        assert_eq!(request.bundle, None);
+        assert_eq!(request.env.as_deref(), Some("demo2"));
+
+        let stop_args = request.to_runtime_stop_args("en");
+        assert!(
+            !stop_args.contains(&"--bundle".to_string()),
+            "{stop_args:?}"
+        );
+        assert!(stop_args.contains(&"--env".to_string()), "{stop_args:?}");
+        assert!(stop_args.contains(&"demo2".to_string()), "{stop_args:?}");
+    }
+
+    #[test]
+    fn parse_stop_cli_options_extracts_positional_after_value_flag() {
+        let opts =
+            parse_stop_cli_options(&args(&["--tenant", "demo", "bundle.gtbundle"])).expect("opts");
+        assert_eq!(opts.bundle_ref.as_deref(), Some("bundle.gtbundle"));
+        assert_eq!(opts.stop_args, args(&["--tenant", "demo"]));
+    }
+
+    #[test]
+    fn flag_arity_helpers_stay_in_lockstep_with_the_allowlists() {
+        // Every spaced-form flag the start parser accepts with a value must
+        // be classified as value-taking — otherwise the cli-options walker
+        // mistakes the value for the positional bundle ref. Boolean flags
+        // must NOT consume a value. Update BOTH the parser allowlist and
+        // `start_flag_takes_value` when adding a flag.
+        for flag in [
+            "--env",
+            "--tenant",
+            "--team",
+            "--nats",
+            "--nats-url",
+            "--config",
+            "--cloudflared",
+            "--cloudflared-binary",
+            "--ngrok",
+            "--ngrok-binary",
+            "--runner-binary",
+            "--restart",
+            "--log-dir",
+            "--admin-port",
+            "--admin-certs-dir",
+            "--admin-allowed-clients",
+            "--bundle",
+        ] {
+            assert!(start_flag_takes_value(flag), "{flag} takes a value");
+        }
+        for flag in [
+            "--no-nats",
+            "--no-browser",
+            "--verbose",
+            "--quiet",
+            "--admin",
+        ] {
+            assert!(!start_flag_takes_value(flag), "{flag} is boolean");
+        }
+        for flag in ["--env", "--tenant", "--team", "--state-dir", "--bundle"] {
+            assert!(stop_flag_takes_value(flag), "{flag} takes a value");
+        }
     }
 
     #[test]

--- a/src/bin/gtc/extensions.rs
+++ b/src/bin/gtc/extensions.rs
@@ -214,16 +214,12 @@ pub(super) fn run_extension_setup(
 }
 
 pub(super) fn run_extension_start(
-    sub_matches: &ArgMatches,
+    handoff_path: &str,
     tail: &[String],
     debug: bool,
     locale: &str,
 ) -> i32 {
-    let Some(path) = sub_matches.get_one::<String>("extension-start-handoff") else {
-        eprintln!("missing --extension-start-handoff");
-        return 2;
-    };
-    let handoff = match load_extension_start_handoff(Path::new(path)) {
+    let handoff = match load_extension_start_handoff(Path::new(handoff_path)) {
         Ok(value) => value,
         Err(err) => {
             eprintln!("{err}");
@@ -232,6 +228,34 @@ pub(super) fn run_extension_start(
     };
     let merged_tail = build_start_tail_from_handoff(&handoff, tail);
     run_start_with_bundle_ref_and_tail(&handoff.bundle_ref, &merged_tail, debug, locale)
+}
+
+/// Pull `--extension-start-handoff <path>` (or `=path`) out of a raw start
+/// tail. Returns the path plus the tail with the flag removed, so the
+/// downstream start parsing never sees a gtc-internal flag. The clap layer
+/// no longer declares it — `start` is a pure catch-all.
+pub(super) fn take_extension_start_handoff(
+    tail: &[String],
+) -> Result<Option<(String, Vec<String>)>, String> {
+    let mut path = None;
+    let mut rest = Vec::with_capacity(tail.len());
+    let mut idx = 0usize;
+    while idx < tail.len() {
+        let arg = &tail[idx];
+        if arg == "--extension-start-handoff" {
+            idx += 1;
+            let value = tail
+                .get(idx)
+                .ok_or_else(|| "missing value for --extension-start-handoff".to_string())?;
+            path = Some(value.clone());
+        } else if let Some(value) = arg.strip_prefix("--extension-start-handoff=") {
+            path = Some(value.to_string());
+        } else {
+            rest.push(arg.clone());
+        }
+        idx += 1;
+    }
+    Ok(path.map(|path| (path, rest)))
 }
 
 fn collect_extension_ids(sub_matches: &ArgMatches) -> Vec<String> {
@@ -543,7 +567,8 @@ mod tests {
         collect_extension_ids, has_extension_flags, load_descriptor, load_extension_setup_handoff,
         load_extension_start_handoff, load_registry, resolve_descriptor_path,
         resolve_descriptor_working_directory, resolve_handoff_output_path, resolve_registry_path,
-        run_extension_setup, run_extension_start, run_extension_wizard, write_launcher_handoff,
+        run_extension_setup, run_extension_start, run_extension_wizard,
+        take_extension_start_handoff, write_launcher_handoff,
     };
     use crate::tests::env_test_lock;
     use clap::{Arg, ArgAction, Command};
@@ -1043,33 +1068,42 @@ mod tests {
     }
 
     #[test]
-    fn run_extension_start_errors_when_handoff_flag_missing() {
-        let matches = Command::new("extension-start")
-            .arg(
-                Arg::new("extension-start-handoff")
-                    .long("extension-start-handoff")
-                    .num_args(1),
-            )
-            .try_get_matches_from(["extension-start"])
-            .expect("matches");
-        assert_eq!(run_extension_start(&matches, &[], false, "en"), 2);
+    fn take_extension_start_handoff_extracts_both_forms_and_strips_flag() {
+        let tail = vec![
+            "bundle.gtbundle".to_string(),
+            "--extension-start-handoff".to_string(),
+            "/tmp/handoff.json".to_string(),
+            "--tenant".to_string(),
+            "demo".to_string(),
+        ];
+        let (path, rest) = take_extension_start_handoff(&tail)
+            .expect("extraction succeeds")
+            .expect("flag present");
+        assert_eq!(path, "/tmp/handoff.json");
+        assert_eq!(rest, vec!["bundle.gtbundle", "--tenant", "demo"]);
+
+        let tail = vec!["--extension-start-handoff=/tmp/h.json".to_string()];
+        let (path, rest) = take_extension_start_handoff(&tail)
+            .expect("extraction succeeds")
+            .expect("flag present");
+        assert_eq!(path, "/tmp/h.json");
+        assert!(rest.is_empty());
+
+        assert!(
+            take_extension_start_handoff(&["--tenant".to_string(), "demo".to_string()])
+                .expect("extraction succeeds")
+                .is_none()
+        );
+        take_extension_start_handoff(&["--extension-start-handoff".to_string()])
+            .expect_err("missing value must error");
     }
 
     #[test]
     fn run_extension_start_errors_when_handoff_path_invalid() {
-        let matches = Command::new("extension-start")
-            .arg(
-                Arg::new("extension-start-handoff")
-                    .long("extension-start-handoff")
-                    .num_args(1),
-            )
-            .try_get_matches_from([
-                "extension-start",
-                "--extension-start-handoff",
-                "/definitely/missing/start.json",
-            ])
-            .expect("matches");
-        assert_eq!(run_extension_start(&matches, &[], false, "en"), 1);
+        assert_eq!(
+            run_extension_start("/definitely/missing/start.json", &[], false, "en"),
+            1
+        );
     }
 
     #[test]

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -35,6 +35,9 @@ pub enum RestartTarget {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StartRequest {
     pub bundle: Option<String>,
+    /// Environment id forwarded to greentic-start's bundle-less boot
+    /// (flag > `$GREENTIC_ENV` > `local` — precedence lives there).
+    pub env: Option<String>,
     pub tenant: Option<String>,
     pub team: Option<String>,
     pub no_nats: bool,
@@ -62,6 +65,8 @@ pub struct StartRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StopRequest {
     pub bundle: Option<String>,
+    /// Environment id forwarded to greentic-start's bundle-less stop.
+    pub env: Option<String>,
     pub state_dir: Option<PathBuf>,
     pub tenant: String,
     pub team: String,
@@ -77,6 +82,10 @@ impl StartRequest {
         if let Some(bundle) = self.bundle.as_deref() {
             args.push("--bundle".to_string());
             args.push(bundle.to_string());
+        }
+        if let Some(env) = self.env.as_deref() {
+            args.push("--env".to_string());
+            args.push(env.to_string());
         }
         if let Some(tenant) = self.tenant.as_deref() {
             args.push("--tenant".to_string());
@@ -170,6 +179,10 @@ impl StopRequest {
             args.push("--bundle".to_string());
             args.push(bundle.to_string());
         }
+        if let Some(env) = self.env.as_deref() {
+            args.push("--env".to_string());
+            args.push(env.to_string());
+        }
         if let Some(state_dir) = self.state_dir.as_deref() {
             args.push("--state-dir".to_string());
             args.push(state_dir.display().to_string());
@@ -195,6 +208,7 @@ pub fn parse_runtime_config_start_request(tail: &[String]) -> GtcResult<StartReq
 pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<StartRequest> {
     let mut request = StartRequest {
         bundle: Some(bundle_dir.display().to_string()),
+        env: None,
         tenant: None,
         team: None,
         no_nats: false,
@@ -222,6 +236,10 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
     while idx < tail.len() {
         let arg = &tail[idx];
         match arg.as_str() {
+            "--env" => {
+                idx += 1;
+                request.env = Some(required_value(tail, idx, "--env")?);
+            }
             "--tenant" => {
                 idx += 1;
                 request.tenant = Some(required_value(tail, idx, "--tenant")?);
@@ -317,7 +335,9 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
                 ));
             }
             other => {
-                if let Some(value) = other.strip_prefix("--tenant=") {
+                if let Some(value) = other.strip_prefix("--env=") {
+                    request.env = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--tenant=") {
                     request.tenant = Some(value.to_string());
                 } else if let Some(value) = other.strip_prefix("--team=") {
                     request.team = Some(value.to_string());
@@ -379,9 +399,20 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
     Ok(request)
 }
 
+/// Build a [`StopRequest`] for the no-bundle runtime-config model: identical
+/// flag parsing to [`parse_stop_request`], but with `bundle: None` so
+/// greentic-start stops the active env's serving runtime instead of a
+/// bundle-rooted one.
+pub fn parse_runtime_config_stop_request(tail: &[String]) -> GtcResult<StopRequest> {
+    let mut request = parse_stop_request(tail, PathBuf::new())?;
+    request.bundle = None;
+    Ok(request)
+}
+
 pub fn parse_stop_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<StopRequest> {
     let mut request = StopRequest {
         bundle: Some(bundle_dir.display().to_string()),
+        env: None,
         state_dir: None,
         tenant: "demo".to_string(),
         team: "default".to_string(),
@@ -391,6 +422,10 @@ pub fn parse_stop_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<Sto
     while idx < tail.len() {
         let arg = &tail[idx];
         match arg.as_str() {
+            "--env" => {
+                idx += 1;
+                request.env = Some(required_value(tail, idx, "--env")?);
+            }
             "--tenant" => {
                 idx += 1;
                 request.tenant = required_value(tail, idx, "--tenant")?;
@@ -409,7 +444,9 @@ pub fn parse_stop_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<Sto
                 ));
             }
             other => {
-                if let Some(value) = other.strip_prefix("--tenant=") {
+                if let Some(value) = other.strip_prefix("--env=") {
+                    request.env = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--tenant=") {
                     request.tenant = value.to_string();
                 } else if let Some(value) = other.strip_prefix("--team=") {
                     request.team = value.to_string();
@@ -430,6 +467,43 @@ pub fn parse_stop_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<Sto
     }
 
     Ok(request)
+}
+
+/// Does this spaced-form `start`/`restart` flag consume the next token as
+/// its value? The single source of arity truth for hand parsers that walk
+/// a raw tail (gtc's `parse_start_cli_options` uses it to tell a flag
+/// value apart from the positional bundle ref). Must stay in lockstep with
+/// [`parse_start_request`]'s allowlist — pinned by a test.
+pub fn start_flag_takes_value(flag: &str) -> bool {
+    matches!(
+        flag,
+        "--env"
+            | "--tenant"
+            | "--team"
+            | "--nats"
+            | "--nats-url"
+            | "--config"
+            | "--cloudflared"
+            | "--cloudflared-binary"
+            | "--ngrok"
+            | "--ngrok-binary"
+            | "--runner-binary"
+            | "--restart"
+            | "--log-dir"
+            | "--admin-port"
+            | "--admin-certs-dir"
+            | "--admin-allowed-clients"
+            | "--bundle"
+    )
+}
+
+/// [`start_flag_takes_value`] for the `stop` allowlist
+/// ([`parse_stop_request`]).
+pub fn stop_flag_takes_value(flag: &str) -> bool {
+    matches!(
+        flag,
+        "--env" | "--tenant" | "--team" | "--state-dir" | "--bundle"
+    )
 }
 
 fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -506,7 +506,8 @@ pub fn stop_flag_takes_value(flag: &str) -> bool {
     )
 }
 
-fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {
+/// Return `args[idx]` or a "missing value for {flag}" error.
+pub fn required_value(args: &[String], idx: usize, flag: &str) -> GtcResult<String> {
     let flag_name = flag.to_string();
     args.get(idx)
         .cloned()


### PR DESCRIPTION
Operator-surface PR-3 of `plans/operator-surface-unification.md` (§5) — collapse the gtc `start`/`stop` clap subcommands to the pure catch-all shape `op` uses, so **one parser** (the tail allowlist) owns the whole surface. Depends on greenticai/greentic-start#250 landing first (gtc now forwards `--env`; an old greentic-start would reject it).

## What

- **cli.rs:** `start`/`stop` keep only the trailing catch-all. This is the root-cause fix for the 2026-06-10 repro — `gtc start --cloudflared on` (bundle-less) died at the clap layer because `trailing_var_arg` only activates after the positional, so a leading flag never reached the tail parser. Any greentic-start flag (current or future) now works with or without a bundle ref. `gtc stop` no longer requires a bundle ref.
- **Positional extraction:** `parse_start_cli_options`/`parse_stop_cli_options` pull the bundle ref out of the tail. Flag values are never mistaken for it: new `start_flag_takes_value`/`stop_flag_takes_value` arity helpers in `start_stop_parsing.rs` are the single source of arity truth, lockstep-pinned to the parser allowlists by a test. A second positional is a clear error.
- **gtc-specific flags** moved fully into the tail parsers: `--extension-start-handoff` (new `take_extension_start_handoff`, stripped before dispatch), `--deploy-bundle-source`/`--upload-bundle*` (already tail-parsed — they now work in any position, where before they only worked in clap position *or* after the positional, two drifting implementations).
- **`--env` forwarding:** `StartRequest`/`StopRequest` gain `env`; `--env` joins both allowlists and `to_runtime_*_args` emission. `gtc stop` (no bundle ref) forwards to greentic-start's bundle-less env stop (#249 mechanics); `--destroy`/`--target` without a bundle ref are clear errors.
- **Help:** `--help`/`-h` inside the tail prints a usage block listing gtc flags + forwarded runtime flags; a leading `--help` still renders clap's subcommand help.
- **Scope guard (per the design's risk note):** only *parsing* moved — `run_start`'s post-parse orchestration (admin certs, target selection, bundle prep, deploy) is untouched; `run_start`/`run_stop`/`run_extension_start` just take the tail instead of `ArgMatches`.

## Verification

- `cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` + `cargo test --all-features --lib --bins --tests` all green (449 tests).
- New tests: positional in any position; second-positional rejection; the bundle-less `--cloudflared` repro parses into a runtime-config request; gtc-flag extraction after the positional; `--env` parse + emission on both verbs; bundle-less stop request shape (no `--bundle`, `--env` forwarded); arity-lockstep pin; handoff extraction (spaced + `=` forms, missing-value error).
- Smoked with `GREENTIC_START_BIN=/bin/echo`: `gtc start --cloudflared on` → `--locale en start --nats off --cloudflared on …` (the repro, fixed); `gtc start --env demo2 --cloudflared on` and `gtc stop --env demo2` forward correctly; `gtc stop --destroy` (no bundle) → clear error, exit 2; both help paths render.

## Note on the perf bench

`cargo build --bench perf` fails to **link** in this checkout (`mold: undefined symbol: c_with_alloca`) — pre-existing/environmental: reproduced identically on a clean `develop` worktree sharing the same target dir; type-checking (clippy `--all-targets`) is green. CI links from scratch.
