### PR TITLE
Pass uploaded AWS bundle object metadata to deployer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtc"
-version = "1.0.31"
+version = "1.0.32"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/deploy/cloud_deploy.rs
+++ b/src/bin/gtc/deploy/cloud_deploy.rs
@@ -554,13 +554,12 @@ fn binary_in_path(binary: &str) -> bool {
 }
 
 /// If `--upload-bundle` is set, upload the already prepared bundle artifact and
-/// return the URL + digest to be injected into the standard deploy flow.
-/// Returns `(remote_url, digest)`.
+/// return the uploaded object metadata to be injected into the standard deploy flow.
 pub(crate) fn resolve_upload_bundle(
     prepared_artifact: &Path,
     upload_bundle: &str,
     presign_expires: u64,
-) -> GtcResult<(String, String)> {
+) -> GtcResult<super::bundle_upload_orchestrator::UploadedBundle> {
     use super::bundle_upload_orchestrator;
 
     let result = bundle_upload_orchestrator::upload_bundle(
@@ -578,7 +577,7 @@ pub(crate) fn resolve_upload_bundle(
     eprintln!("  object ref:  {}", result.object_ref);
     eprintln!("To refresh URL without re-uploading: gtc deploy refresh-bundle-url <BUNDLE_REF>");
 
-    Ok((result.url, result.digest))
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -196,6 +196,7 @@ struct UploadedBundleSource {
     object_ref: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_multi_target_deployer_apply(
     _bundle_ref: &str,
     resolved: &StartBundleResolution,

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -190,6 +190,12 @@ fn save_deployment_state(path: &Path, state: &StartDeploymentState) -> GtcResult
 }
 
 #[allow(clippy::too_many_arguments)]
+struct UploadedBundleSource {
+    url: String,
+    digest: String,
+    object_ref: String,
+}
+
 fn run_multi_target_deployer_apply(
     _bundle_ref: &str,
     resolved: &StartBundleResolution,
@@ -200,12 +206,16 @@ fn run_multi_target_deployer_apply(
     debug: bool,
     locale: &str,
 ) -> GtcResult<()> {
-    let synthesized_source: Option<(String, String, String)> =
+    let synthesized_source: Option<UploadedBundleSource> =
         if let Some(upload_target) = cli_options.upload_bundle.as_deref() {
             let presign = cli_options.upload_bundle_presign_expires.unwrap_or(604800);
             let uploaded =
                 super::resolve_upload_bundle(&prepared.artifact_path, upload_target, presign)?;
-            Some((uploaded.url, uploaded.digest, uploaded.object_ref))
+            Some(UploadedBundleSource {
+                url: uploaded.url,
+                digest: uploaded.digest,
+                object_ref: uploaded.object_ref,
+            })
         } else {
             None
         };
@@ -214,7 +224,7 @@ fn run_multi_target_deployer_apply(
 
     let remote_override = synthesized_source
         .as_ref()
-        .map(|(url, _, _)| url.clone())
+        .map(|uploaded| uploaded.url.clone())
         .or_else(|| cli_options.deploy_bundle_source.clone())
         .or_else(resolve_remote_deploy_bundle_source_override);
 
@@ -228,14 +238,14 @@ fn run_multi_target_deployer_apply(
         child_env.extend(secret_env);
     }
     if target == StartTarget::Aws
-        && let Some((_, _, object_ref)) = synthesized_source.as_ref()
-        && object_ref.starts_with("s3://")
+        && let Some(uploaded) = synthesized_source.as_ref()
+        && uploaded.object_ref.starts_with("s3://")
     {
         child_env.set(
             "GREENTIC_DEPLOY_TERRAFORM_VAR_BUNDLE_S3_OBJECT_REF",
-            object_ref.clone(),
+            uploaded.object_ref.clone(),
         );
-        if let Some(arn) = s3_object_arn(object_ref) {
+        if let Some(arn) = s3_object_arn(&uploaded.object_ref) {
             child_env.set("GREENTIC_DEPLOY_TERRAFORM_VAR_BUNDLE_S3_OBJECT_ARN", arn);
         }
     }
@@ -244,12 +254,12 @@ fn run_multi_target_deployer_apply(
         .clone()
         .unwrap_or_else(|| bundle_artifact.display().to_string());
 
-    if let Some((_, _, uploaded_digest)) = synthesized_source.as_ref()
-        && uploaded_digest != &prepared.digest
+    if let Some(uploaded) = synthesized_source.as_ref()
+        && uploaded.digest != prepared.digest
     {
         eprintln!(
-            "warning: uploaded bundle digest {uploaded_digest} differs from prepared digest {}",
-            prepared.digest
+            "warning: uploaded bundle digest {} differs from prepared digest {}",
+            uploaded.digest, prepared.digest
         );
     }
     let bundle_digest = prepared.digest.clone();

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -200,12 +200,12 @@ fn run_multi_target_deployer_apply(
     debug: bool,
     locale: &str,
 ) -> GtcResult<()> {
-    let synthesized_source: Option<(String, String)> =
+    let synthesized_source: Option<(String, String, String)> =
         if let Some(upload_target) = cli_options.upload_bundle.as_deref() {
             let presign = cli_options.upload_bundle_presign_expires.unwrap_or(604800);
-            let (url, digest) =
+            let uploaded =
                 super::resolve_upload_bundle(&prepared.artifact_path, upload_target, presign)?;
-            Some((url, digest))
+            Some((uploaded.url, uploaded.digest, uploaded.object_ref))
         } else {
             None
         };
@@ -214,7 +214,7 @@ fn run_multi_target_deployer_apply(
 
     let remote_override = synthesized_source
         .as_ref()
-        .map(|(url, _)| url.clone())
+        .map(|(url, _, _)| url.clone())
         .or_else(|| cli_options.deploy_bundle_source.clone())
         .or_else(resolve_remote_deploy_bundle_source_override);
 
@@ -227,12 +227,24 @@ fn run_multi_target_deployer_apply(
     if let Some(secret_env) = local_deployer_secret_env(&resolved.bundle_dir) {
         child_env.extend(secret_env);
     }
+    if target == StartTarget::Aws
+        && let Some((_, _, object_ref)) = synthesized_source.as_ref()
+        && object_ref.starts_with("s3://")
+    {
+        child_env.set(
+            "GREENTIC_DEPLOY_TERRAFORM_VAR_BUNDLE_S3_OBJECT_REF",
+            object_ref.clone(),
+        );
+        if let Some(arn) = s3_object_arn(object_ref) {
+            child_env.set("GREENTIC_DEPLOY_TERRAFORM_VAR_BUNDLE_S3_OBJECT_ARN", arn);
+        }
+    }
 
     let deploy_bundle_source = remote_override
         .clone()
         .unwrap_or_else(|| bundle_artifact.display().to_string());
 
-    if let Some((_, uploaded_digest)) = synthesized_source.as_ref()
+    if let Some((_, _, uploaded_digest)) = synthesized_source.as_ref()
         && uploaded_digest != &prepared.digest
     {
         eprintln!(
@@ -294,6 +306,16 @@ fn run_multi_target_deployer_apply(
         Some(&child_env),
     )
     .map_err(|e| GtcError::message(e.to_string()))
+}
+
+fn s3_object_arn(object_ref: &str) -> Option<String> {
+    let rest = object_ref.trim().strip_prefix("s3://")?;
+    let (bucket, key) = rest.split_once('/')?;
+    let key = key.trim_start_matches('/');
+    if bucket.is_empty() || key.is_empty() {
+        return None;
+    }
+    Some(format!("arn:aws:s3:::{bucket}/{key}"))
 }
 
 fn local_deployer_secret_env(bundle_dir: &Path) -> Option<ChildProcessEnv> {

--- a/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
@@ -314,19 +314,19 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_provider_pack_from_metadata_errors_on_unknown_target() {
+    fn resolve_target_provider_pack_from_metadata_skips_unknown_target() {
         let dir = tempfile::tempdir().expect("tempdir");
         let greentic = dir.path().join(".greentic");
         fs::create_dir_all(&greentic).expect("mkdir");
         fs::write(
             greentic.join("deployment-targets.json"),
-            r#"{"targets":[{"target":"weird","provider_pack":"packs/demo.gtpack"}]}"#,
+            r#"{"targets":[{"target":"single-vm","provider_pack":"packs/demo.gtpack"}]}"#,
         )
         .expect("write");
 
-        let err =
-            resolve_target_provider_pack_from_metadata(dir.path(), StartTarget::Aws).unwrap_err();
-        assert!(err.contains("unsupported --target value"));
+        let resolved =
+            resolve_target_provider_pack_from_metadata(dir.path(), StartTarget::Aws).unwrap();
+        assert!(resolved.is_none());
     }
 
     #[test]

--- a/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/provider_packs.rs
@@ -128,11 +128,7 @@ fn resolve_target_provider_pack_from_metadata(
             "aws" => StartTarget::Aws,
             "gcp" => StartTarget::Gcp,
             "azure" => StartTarget::Azure,
-            other => {
-                return Err(GtcError::message(format!(
-                    "unsupported --target value {other}; expected runtime, aws, gcp, or azure"
-                )));
-            }
+            _ => continue,
         };
         if parsed_target != target {
             continue;


### PR DESCRIPTION
## Summary
- bump gtc to 1.0.32
- keep runtime bundle_source as the uploaded HTTPS URL
- pass uploaded S3 object ref/ARN to AWS deployer via Terraform env vars

## Verification
- cargo check