### PR TITLE
chore: re-arm develop to 1.1.1-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.0-dev.0"
+version = "1.1.1-dev.0"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.0-dev.0"
+version = "1.1.1-dev.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
Post-stable-cut develop hygiene: bump package versions to the next patch dev lane (1.1.1-dev.0) so the next stable cut does not collide with the existing tag. Internal crate ranges go patch-precise; external greentic deps stay minor-keyed. Lock synced (workspace members only).

https://claude.ai/code/session_0138agQukuvEkhBo7giUgGby