### PR TITLE
feat(gtc): gtc worker — author agentic workers from the CLI (1.1.2)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-cli-agent-types-slice1-authoring.md
+++ b/docs/superpowers/plans/2026-07-06-cli-agent-types-slice1-authoring.md
@@ -1,0 +1,655 @@
+# CLI Agent Types — Slice 1 (Authoring) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user author all three agentic-worker types (`single_turn`, `agent_graph`, `deep_worker`) — including memory and knowledge — entirely from the CLI (`gtc worker`), producing a runner-loadable `.gtpack` identical to the Designer's.
+
+**Architecture:** Extract the Designer's pure pack-assembly logic into a new standalone crate `greentic-dw-authoring` whose assembly is **DB-free** (knowledge text supplied by the caller, not read from sqlite). A canonical `WorkerSpec` (YAML/JSON) is the single authoring format; the Designer and the CLI both project their state into it. `greentic-dw` gains a `worker` subcommand built on the crate; `gtc worker` passes through to `greentic-dw`. The Designer is refactored onto the crate with a parity test guaranteeing it emits the same pack as before.
+
+**Tech Stack:** Rust (edition 2021, rustc 1.95.0), `serde`/`serde_json`/`serde_yaml_bw`, `greentic-pack-lib` (imported as `greentic_pack`), `greentic-types`, `greentic-aw-runtime` (`AgentConfig`), `clap`, `schemars` (schema), `anyhow`/`thiserror`.
+
+## Global Constraints
+
+- Rust toolchain **1.95.0** pinned via `rust-toolchain.toml` (do not edit).
+- `#![forbid(unsafe_code)]` at the new crate root.
+- **No `unwrap()` / `panic!()` / `expect()` in non-test code** — use `anyhow`/`thiserror`.
+- Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`).
+- English only in source, tests, comments, tracing.
+- The new crate's `greentic-*` deps must match the versions the Designer already pins (verbatim): `greentic-types = "=1.2.0-research.1"`, `greentic-pack-lib = "=1.2.0-research.0"` (lib name `greentic_pack`), `greentic-flow = "=1.2.0-research.0"`, `greentic-dw-types = "1.1.0-dev"`, `greentic-aw-runtime` at the Designer's git rev (`greentic-designer/Cargo.toml:73`).
+- The emitted `.gtpack` MUST be runner-loadable: a `manifest.cbor` decodable via `greentic_types::decode_pack_manifest`, plus `dw-agents.json`, plus `flows/main.ygtc`.
+- `greentic-dev` stays a pass-through: **no** agent semantics land there. Agent authoring lives in `greentic-dw` + `greentic-dw-authoring`.
+- `git commit` in each repo's own worktree; never bypass hooks with `--no-verify`.
+
+## Design decisions locked by code-grounding (read before Task 1)
+
+1. **Standalone crate, not a workspace member.** `greentic-designer` is a single crate (no `[workspace]`). Create `greentic-dw-authoring/` as a sibling directory with its own `Cargo.toml`; the Designer adds it as `path = "../greentic-dw-authoring"`.
+2. **DB-free assembly seam.** The Designer's real workhorse `dw_application_pack::build_dw_pack_from_answer_document` is DB-bound (reads `knowledge_documents` from sqlite). The crate must NOT depend on sqlx. The crate's assembly takes knowledge as already-extracted text: `Vec<KnowledgeInput { id: String, text: String }>`. The Designer supplies these from its DB; the CLI supplies them by reading local files.
+3. **One canonical `WorkerSpec`.** Neither the Designer's untyped `serde_json::Value` AnswerDocument nor greentic-dw's typed `AnswerDocument` is reused as the authoring format. The crate owns `WorkerSpec` (a typed struct, `schemars::JsonSchema`), and an internal `WorkerSpec → serde_json::Value` projection that reproduces the shape `dw_form_to_answer_doc::convert` produces today.
+4. **Port injector fns individually.** `pack_via_packc/mod.rs` is coupled to Designer internals, but `embed_dw_agents`, `inject_dw_agent_graph_node`, `inject_operala_call_node`, `inject_dw_agent_nodes` each only need `serde_json`/`serde_yaml_bw`/`cbor_flow_post`/`greentic_aw_runtime`. Move those four fns (+ `DwAgentInjection`) into the crate, not the whole module.
+5. **Port `cbor_flow_post` + `loadable` + `slugify`** into the crate (they are pure and required by the assembly).
+6. **Executing-node mapping** (from `dw_form_to_answer_doc.rs:131-142`): `AgentGraph → {"kind":"dw.agent_graph"}`, `DeepWorker → {"kind":"operala.call","deep_worker":<config>}`, `SingleTurn → none` (single_turn flow is synthesized by `single_turn_main_ygtc`).
+
+---
+
+## Task Group 1 — The `greentic-dw-authoring` crate
+
+### Task 1: Scaffold the crate
+
+**Files:**
+- Create: `greentic-dw-authoring/Cargo.toml`
+- Create: `greentic-dw-authoring/src/lib.rs`
+- Create: `greentic-dw-authoring/rust-toolchain.toml` (copy from a sibling repo, pin 1.95.0)
+
+**Interfaces:**
+- Produces: crate `greentic_dw_authoring` compiling with the pinned deps.
+
+- [ ] **Step 1: Write `Cargo.toml`**
+
+```toml
+[package]
+name = "greentic-dw-authoring"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.95.0"
+description = "Author agentic-worker packs (single_turn / agent_graph / deep_worker) from a WorkerSpec"
+license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml_bw = "2"
+schemars = "0.8"
+anyhow = "1"
+thiserror = "2"
+blake3 = "1"
+time = { version = "0.3", features = ["formatting"] }
+semver = "1"
+greentic-types = "=1.2.0-research.1"
+greentic-pack-lib = "=1.2.0-research.0"
+greentic-flow = "=1.2.0-research.0"
+greentic-dw-types = "1.1.0-dev"
+greentic-extension-sdk-contract = { workspace = false, version = "*" } # match designer Cargo.toml:XX exact pin
+greentic-aw-runtime = { git = "…", rev = "…", features = ["test-mock"] } # copy verbatim from greentic-designer/Cargo.toml:73
+
+[dev-dependencies]
+zip = "2"
+```
+
+> Copy the exact `greentic-aw-runtime` and `greentic-extension-sdk-contract` dependency lines from `greentic-designer/Cargo.toml` (lines 73 and the sdk-contract line) rather than guessing the rev/version.
+
+- [ ] **Step 2: Write `src/lib.rs` skeleton**
+
+```rust
+#![forbid(unsafe_code)]
+
+pub mod model;      // WorkerSpec + sub-types (Task 2)
+pub mod project;    // WorkerSpec -> answer Value (Task 4)
+pub mod assemble;   // answer Value + knowledge -> .gtpack (Tasks 5-8)
+pub mod slug;       // ported slugify (Task 3)
+
+pub use model::*;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd greentic-dw-authoring && cargo build`
+Expected: PASS (empty modules; create empty `model.rs`/`project.rs`/`assemble.rs`/`slug.rs` with `//! placeholder` so the mods resolve).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add greentic-dw-authoring/
+git commit -m "feat(dw-authoring): scaffold crate"
+```
+
+### Task 2: `WorkerSpec` model
+
+**Files:**
+- Create: `greentic-dw-authoring/src/model.rs`
+- Test: `greentic-dw-authoring/tests/model.rs`
+
+**Interfaces:**
+- Produces: `WorkerSpec`, `AgentKind`, `LlmRef`, `ToolRef`, `MemorySpec`, `KnowledgeSpec`, `EmbeddingRef`, `AgentGraphSpec`, `Specialist`, `DeepWorkerSpec`, `KnowledgeInput`. All `Serialize + Deserialize + JsonSchema`, `#[serde(rename_all = "snake_case")]` on `AgentKind`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/model.rs
+use greentic_dw_authoring::{AgentKind, WorkerSpec};
+
+#[test]
+fn worker_spec_round_trips_yaml() {
+    let yaml = r#"
+apiVersion: greentic.ai/v1
+kind: single_turn
+name: triage
+llm: { provider: openai, model: gpt-4o, credential_ref: llm-openai }
+instructions: "You are a triage agent."
+tools: [ web.search ]
+"#;
+    let spec: WorkerSpec = serde_yaml_bw::from_str(yaml).expect("parse");
+    assert_eq!(spec.kind, AgentKind::SingleTurn);
+    assert_eq!(spec.name, "triage");
+    assert_eq!(spec.llm.provider, "openai");
+    assert_eq!(spec.tools, vec!["web.search".to_string()]);
+}
+
+#[test]
+fn deep_worker_defaults() {
+    let spec: WorkerSpec = serde_yaml_bw::from_str(
+        "apiVersion: greentic.ai/v1\nkind: deep_worker\nname: r\nllm: {provider: openai, model: gpt-4o}\ninstructions: x\ndeep_worker: {}\n",
+    ).unwrap();
+    let dw = spec.deep_worker.unwrap();
+    assert_eq!(dw.iteration_budget, 8);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p greentic-dw-authoring --test model`
+Expected: FAIL (types not defined).
+
+- [ ] **Step 3: Implement `model.rs`**
+
+```rust
+//! The canonical authoring format for an agentic worker.
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentKind {
+    #[default]
+    SingleTurn,
+    AgentGraph,
+    DeepWorker,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct WorkerSpec {
+    #[serde(default)]
+    pub kind: AgentKind,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    pub llm: LlmRef,
+    #[serde(default)]
+    pub instructions: String,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<MemorySpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge: Option<KnowledgeSpec>,
+    #[serde(default)]
+    pub guardrails: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_graph: Option<AgentGraphSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deep_worker: Option<DeepWorkerSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct LlmRef {
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct MemorySpec {
+    #[serde(default)]
+    pub short_term: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub long_term: Option<ProviderRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProviderRef {
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct KnowledgeSpec {
+    pub provider: String,
+    pub embedding: EmbeddingRef,
+    #[serde(default = "default_top_k")]
+    pub top_k: u32,
+    /// Local file paths to bake into the corpus (CLI); ignored when `KnowledgeInput`s are supplied directly.
+    #[serde(default)]
+    pub documents: Vec<String>,
+}
+fn default_top_k() -> u32 { 5 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct EmbeddingRef {
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct AgentGraphSpec {
+    pub coordinator: Coordinator,
+    pub specialists: Vec<Specialist>,
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Coordinator {
+    #[serde(default)]
+    pub instructions: String,
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Specialist {
+    pub name: String,
+    #[serde(default)]
+    pub instructions: String,
+    #[serde(default)]
+    pub tools: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DeepWorkerSpec {
+    #[serde(default = "default_iteration_budget")]
+    pub iteration_budget: u32,
+    #[serde(default)]
+    pub reflection: bool,
+    #[serde(default)]
+    pub delegation: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planning_model: Option<String>,
+}
+fn default_iteration_budget() -> u32 { 8 }
+impl Default for DeepWorkerSpec {
+    fn default() -> Self {
+        Self { iteration_budget: 8, reflection: false, delegation: false, planning_model: None }
+    }
+}
+
+/// Knowledge document text supplied by the caller (DB for the Designer, local files for the CLI).
+#[derive(Debug, Clone, PartialEq)]
+pub struct KnowledgeInput {
+    pub id: String,
+    pub text: String,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p greentic-dw-authoring --test model`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add greentic-dw-authoring/src/model.rs greentic-dw-authoring/tests/model.rs
+git commit -m "feat(dw-authoring): WorkerSpec model"
+```
+
+### Task 3: Port `slugify`
+
+**Files:**
+- Create: `greentic-dw-authoring/src/slug.rs`
+- Test: inline `#[cfg(test)]`
+
+**Interfaces:**
+- Produces: `pub fn slugify(input: &str) -> String`
+
+- [ ] **Step 1: Copy the function.** Open `greentic-designer/src/orchestrate/util.rs`, find `pub fn slugify`, and copy its body verbatim into `src/slug.rs`. Add its existing unit tests (or write one: `assert_eq!(slugify("Support Triage!"), "support-triage")`).
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-authoring slug` — Expected: PASS.
+- [ ] **Step 3: Commit** `git commit -m "refactor(dw-authoring): port slugify"`
+
+### Task 4: Projection `WorkerSpec → answer Value`
+
+**Files:**
+- Create: `greentic-dw-authoring/src/project.rs`
+- Test: `greentic-dw-authoring/tests/project.rs`
+
+**Interfaces:**
+- Consumes: `WorkerSpec`, `slug::slugify`.
+- Produces: `pub fn to_answer_document(spec: &WorkerSpec) -> Result<serde_json::Value, ProjectError>` and `pub fn executing_node(spec: &WorkerSpec) -> Option<serde_json::Value>`. `ProjectError` (thiserror) with `MissingLlm` — retained for parity even though `WorkerSpec.llm` is non-optional (validation lives in Task 9).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/project.rs
+use greentic_dw_authoring::{project, AgentKind, DeepWorkerSpec, WorkerSpec, LlmRef};
+
+fn base(kind: AgentKind) -> WorkerSpec {
+    WorkerSpec {
+        kind, name: "w".into(), description: None, tenant: None,
+        llm: LlmRef { provider: "openai".into(), model: "gpt-4o".into(), credential_ref: None },
+        instructions: "do things".into(), tools: vec![], memory: None, knowledge: None,
+        guardrails: vec![], agent_graph: None, deep_worker: None,
+    }
+}
+
+#[test]
+fn single_turn_has_no_executing_node() {
+    assert!(project::executing_node(&base(AgentKind::SingleTurn)).is_none());
+}
+#[test]
+fn agent_graph_executing_node() {
+    let n = project::executing_node(&base(AgentKind::AgentGraph)).unwrap();
+    assert_eq!(n["kind"], "dw.agent_graph");
+}
+#[test]
+fn deep_worker_executing_node_carries_config() {
+    let mut s = base(AgentKind::DeepWorker);
+    s.deep_worker = Some(DeepWorkerSpec { iteration_budget: 12, ..Default::default() });
+    let n = project::executing_node(&s).unwrap();
+    assert_eq!(n["kind"], "operala.call");
+    assert_eq!(n["deep_worker"]["iteration_budget"], 12);
+}
+#[test]
+fn answer_document_has_manifest_id_and_display_name() {
+    let doc = project::to_answer_document(&base(AgentKind::SingleTurn)).unwrap();
+    assert!(doc["manifest_id"].is_string());
+    assert_eq!(doc["display_name"], "w");
+}
+```
+
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-authoring --test project` — Expected: FAIL.
+- [ ] **Step 3: Implement `project.rs`.** Port the body of `dw_form_to_answer_doc.rs::convert` (`greentic-designer/src/orchestrate/dw_form_to_answer_doc.rs:39`), adapting: read from `WorkerSpec` fields instead of `DwFormState`; reproduce the same top-level JSON keys (`manifest_id`, `display_name`, `manifest{metadata,capability_plan,defaults,behavior_scaffold}`, `provider_overrides`, `locale`, `tenant`, optional `extension_tools`, `guardrails`); use `slug::slugify` for `resolve_manifest_id`. Implement `executing_node` exactly per the mapping in Design Decision 6.
+
+```rust
+//! Project a WorkerSpec into the untyped "answer document" the pack assembler consumes.
+use crate::model::{AgentKind, WorkerSpec};
+use serde_json::{json, Value};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectError {
+    #[error("missing LLM binding")]
+    MissingLlm,
+}
+
+pub fn executing_node(spec: &WorkerSpec) -> Option<Value> {
+    match spec.kind {
+        AgentKind::SingleTurn => None,
+        AgentKind::AgentGraph => Some(json!({ "kind": "dw.agent_graph" })),
+        AgentKind::DeepWorker => {
+            let dw = spec.deep_worker.clone().unwrap_or_default();
+            Some(json!({ "kind": "operala.call", "deep_worker": dw }))
+        }
+    }
+}
+
+pub fn to_answer_document(spec: &WorkerSpec) -> Result<Value, ProjectError> {
+    // ... port dw_form_to_answer_doc::convert here, reading from WorkerSpec ...
+    // Returns the same JSON shape the Designer produces today.
+    todo!("port convert() body per Task 4 Step 3")
+}
+```
+
+> The `todo!` above is a landmark for the implementer — replace it with the ported body in this same step; do not commit a `todo!`.
+
+- [ ] **Step 4: Run** `cargo test -p greentic-dw-authoring --test project` — Expected: PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(dw-authoring): WorkerSpec projection to answer document"`
+
+### Task 5: Port `cbor_flow_post`
+
+**Files:**
+- Create: `greentic-dw-authoring/src/cbor_flow_post.rs`
+- Modify: `greentic-dw-authoring/src/lib.rs` (add `pub(crate) mod cbor_flow_post;`)
+
+**Interfaces:**
+- Produces: `inject_sidecar(pack_bytes: &[u8], name: &str, contents: &[u8]) -> Result<Vec<u8>, PostProcessError>`, `populate_manifest_flows(...)`, `PostProcessError`. Use the exact signatures from `greentic-designer/src/orchestrate/cbor_flow_post.rs`.
+
+- [ ] **Step 1: `git show` the source**, then copy `cbor_flow_post.rs` verbatim into the crate. Rewrite any `crate::orchestrate::…` imports to the crate-local paths. Keep its existing tests.
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-authoring cbor_flow_post` — Expected: PASS.
+- [ ] **Step 3: Commit** `git commit -m "refactor(dw-authoring): port cbor_flow_post"`
+
+### Task 6: Port the DW injector functions
+
+**Files:**
+- Create: `greentic-dw-authoring/src/inject.rs`
+- Modify: `greentic-dw-authoring/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `cbor_flow_post::inject_sidecar`, `greentic_aw_runtime::AgentConfig`.
+- Produces (exact signatures copied from `pack_via_packc/mod.rs`):
+  - `pub fn embed_dw_agents(pack_path: &Path, agents: &BTreeMap<String, greentic_aw_runtime::AgentConfig>) -> Result<(), String>`
+  - `pub fn inject_dw_agent_graph_node(ygtc_text: &str, pack_id: &str) -> Result<String, String>`
+  - `pub fn inject_operala_call_node(ygtc_text: &str, target: &str, deep_worker: &serde_json::Value) -> Result<String, String>`
+  - `pub fn inject_dw_agent_nodes(ygtc_text: &str, injections: &[DwAgentInjection]) -> Result<String, String>` + `pub struct DwAgentInjection { pub node_id: String, pub agent_id: String, pub successor_id: Option<String> }`
+
+- [ ] **Step 1: Copy the four fns + `DwAgentInjection`** from `greentic-designer/src/orchestrate/pack_via_packc/mod.rs` (lines 512, 1826-1829, 1851, 1921, 1990) into `inject.rs`. Rewrite imports to crate-local `cbor_flow_post`. Copy any of their unit tests.
+- [ ] **Step 2: Write a smoke test** asserting `inject_operala_call_node("id: main\ntype: messaging\nstart: x\nnodes: {}", "tgt", &json!({"iteration_budget":8}))` returns `Ok` containing `operala.call`.
+- [ ] **Step 3: Run** `cargo test -p greentic-dw-authoring inject` — Expected: PASS.
+- [ ] **Step 4: Commit** `git commit -m "refactor(dw-authoring): port DW node injectors"`
+
+### Task 7: Port `loadable` (runner-loadable manifest.cbor)
+
+**Files:**
+- Create: `greentic-dw-authoring/src/loadable.rs`
+- Modify: `greentic-dw-authoring/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `cbor_flow_post`, `greentic_types::{PackManifest, decode_pack_manifest, encode_pack_manifest}`.
+- Produces: `pub fn make_runner_loadable(pack_path: &Path, pack_id: &str) -> Result<(), LoadableError>`, `pub(crate) fn single_turn_main_ygtc(agent_id: &str) -> Result<String, String>`, `LoadableError`.
+
+- [ ] **Step 1: Copy `loadable.rs`** from `greentic-designer/src/orchestrate/runner_sidecar/loadable.rs` verbatim; rewrite `crate::orchestrate::cbor_flow_post` → crate-local. Keep the full `build_runner_manifest` `PackManifest` literal (all 15 fields) and `single_turn_main_ygtc` (the inline flow JSON at `:116-128`). Keep its tests (they use `greentic_flow` — add as dev-dep if needed).
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-authoring loadable` — Expected: PASS.
+- [ ] **Step 3: Commit** `git commit -m "refactor(dw-authoring): port runner-loadable manifest builder"`
+
+### Task 8: The DB-free assembler `build_worker_pack`
+
+**Files:**
+- Create: `greentic-dw-authoring/src/assemble.rs`
+- Test: `greentic-dw-authoring/tests/assemble.rs`
+
+**Interfaces:**
+- Consumes: `project::to_answer_document`/`executing_node`, `inject::*`, `loadable::*`, `greentic_pack::builder::{PackBuilder, PackMeta, FlowBundle}`, `model::KnowledgeInput`, `greentic_aw_runtime::AgentConfig`.
+- Produces:
+  - `pub fn build_worker_pack(spec: &WorkerSpec, knowledge: &[KnowledgeInput], out_dir: &Path) -> Result<WorkerPack, AssembleError>`
+  - `pub struct WorkerPack { pub pack_path: PathBuf, pub pack_id: String }`
+  - `pub struct AssembleError` (thiserror)
+  - `pub fn agent_configs(spec: &WorkerSpec) -> BTreeMap<String, greentic_aw_runtime::AgentConfig>` — the CLI's analog of `dw_form_to_agent_config` (build one `AgentConfig` per agent: single = one; graph = coordinator + specialists; deep = one).
+
+This is the crate's centerpiece: it reproduces `materialize_worker_pack`'s orchestration (grounding A.5) but DB-free and file-free-of-sqlx.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// tests/assemble.rs
+use greentic_dw_authoring::{assemble, AgentKind, LlmRef, WorkerSpec};
+use std::io::Read;
+
+fn spec(kind: AgentKind) -> WorkerSpec { /* same builder as tests/project.rs `base` */ todo!() }
+
+fn read_zip_entry(pack: &std::path::Path, name: &str) -> Option<Vec<u8>> {
+    let f = std::fs::File::open(pack).unwrap();
+    let mut zip = zip::ZipArchive::new(f).unwrap();
+    let mut file = zip.by_name(name).ok()?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    Some(buf)
+}
+
+#[test]
+fn single_turn_pack_is_runner_loadable() {
+    let dir = tempdir_like(); // std::env::temp_dir().join(unique)
+    let out = assemble::build_worker_pack(&spec(AgentKind::SingleTurn), &[], &dir).unwrap();
+    let cbor = read_zip_entry(&out.pack_path, "manifest.cbor").expect("manifest.cbor present");
+    greentic_types::decode_pack_manifest(&cbor).expect("decodes");
+    assert!(read_zip_entry(&out.pack_path, "dw-agents.json").is_some());
+    assert!(read_zip_entry(&out.pack_path, "flows/main.ygtc").is_some());
+}
+```
+
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-authoring --test assemble` — Expected: FAIL.
+- [ ] **Step 3: Implement `build_worker_pack`.** Orchestration (mirroring grounding A.5, DB-free):
+  1. `let answer = project::to_answer_document(spec)?;`
+  2. Build the base pack with `PackBuilder` (port the relevant bits of `dw_pack.rs::build_dw_pack` — `PackMeta` construction at `dw_pack.rs:226-249`, `PackBuilder::new(meta).with_flow(...).build(out_path)`), writing a real flow rather than the stub: for `SingleTurn` use `loadable::single_turn_main_ygtc(display_name)`; for `AgentGraph`/`DeepWorker` start from a minimal messaging flow and apply `inject_dw_agent_graph_node` / `inject_operala_call_node` with `executing_node(spec)`.
+  3. Bake knowledge: if `!knowledge.is_empty()`, chunk each `KnowledgeInput.text` and write `knowledge_corpus.json` + `assets/knowledge/*.txt` into the pack via `cbor_flow_post::inject_sidecar` (port the corpus-writing logic from `dw_application_pack.rs`, but taking `KnowledgeInput` text instead of DB rows).
+  4. `loadable::make_runner_loadable(&pack_path, &pack_id)?;`
+  5. `inject::embed_dw_agents(&pack_path, &agent_configs(spec))?;`
+  6. Return `WorkerPack { pack_path, pack_id }`.
+- [ ] **Step 4: Implement `agent_configs`.** Port `dw_form_to_agent_config.rs` mapping, reading from `WorkerSpec` (map `llm`→`LlmProviderRef`, `tools`→`Vec<ToolRef>`, `memory`→`MemorySettings`, `knowledge`→`KnowledgeSettings`, `guardrails`). Reference the runtime structs at `greentic-runner/crates/greentic-aw-runtime/src/config.rs:96,48,68`.
+- [ ] **Step 5: Run** `cargo test -p greentic-dw-authoring --test assemble` — Expected: PASS.
+- [ ] **Step 6: Commit** `git commit -m "feat(dw-authoring): DB-free worker pack assembler"`
+
+### Task 9: Spec validation
+
+**Files:**
+- Create: `greentic-dw-authoring/src/validate.rs`
+- Test: `greentic-dw-authoring/tests/validate.rs`
+
+**Interfaces:**
+- Produces: `pub fn validate(spec: &WorkerSpec) -> Result<(), Vec<ValidationError>>`, `pub struct ValidationError { pub field: String, pub message: String }`.
+
+- [ ] **Step 1: Write failing tests** for: empty `name` → error; `agent_graph` kind with `< 2` specialists → error; `agent_graph` with duplicate specialist names → error; `deep_worker.iteration_budget == 0` or `> 100` → error; `single_turn` with an `agent_graph` block set → warning-free but error if kind/block mismatch. Assert error `field`s.
+- [ ] **Step 2: Run** — Expected: FAIL.
+- [ ] **Step 3: Implement `validate`** with explicit, non-panicking checks. No silent skips.
+- [ ] **Step 4: Run** — Expected: PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(dw-authoring): WorkerSpec validation"`
+
+---
+
+## Task Group 2 — Refactor the Designer onto the crate
+
+### Task 10: Add the crate as a Designer dependency + adapter
+
+**Files:**
+- Modify: `greentic-designer/Cargo.toml` (add `greentic-dw-authoring = { path = "../greentic-dw-authoring" }`)
+- Create: `greentic-designer/src/orchestrate/dw_authoring_adapter.rs` — `pub fn worker_spec_from_form(form: &DwFormState) -> WorkerSpec` and `pub async fn knowledge_inputs(db, tenant, team, ids) -> Vec<KnowledgeInput>` (reads `knowledge_documents` via the existing `knowledge_documents::get_with_text`).
+
+**Interfaces:**
+- Consumes: `greentic_dw_authoring::{WorkerSpec, KnowledgeInput, assemble}`, existing `DwFormState`, existing `knowledge_documents` repo.
+- Produces: an adapter that lets the Designer build packs through the crate.
+
+- [ ] **Step 1: Write a failing test** in the Designer: `worker_spec_from_form(&DwFormState::default())` produces a `WorkerSpec` with `kind == SingleTurn`.
+- [ ] **Step 2: Run** `cargo test -p greentic-designer --features test-mock dw_authoring_adapter` — Expected: FAIL.
+- [ ] **Step 3: Implement the adapter** — map each `DwFormState` field to the `WorkerSpec` equivalent (this is the inverse of the CLI's projection and the parity anchor).
+- [ ] **Step 4: Run** — Expected: PASS.
+- [ ] **Step 5: Commit** (in the greentic-designer worktree) `git commit -m "feat(designer): dw-authoring adapter"`
+
+### Task 11: Route `materialize_worker_pack` through the crate + parity test
+
+**Files:**
+- Modify: `greentic-designer/src/orchestrate/runner_sidecar/materialize.rs`
+- Test: `greentic-designer/tests/dw_authoring_parity.rs`
+
+**Interfaces:**
+- Consumes: `dw_authoring_adapter`, `greentic_dw_authoring::assemble::build_worker_pack`.
+
+- [ ] **Step 1: Write the parity test (failing).** For each kind, build a representative `DwFormState`; produce a pack the **old** way (current `materialize_worker_pack`) and the **new** way (adapter → `build_worker_pack`); assert the two `.gtpack`s have byte-equal `manifest.cbor` (decoded + re-encoded to normalize), equal `dw-agents.json`, and equal `flows/main.ygtc`.
+- [ ] **Step 2: Run** — Expected: FAIL (new path not wired).
+- [ ] **Step 3: Re-point `materialize_worker_pack`** internals: replace the hand-orchestrated body (grounding A.5 steps 1-7) with `let spec = worker_spec_from_form(form); let ki = knowledge_inputs(db, tenant, team, &spec.document_ids()).await; let pack = build_worker_pack(&spec, &ki, dir)?;` then keep the Designer-specific `gtbind::write_gtbind` tail. Preserve `WorkerPackArtifacts`.
+- [ ] **Step 4: Run** the parity test + the full existing sidecar tests — Expected: PASS.
+- [ ] **Step 5: Run** `bash ci/local_check.sh` in greentic-designer (fmt + clippy -D + tests + FE build). Expected: PASS.
+- [ ] **Step 6: Commit** `git commit -m "refactor(designer): assemble worker packs via greentic-dw-authoring"`
+
+### Task 12: Delete the now-duplicated Designer code
+
+**Files:**
+- Modify/Delete: the Designer copies of the ported logic (`dw_form_to_answer_doc.rs` projection body, the four injector fns in `pack_via_packc/mod.rs`, `runner_sidecar/loadable.rs`, `cbor_flow_post.rs`) — replace their bodies with re-exports of the crate, or delete and update call sites, whichever keeps the tree compiling.
+
+- [ ] **Step 1:** For each duplicated item, replace the Designer definition with `pub use greentic_dw_authoring::… as …;` (or delete + fix imports). Keep anything still used only by the Designer.
+- [ ] **Step 2: Run** `bash ci/local_check.sh` — Expected: PASS.
+- [ ] **Step 3: Commit** `git commit -m "refactor(designer): drop code now owned by greentic-dw-authoring"`
+
+---
+
+## Task Group 3 — `greentic-dw worker` CLI
+
+### Task 13: Add `worker` deps + subcommand types
+
+**Files:**
+- Modify: `greentic-dw/crates/greentic-dw-cli/Cargo.toml` (add `greentic-dw-authoring` path/version dep)
+- Modify: `greentic-dw/crates/greentic-dw-cli/src/cli_types.rs` (add `Worker(WorkerArgs)` to `Command`; define `WorkerArgs` with a `WorkerSub` enum)
+- Modify: `greentic-dw/crates/greentic-dw-cli/src/lib.rs` (add `mod worker;`)
+
+**Interfaces:**
+- Produces: clap `WorkerArgs { #[command(subcommand)] cmd: WorkerSub }`, `enum WorkerSub { Init { kind: String, out: Option<PathBuf> }, New { .. }, Build { spec: PathBuf, out: Option<PathBuf> }, Validate { spec: PathBuf } }`.
+
+- [ ] **Step 1: Write a failing test** in `greentic-dw-cli`: parsing `["greentic-dw","worker","validate","spec.yaml"]` via `Cli::parse_from` yields `Command::Worker(WorkerArgs { cmd: WorkerSub::Validate { .. } })`.
+- [ ] **Step 2: Run** — Expected: FAIL.
+- [ ] **Step 3: Add the enum variants + `WorkerArgs`/`WorkerSub`** in `cli_types.rs` (mirror the `WizardArgs` style, `cli_types.rs:59-118`).
+- [ ] **Step 4: Run** — Expected: PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(dw-cli): worker subcommand types"`
+
+### Task 14: Dispatch + `run_worker`
+
+**Files:**
+- Create: `greentic-dw/crates/greentic-dw-cli/src/worker.rs`
+- Modify: `greentic-dw/crates/greentic-dw-cli/src/wizard.rs` (add `Command::Worker(a) => worker::run_worker(a)` to the `run` match at `wizard.rs:40-42`)
+
+**Interfaces:**
+- Consumes: `greentic_dw_authoring::{WorkerSpec, validate, assemble}`, `WorkerArgs`/`WorkerSub`.
+- Produces: `pub fn run_worker(args: WorkerArgs) -> Result<(), CliError>`.
+
+- [ ] **Step 1: Write failing tests** (`worker.rs` `#[cfg(test)]`):
+  - `run_worker(validate spec)` on a valid YAML file → `Ok`; on an invalid one → `Err` with a message naming the field.
+  - `run_worker(build spec)` writes a `.gtpack` at the requested path, and `greentic_types::decode_pack_manifest` succeeds on its `manifest.cbor`.
+  - `run_worker(init single_turn)` writes a YAML file that `serde_yaml_bw::from_str::<WorkerSpec>` parses.
+- [ ] **Step 2: Run** `cargo test -p greentic-dw-cli worker` — Expected: FAIL.
+- [ ] **Step 3: Implement `run_worker`.**
+  - `Init` → write a starter `WorkerSpec` (serialize a `Default`-ish spec for the kind) to `out` (default `./<kind>-worker.yaml`).
+  - `Validate` → load YAML → `validate::validate` → print errors or "ok".
+  - `Build` → load YAML → `validate` → read `knowledge.documents` local files, extract text (plain text as-is; `.pdf` via a `pdf-extract`/`lopdf` helper — reuse the Designer's `extract` approach, add the dep), build `Vec<KnowledgeInput>` → `assemble::build_worker_pack` → report path.
+  - `New` → interactive prompts building a `WorkerSpec`, then the `Build` path. Mirror the `run_wizard` harness (`wizard.rs:45`) for `--answers`/non-interactive/`--schema` (`schema_for!(WorkerSpec)`).
+- [ ] **Step 4: Run** — Expected: PASS.
+- [ ] **Step 5: Run** `bash ci/local_check.sh` in greentic-dw. Expected: PASS.
+- [ ] **Step 6: Commit** `git commit -m "feat(dw-cli): gtc worker init/new/build/validate"`
+
+---
+
+## Task Group 4 — `gtc worker` routing
+
+### Task 15: Add `DW_BIN` + router arm
+
+**Files:**
+- Modify: `greentic/src/bin/gtc.rs` (add `const DW_BIN: &str = "greentic-dw";` near `gtc.rs:95-106`)
+- Modify: `greentic/src/bin/gtc/router.rs` (`use super::…DW_BIN`; add `"worker" => Some((DW_BIN, tail.to_vec())),` to `route_passthrough_subcommand` at `:59-71`)
+- Test: `greentic/src/bin/gtc/router.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: existing `route_passthrough_subcommand` pattern.
+
+- [ ] **Step 1: Write a failing test:** `route_passthrough_subcommand("worker", &["build".into(),"s.yaml".into()], "en")` returns `Some(("greentic-dw", vec!["build","s.yaml"]))`.
+- [ ] **Step 2: Run** `cargo test -p gtc router` — Expected: FAIL.
+- [ ] **Step 3: Add `DW_BIN` + the match arm.**
+- [ ] **Step 4: Run** — Expected: PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(gtc): route worker subcommand to greentic-dw"`
+
+### Task 16: Register the clap subcommand + dispatch
+
+**Files:**
+- Modify: `greentic/src/bin/gtc/cli.rs` (add a `worker` `.subcommand(...)` mirroring the `dev` block at `:920-928`, using `cmd_args.clone()`)
+- Modify: `greentic/src/bin/gtc/commands.rs` (add `"worker"` to the passthrough tuple pattern at `:134`, skipping the wizard/setup-only branches)
+- Modify: `greentic/src/bin/gtc/process.rs` (add `DW_BIN` to `is_greentic_companion_binary` `matches!` at `:427-437` and, if env-override desired, to `companion_binary_env_override` at `:486-501`)
+
+**Interfaces:**
+- Consumes: `passthrough`, `route_passthrough_subcommand`.
+
+- [ ] **Step 1: Write a failing test** (or a shell smoke): `gtc worker --help` forwards to `greentic-dw worker --help`. Unit-test `is_greentic_companion_binary("greentic-dw") == true`.
+- [ ] **Step 2: Run** — Expected: FAIL.
+- [ ] **Step 3: Implement** the three edits.
+- [ ] **Step 4: Run** `cargo test -p gtc` — Expected: PASS.
+- [ ] **Step 5: Manual smoke:** build `gtc` + `greentic-dw`, put both on PATH, run `gtc worker init single_turn` → a YAML file appears; `gtc worker build <that>.yaml` → a `.gtpack`.
+- [ ] **Step 6: Run** `bash ci/local_check.sh` in greentic. Expected: PASS.
+- [ ] **Step 7: Commit** `git commit -m "feat(gtc): register worker passthrough command"`
+
+---
+
+## Self-Review
+
+**Spec coverage:** Slice 1 §4 (shared crate, WorkerSpec, `gtc worker` verbs, data flow, error handling, all 3 kinds) → Task Groups 1-4. Parity test (§6) → Task 11. DB-free knowledge seam → Design Decision 2 + Task 8. Slice 2 (runtime productionization) and Slice 3 (deep_worker RAG) are **out of scope for this plan** (separate plans, per spec §8).
+
+**Known landmarks left for the implementer (not placeholders — each has a precise source to port):** Task 4 Step 3 `to_answer_document` body (port `convert`), Task 8 Step 3 corpus-writing (port from `dw_application_pack.rs`), Task 14 PDF extraction (reuse Designer `extract`). Each names the exact source file+lines to copy from; the implementer must replace the `todo!()`/prose landmarks with the ported code in the same step and must not commit a `todo!()`.
+
+**Type consistency:** `WorkerSpec`/`AgentKind`/`KnowledgeInput` defined in Task 2 are referenced consistently in Tasks 4, 8-11, 13-14. `build_worker_pack(spec, knowledge, out_dir) -> WorkerPack` signature is stable across Tasks 8, 11, 14.
+
+**Open decision for review:** the `apiVersion` string in `WorkerSpec` YAML examples (`greentic.ai/v1`) is cosmetic — confirm the desired value. `WorkerSpec` currently omits per-tool extension bindings (`extension_tools`) and opening-message/vertical metadata that `DwFormState` carries; if CLI-authored workers must reach full Designer parity on those, add them to `WorkerSpec` before Task 11's parity test (otherwise the parity test must scope them out explicitly).
+
+---
+
+## Execution Handoff
+
+See the skill's execution options after review.

--- a/docs/superpowers/specs/2026-07-06-cli-agent-types-memory-knowledge-design.md
+++ b/docs/superpowers/specs/2026-07-06-cli-agent-types-memory-knowledge-design.md
@@ -1,0 +1,199 @@
+# CLI Agent Types + Memory + Knowledge (target: gtc 1.1.2)
+
+**Status:** Design — ready for review
+**Date:** 2026-07-06
+**Author:** Bima Pangestu (with Claude)
+**Repos touched:** `greentic` (gtc CLI), `greentic-dw` (authoring wizard + new shared crate), `greentic-designer` (refactor onto shared crate), `greentic-runner` (feature passthrough + release variant)
+**Base:** `greentic` `origin/main` @ `b6f390d` (v1.1.0)
+
+---
+
+## 1. Problem & Goal
+
+Today the three agentic-worker types — **single_turn**, **agent_graph**, **deep_worker** — plus agent **memory** and **knowledge/RAG** can only be authored in the **web designer/composer**. The `gtc` CLI has **zero** agent-type / memory / knowledge surface (verified: `gtc` v1.1.0 source has no `AgentKind`, no memory/knowledge command; `gtc wizard` just launches `greentic-pack`/`greentic-bundle` wizards).
+
+**Goal for 1.1.2:** let a user create, configure, and build all three worker types — including memory and knowledge — entirely from the CLI, producing a runner-loadable `.gtpack`, with real runtime retrieval available on a shipped runner build.
+
+**Non-goal (deferred to Slice 3 / 1.1.3):** knowledge/RAG on the **deep_worker** execution path (greentic-dw deep-loop has no retrieval wiring yet) and `greentic-dw serve` HTTP ingress.
+
+### Success criteria
+- `gtc worker new` (interactive) and `gtc worker build <spec>` (declarative) both produce a runner-loadable `.gtpack` for each of the 3 kinds.
+- The `.gtpack` is **structurally equivalent** to what the designer emits (same `manifest.cbor` + `dw-agents.json` + `flows/main.ygtc` executing-node shape).
+- A worker declaring memory/knowledge, run via `gtc start` against the shipped knowledge-enabled runner + embedding env, retrieves from its corpus (single_turn / agent_graph).
+- Designer continues to emit identical packs after being refactored onto the shared crate (parity is enforced by test, not by hand).
+
+---
+
+## 2. Verified current state (grounding)
+
+| Fact | Evidence |
+|---|---|
+| `gtc` = v1.1.0 on `origin/main`; no agent/memory/knowledge CLI surface | `greentic/Cargo.toml`; full-source search (zero hits) |
+| `gtc wizard` → `greentic-dev wizard` (a launcher delegating to `greentic-pack`/`greentic-bundle`); `gtc dw publish/install` = store client in greentic-dev (no build) | `greentic/src/bin/gtc/router.rs:59-68`; `greentic-dev/src/dw_cmd.rs`, `src/wizard/mod.rs` |
+| Full DW pack-assembly (`AgentKind → AnswerDocument → .gtpack`) lives **only** inside `greentic-designer/src/orchestrate/`; never extracted to a shared crate (code comments anticipate promoting to `greentic-pack-lib`) | `greentic-designer/src/orchestrate/{dw_form.rs,dw_form_to_answer_doc.rs,dw_pack.rs,runner_sidecar/loadable.rs,dw_application_pack.rs}` |
+| Canonical 3-way enum `AgentKind{SingleTurn,AgentGraph,DeepWorker}` is designer-only | `greentic-designer/src/orchestrate/dw_form.rs:17-22` |
+| Runtime config the runner consumes: `AgentConfig`, `MemorySettings`, `KnowledgeSettings` | `greentic-runner/crates/greentic-aw-runtime/src/config.rs:96,48,68` |
+| Sidecar pack-loadable gap **RESOLVED**: designer now emits `manifest.cbor` (via `greentic_pack::builder::PackBuilder`) + `dw-agents.json` + inline flow | `greentic-designer` research @ `25ef8c06`, PR #858; `runner_sidecar/materialize.rs`, `dw_pack.rs:29,157` |
+| Deployed runner is built with default features `["verify","agentic-worker"]` only; `knowledge-chronicle` / `long-term-chronicle` are opt-in and **not surfaced on the binary crate**; release workflow passes no `--features` | `greentic-runner/crates/greentic-runner/Cargo.toml:100`; `.github/workflows/release-binaries.yml`, `ci.yml:24-33` |
+| Retrieval code path is live but silently disabled without feature+env (`GREENTIC_KNOWLEDGE_EMBED_*`) | `greentic-aw-runtime/src/loop.rs:199-213`; `greentic-runner-host/src/runner/knowledge_mount.rs` |
+| Short-term working memory = always-on in-memory provider; but dw.agent needs a state store (server: `GREENTIC_AW_REDIS_URL`; else `desktop-agent-ephemeral` feature) | `agent_node.rs:1087,899,916,954` |
+| deep_worker path has **no** knowledge wiring; `greentic-dw serve` on main lacks `--port`/`/healthz` | `greentic-dw/crates/greentic-dw-runtime/src/deep_loop.rs`; `greentic-dw-cli/src` (no serve on main) |
+
+**Consequence:** "expose memory+knowledge via CLI with real retrieval" is not merely a surfacing job — it requires **productionizing the runner build** (Slice 2). Short-term memory is essentially surfacing-only.
+
+---
+
+## 3. Approach (decided: Approach A)
+
+**Extract the designer's authoring/assembly pipeline into a new shared crate; `greentic-dw` owns the CLI wizard; `gtc` routes to it.** This is the reuse-first, anti-divergence choice: it gives the three agent types a single canonical home and keeps the designer and CLI in lockstep, paying down the current 3-divergent-models debt (designer `DwFormState` vs runner `AgentConfig` vs greentic-dw `DigitalWorkerManifest`).
+
+Rejected alternatives:
+- **B** — build the CLI on greentic-dw's existing `DigitalWorkerManifest`: risks a permanent third model and re-implementing designer graph logic → divergence.
+- **C** — thin CLI straight onto runtime `AgentConfig` + `PackBuilder`: smallest surface but re-derives agent_graph construction outside the designer → duplication.
+
+---
+
+## 4. Slice 1 — CLI authoring
+
+### 4.1 New shared crate `greentic-dw-authoring`
+Home for the code extracted (mechanically, behavior-preserving) from `greentic-designer/src/orchestrate/`:
+- **Type model:** `AgentKind{SingleTurn,AgentGraph,DeepWorker}` + the worker config structs (`MemorySection`, `KnowledgeBinding`, `DeepWorkerConfig`, `ProviderBinding`, tool/guardrail refs). These move here (or into `greentic-dw-types`); designer re-exports/adapts.
+- **Projection:** `WorkerSpec → AnswerDocument` (the existing `dw_form_to_answer_doc` logic, generalized off `DwFormState`).
+- **Assembly:** `AnswerDocument → .gtpack` — `dw_pack.rs` (`greentic_pack::builder::{PackBuilder,PackMeta,FlowBundle}` → `manifest.cbor`), `loadable.rs` (synthesize `flows/main.ygtc` + inline compiled flow), `embed_dw_agents` (`dw-agents.json`), knowledge corpus baking.
+- **Executing-node injection:** `dw.agent` (single_turn), `dw.agent_graph` (agent_graph), `operala.call` (deep_worker) — reuse `inject_dw_agent_graph_node` / `inject_operala_call_node`.
+- **Validation:** spec validation + local PDF/text extraction (reuse designer's `extract` + `lopdf`).
+
+**Extraction risk mitigation:** only the relatively pure modules move (`dw_pack`, `loadable`, `dw_form_to_answer_doc`, `embed_dw_agents` already use `greentic_pack::builder` in-process and are projection-shaped). Web/DB glue (session persistence, HTTP routes, knowledge-library DB) **stays** in the designer; the designer calls the shared crate with an in-memory `WorkerSpec` built from its `DwFormState`. Designer refactor + CLI land in one coordinated release.
+
+### 4.2 `WorkerSpec` — the single authoring format (surfaces A **and** B)
+The interactive wizard and the declarative file path produce/consume the **same** `WorkerSpec`. The wizard is an interactive front-end that emits a `WorkerSpec`, then builds it.
+
+```yaml
+apiVersion: greentic.dev/v1
+kind: single_turn            # | agent_graph | deep_worker
+name: support-triage
+llm:      { provider: openai, model: gpt-4o, credential_ref: llm-openai }
+instructions: |              # system prompt
+  You are a support triage agent...
+tools:    [ web.search, hubspot.contacts ]
+memory:
+  short_term: { enabled: true }
+  long_term:  { provider: chronicle, credential_ref: chronicle-main }
+knowledge:                   # RAG (auto pre-retrieval)
+  provider: chronicle
+  embedding: { provider: openai, model: text-embedding-3-small, credential_ref: embed-openai }
+  top_k: 5
+  documents: [ ./kb/policies.pdf, ./kb/faq.md ]
+guardrails: [ pii-redact ]
+
+# type-specific block (only the one matching `kind`):
+agent_graph:
+  coordinator: { instructions: "route to the right specialist" }
+  specialists:
+    - { name: billing, instructions: "...", tools: [stripe.lookup] }
+    - { name: tech,     instructions: "...", tools: [docs.search]  }
+deep_worker:
+  iteration_budget: 8
+  reflection: true
+  planning_model: gpt-4o
+```
+
+Design note: the agent_graph shape is **coordinator + specialists** (the proven "form-first" designer model, PR #861), not an arbitrary canvas — this keeps CLI graph authoring tractable while staying faithful to the runtime (supervisor routing + shared blackboard).
+
+### 4.3 CLI verbs — new `gtc worker` tree → `greentic-dw`
+`gtc` gains a pass-through verb `worker` routed to the `greentic-dw` binary (add `DW_BIN` in `router.rs`, mirroring `gtc setup`→`greentic-setup`). Not overloaded onto `gtc dw` (store publish/install, greentic-dev) or `gtc wizard` (pack/bundle launcher).
+
+| Command | Behavior |
+|---|---|
+| `gtc worker init <single_turn\|agent_graph\|deep_worker>` | scaffold a starter `WorkerSpec` YAML for that kind |
+| `gtc worker new` | interactive wizard (surface **A**) → emit `WorkerSpec` + build `.gtpack` |
+| `gtc worker build <spec.yaml> [-o out.gtpack]` | declarative build (surface **B**) |
+| `gtc worker validate <spec.yaml>` | validate without building |
+
+`greentic-dw` implements `worker {init,new,build,validate}` on the shared crate. The wizard reuses greentic-dw's existing answers/schema-driven pattern (`--answers` for non-interactive/testable runs).
+
+### 4.4 Data flow
+```
+gtc worker new/build
+  → WorkerSpec (YAML/JSON, on disk)
+    → greentic_dw_authoring: WorkerSpec → AnswerDocument
+      → assembly: manifest.cbor + dw-agents.json + flows/main.ygtc(executing-node) + knowledge corpus
+        → <name>.gtpack   (runner-loadable; verified via greentic_types::decode_pack_manifest)
+```
+Knowledge documents are read locally, text-extracted + chunked, baked into the pack corpus — the CLI analog of the designer knowledge library.
+
+### 4.5 Error handling (anyhow/thiserror, no panics)
+Explicit, non-silent failures: unknown `kind`; missing `llm`; `agent_graph` requires ≥2 specialists + consistent branch labels; `deep_worker.iteration_budget` within bounds; **knowledge document path not found → hard error, not silent skip**; unresolved `credential_ref` → warning at build, hard error at run. Reuse validation extracted from the designer.
+
+---
+
+## 5. Slice 2 — Runtime productionization
+
+Makes real retrieval work on a **shipped** runner. Prerequisite (assumed sorted): CI/release access to the cross-org private `greentic-biz/greentic-chronicle-ext` deps.
+
+### 5.1 Binary-crate feature passthrough
+`greentic-runner/crates/greentic-runner/Cargo.toml` (mirror existing `verify`/`telemetry` passthroughs):
+```toml
+knowledge-chronicle     = ["greentic-runner-host/knowledge-chronicle"]
+long-term-chronicle     = ["greentic-runner-host/long-term-chronicle"]
+desktop-agent-ephemeral = ["greentic-runner-host/desktop-agent-ephemeral"]
+```
++ `#![recursion_limit = "512"]` in `src/main.rs` (Chronicle+SurrealDB futures exceed the default 128 — proven during S0 investigation). Build env needs `clang` for RocksDB.
+
+### 5.2 `runner-full` release artifact
+Add a release build variant `greentic-runner-full` built with `knowledge-chronicle,long-term-chronicle`. The default `greentic-runner` stays `verify,agentic-worker` (byte-identical, backward-compatible). Two shipped artifacts; the knowledge-enabled one is opt-in for operators who need memory/RAG.
+
+### 5.3 `gtc` env surfacing + guidance
+- `gtc start`: when the pack **declares** `memory.long_term` or `knowledge`, check required env (`GREENTIC_KNOWLEDGE_EMBED_{BASE_URL,API_KEY,MODEL}`, `GREENTIC_CHRONICLE_*`, `GREENTIC_AW_REDIS_URL`); if the running binary lacks the feature or env is missing, emit a **clear warning + pointer to `runner-full`** instead of a silent no-op RAG.
+- `gtc doctor`: add a "knowledge/memory readiness" check (feature detectable? env set?).
+- `gtc setup`: option to write embedding/chronicle env into the bundle config.
+
+### 5.4 Short-term memory
+Already works on stock (in-memory provider). dw.agent needs a state store: server → Redis; local `gtc start` → `desktop-agent-ephemeral` (no-infra). `gtc start` surfaces the choice.
+
+---
+
+## 6. Testing
+
+**Slice 1**
+- `greentic-dw-authoring` unit tests: `WorkerSpec → AnswerDocument → .gtpack` per kind; assert `manifest.cbor` decodes via `greentic_types::decode_pack_manifest`, `dw-agents.json` present, knowledge corpus baked (mirror designer sidecar tests). Snapshot spec→pack.
+- **Parity test:** a `WorkerSpec` equivalent to a designer `DwFormState` produces a structurally-equivalent pack — the guard that keeps A from diverging.
+- greentic-dw CLI tests: `worker init/validate/build` on valid + invalid specs (error messages); wizard via `--answers` (non-interactive).
+
+**Slice 2**
+- CI-full build check: `cargo build -p greentic-runner --features knowledge-chronicle,long-term-chronicle`.
+- `gtc doctor` / `gtc start` env-gating tests: pack declares knowledge without env → warning + non-zero/handled exit.
+
+**Live-verify (manual, external creds — final Slice 2 gate)**
+`gtc worker new` a knowledge worker → `gtc start` with `runner-full` + embedding key → ask a corpus-only question → grounded answer (single_turn / agent_graph).
+
+---
+
+## 7. Risks & honest caveats
+
+1. **Designer extraction** is the biggest Slice 1 risk (`orchestrate/` is entangled with web/DB). Mitigation: extract only the pure projection/assembly modules; leave glue in designer; enforce parity by test. Designer + CLI ship in one coordinated release.
+2. **agent_graph authoring in CLI** is complex (supervisor/parallel/routes). Mitigation: MVP = coordinator+specialists form (proven), reuse extracted graph logic; arbitrary canvas stays designer-only.
+3. **Slice 2 cross-org access** is an org/ops prerequisite (assumed sorted). If it slips, Slice 1 still ships independently (authoring parity); retrieval lights up once `runner-full` deploys.
+4. **deep_worker knowledge gap:** deep_worker workers are authorable + runnable via CLI in 1.1.2, but knowledge auto-retrieval is only effective on single_turn/agent_graph until Slice 3. **Must be documented** so users aren't misled.
+
+---
+
+## 8. Decomposition & sequencing
+
+- **Slice 1** (CLI authoring) — independent, ships the headline feature. Order: (1a) extract shared crate + refactor designer onto it with parity test; (1b) `greentic-dw worker {init,new,build,validate}`; (1c) `gtc worker` routing.
+- **Slice 2** (runtime productionization) — feature passthrough + `runner-full` artifact + `gtc` env surfacing; gated by cross-org access + live-verify.
+- **Slice 3** (deferred, 1.1.3) — deep_worker RAG + `greentic-dw serve` HTTP.
+
+Each slice gets its own implementation plan.
+
+---
+
+## 9. Docs (docs.greentic.ai, parallel deliverable)
+
+Net-new pages in `greentic-docs` (Astro Starlight, English + 7 locales + `astro.config.mjs` sidebar):
+- **Agent types** — single_turn / agent_graph / deep_worker: what each is, when to use, how the pack differs.
+- **Agent memory** — short-term (working) vs long-term (Chronicle); env + build requirements.
+- **Knowledge / RAG** — attaching a corpus, embedding provider, top_k; the `runner-full` requirement; the deep_worker caveat (§7.4).
+- Update `concepts/agentic-workers.mdx` + `cli/*` to reference `gtc worker` (mark "1.1.2").
+
+Docs describe **shipped/verified behavior**; anything 1.1.2-gated is labeled as such.

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -106,6 +106,7 @@ const FLOW_BIN: &str = "greentic-flow";
 const PACK_BIN: &str = "greentic-pack";
 const RUNNER_BIN: &str = "greentic-runner";
 const SECRETS_BIN: &str = "greentic-secrets";
+const DW_BIN: &str = "greentic-dw";
 fn main() {
     let raw_args: Vec<String> = std::env::args().collect();
     let exit_code = run(raw_args);

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -861,6 +861,19 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .arg(cmd_args.clone()),
         )
         .subcommand(
+            Command::new("worker")
+                .help_template(help_template)
+                .subcommand_help_heading(commands_heading)
+                .disable_help_flag(true)
+                .disable_version_flag(true)
+                .about(t_or(
+                    locale,
+                    "gtc.cmd.worker.about",
+                    "Author and build agentic workers (passthrough to greentic-dw).",
+                ))
+                .arg(cmd_args.clone()),
+        )
+        .subcommand(
             Command::new("op")
                 .help_template(help_template)
                 .subcommand_help_heading(commands_heading)

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -144,7 +144,7 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 2
             }
         },
-        Some((name @ ("dev" | "op" | "wizard" | "setup"), sub_matches)) => {
+        Some((name @ ("dev" | "op" | "wizard" | "setup" | "worker"), sub_matches)) => {
             let tail = collect_tail(sub_matches);
             let tail = if matches!(name, "wizard" | "setup") {
                 let release_context =

--- a/src/bin/gtc/process.rs
+++ b/src/bin/gtc/process.rs
@@ -11,8 +11,8 @@ use super::toolchain::{
     InstalledReleaseArtifact, installed_release_artifacts, installed_toolchain_label,
 };
 use super::{
-    BUNDLE_BIN, COMPONENT_BIN, DEPLOYER_BIN, DEV_BIN, FLOW_BIN, OP_BIN, PACK_BIN, RUNNER_BIN,
-    SECRETS_BIN, SETUP_BIN, START_BIN,
+    BUNDLE_BIN, COMPONENT_BIN, DEPLOYER_BIN, DEV_BIN, DW_BIN, FLOW_BIN, OP_BIN, PACK_BIN,
+    RUNNER_BIN, SECRETS_BIN, SETUP_BIN, START_BIN,
 };
 use crate::i18n_support::{t, t_or};
 
@@ -479,6 +479,7 @@ fn is_greentic_companion_binary(binary: &str) -> bool {
             | SECRETS_BIN
             | SETUP_BIN
             | START_BIN
+            | DW_BIN
     )
 }
 
@@ -549,7 +550,7 @@ fn companion_binary_env_override(binary: &str) -> Option<std::ffi::OsString> {
 mod tests {
     #[cfg(unix)]
     use super::{apply_default_deploy_env_for_target, run_binary_capture, run_binary_checked};
-    use super::{first_non_empty_line, resolve_cargo_bin_dir};
+    use super::{first_non_empty_line, is_greentic_companion_binary, resolve_cargo_bin_dir};
     #[cfg(unix)]
     use crate::deploy::StartTarget;
     use crate::tests::env_test_lock;
@@ -637,5 +638,10 @@ mod tests {
             err.to_string()
                 .contains("demo operation failed via /bin/sh with status 7")
         );
+    }
+
+    #[test]
+    fn is_greentic_companion_binary_recognizes_greentic_dw() {
+        assert!(is_greentic_companion_binary("greentic-dw"));
     }
 }

--- a/src/bin/gtc/process.rs
+++ b/src/bin/gtc/process.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
@@ -296,7 +297,188 @@ pub(super) fn run_doctor(locale: &str) -> i32 {
         );
     }
 
+    print_knowledge_memory_readiness(locale);
+
     if failed { 1 } else { 0 }
+}
+
+/// Prints the "Knowledge & Memory readiness" section of `gtc doctor`.
+///
+/// These checks are informational only: absence of any of these env vars is
+/// perfectly fine for workers that don't use memory or knowledge (RAG), so a
+/// WARN here never flips the overall doctor exit code.
+fn print_knowledge_memory_readiness(locale: &str) {
+    println!();
+    println!(
+        "{}",
+        t_or(
+            locale,
+            "gtc.doctor.knowledge_memory.header",
+            "Knowledge & Memory readiness (for workers that use memory or knowledge, you also need):",
+        )
+    );
+
+    let env = EnvView::from_process_env();
+    for line in knowledge_memory_readiness(&env) {
+        let status_label = match line.status {
+            ReadinessStatus::Ok => t(locale, "gtc.doctor.ok"),
+            ReadinessStatus::Warn => t(locale, "gtc.doctor.warn"),
+        };
+        println!("  {}: {status_label} ({})", line.label, line.detail);
+    }
+}
+
+/// Readiness status for a single [`ReadinessLine`].
+///
+/// Deliberately has no "error"/"fail" variant: knowledge/memory capabilities
+/// are optional, so the worst outcome a missing env var can produce here is a
+/// WARN, never a doctor-exit-code failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReadinessStatus {
+    Ok,
+    Warn,
+}
+
+/// One reported line of the knowledge/memory readiness section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ReadinessLine {
+    pub(super) label: &'static str,
+    pub(super) status: ReadinessStatus,
+    pub(super) detail: String,
+}
+
+/// A minimal, injectable view over environment variables.
+///
+/// Keeps [`knowledge_memory_readiness`] pure and unit-testable: production
+/// code builds an [`EnvView`] from the real process environment once, and
+/// tests build one from an in-memory map without mutating `std::env`.
+pub(super) struct EnvView {
+    vars: HashMap<String, String>,
+}
+
+impl EnvView {
+    pub(super) fn from_process_env() -> Self {
+        Self {
+            vars: env::vars().collect(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn from_pairs<I, K, V>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self {
+            vars: pairs
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        }
+    }
+
+    fn is_set(&self, key: &str) -> bool {
+        self.vars.get(key).is_some_and(|value| !value.is_empty())
+    }
+
+    fn has_prefix(&self, prefix: &str) -> bool {
+        self.vars
+            .iter()
+            .any(|(key, value)| key.starts_with(prefix) && !value.is_empty())
+    }
+}
+
+/// Pure readiness logic for the "Knowledge & Memory readiness" doctor section.
+///
+/// Reports on three independent runtime capabilities that only work on a
+/// knowledge-enabled runner build (`runner-full`, built with the
+/// `knowledge-chronicle` / `long-term-chronicle` cargo features):
+/// short-term agent state, RAG embedding config, and long-term (Chronicle)
+/// memory. None of these are required for workers that don't use memory or
+/// knowledge, so every line here is OK/WARN, never a hard failure.
+pub(super) fn knowledge_memory_readiness(env: &EnvView) -> Vec<ReadinessLine> {
+    vec![
+        short_term_memory_readiness(env),
+        knowledge_embedding_readiness(env),
+        long_term_memory_readiness(env),
+    ]
+}
+
+const AW_REDIS_URL_KEY: &str = "GREENTIC_AW_REDIS_URL";
+
+fn short_term_memory_readiness(env: &EnvView) -> ReadinessLine {
+    if env.is_set(AW_REDIS_URL_KEY) {
+        ReadinessLine {
+            label: "Short-term memory / agent state",
+            status: ReadinessStatus::Ok,
+            detail: format!(
+                "{AW_REDIS_URL_KEY} is set; dw.agent short-term state can persist on a server."
+            ),
+        }
+    } else {
+        ReadinessLine {
+            label: "Short-term memory / agent state",
+            status: ReadinessStatus::Warn,
+            detail: format!(
+                "{AW_REDIS_URL_KEY} is not set. Workers using dw.agent short-term state need \
+                 it on a server; for local runs, the desktop-agent-ephemeral no-infra \
+                 alternative works without it."
+            ),
+        }
+    }
+}
+
+const KNOWLEDGE_EMBED_KEYS: [&str; 3] = [
+    "GREENTIC_KNOWLEDGE_EMBED_BASE_URL",
+    "GREENTIC_KNOWLEDGE_EMBED_API_KEY",
+    "GREENTIC_KNOWLEDGE_EMBED_MODEL",
+];
+
+fn knowledge_embedding_readiness(env: &EnvView) -> ReadinessLine {
+    let missing: Vec<&str> = KNOWLEDGE_EMBED_KEYS
+        .into_iter()
+        .filter(|key| !env.is_set(key))
+        .collect();
+
+    if missing.is_empty() {
+        ReadinessLine {
+            label: "Knowledge / RAG (embedding)",
+            status: ReadinessStatus::Ok,
+            detail: "embedding configuration is complete.".to_string(),
+        }
+    } else {
+        ReadinessLine {
+            label: "Knowledge / RAG (embedding)",
+            status: ReadinessStatus::Warn,
+            detail: format!(
+                "missing {}. Knowledge retrieval will be inactive until these are set and the \
+                 runner is built with the knowledge-chronicle feature (runner-full).",
+                missing.join(", ")
+            ),
+        }
+    }
+}
+
+const CHRONICLE_PREFIX: &str = "GREENTIC_CHRONICLE_";
+
+fn long_term_memory_readiness(env: &EnvView) -> ReadinessLine {
+    if env.has_prefix(CHRONICLE_PREFIX) {
+        ReadinessLine {
+            label: "Long-term memory (Chronicle)",
+            status: ReadinessStatus::Ok,
+            detail: format!("{CHRONICLE_PREFIX}* configuration detected."),
+        }
+    } else {
+        ReadinessLine {
+            label: "Long-term memory (Chronicle)",
+            status: ReadinessStatus::Warn,
+            detail: format!(
+                "no {CHRONICLE_PREFIX}* variables set. Long-term memory needs a \
+                 long-term-chronicle-enabled runner build (runner-full) plus this environment."
+            ),
+        }
+    }
 }
 
 fn print_installed_release_artifacts() -> GtcResult<()> {
@@ -643,5 +825,122 @@ mod tests {
     #[test]
     fn is_greentic_companion_binary_recognizes_greentic_dw() {
         assert!(is_greentic_companion_binary("greentic-dw"));
+    }
+
+    use super::{EnvView, ReadinessStatus, knowledge_memory_readiness};
+
+    #[test]
+    fn knowledge_memory_readiness_all_set_reports_ok() {
+        let env = EnvView::from_pairs([
+            ("GREENTIC_AW_REDIS_URL", "redis://localhost:6379"),
+            (
+                "GREENTIC_KNOWLEDGE_EMBED_BASE_URL",
+                "https://embed.example.com",
+            ),
+            ("GREENTIC_KNOWLEDGE_EMBED_API_KEY", "secret"),
+            ("GREENTIC_KNOWLEDGE_EMBED_MODEL", "text-embedding-3-small"),
+            ("GREENTIC_CHRONICLE_URL", "https://chronicle.example.com"),
+        ]);
+
+        let lines = knowledge_memory_readiness(&env);
+
+        assert_eq!(lines.len(), 3);
+        assert!(
+            lines.iter().all(|line| line.status == ReadinessStatus::Ok),
+            "expected all lines OK, got: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn knowledge_memory_readiness_missing_embedding_vars_warns_with_names_and_runner_full() {
+        let env =
+            EnvView::from_pairs([("GREENTIC_KNOWLEDGE_EMBED_MODEL", "text-embedding-3-small")]);
+
+        let lines = knowledge_memory_readiness(&env);
+
+        let embedding_line = lines
+            .iter()
+            .find(|line| line.label == "Knowledge / RAG (embedding)")
+            .expect("embedding readiness line present");
+
+        assert_eq!(embedding_line.status, ReadinessStatus::Warn);
+        assert!(
+            embedding_line
+                .detail
+                .contains("GREENTIC_KNOWLEDGE_EMBED_BASE_URL"),
+            "detail should name the missing base-url var: {}",
+            embedding_line.detail
+        );
+        assert!(
+            embedding_line
+                .detail
+                .contains("GREENTIC_KNOWLEDGE_EMBED_API_KEY"),
+            "detail should name the missing api-key var: {}",
+            embedding_line.detail
+        );
+        assert!(
+            !embedding_line
+                .detail
+                .contains("GREENTIC_KNOWLEDGE_EMBED_MODEL"),
+            "detail should not name a var that is set: {}",
+            embedding_line.detail
+        );
+        assert!(
+            embedding_line.detail.contains("runner-full"),
+            "detail should mention the runner-full build requirement: {}",
+            embedding_line.detail
+        );
+    }
+
+    #[test]
+    fn knowledge_memory_readiness_missing_redis_warns_with_ephemeral_alternative() {
+        let empty_pairs: [(&str, &str); 0] = [];
+        let env = EnvView::from_pairs(empty_pairs);
+
+        let lines = knowledge_memory_readiness(&env);
+
+        let short_term_line = lines
+            .iter()
+            .find(|line| line.label == "Short-term memory / agent state")
+            .expect("short-term readiness line present");
+
+        assert_eq!(short_term_line.status, ReadinessStatus::Warn);
+        assert!(
+            short_term_line.detail.contains("GREENTIC_AW_REDIS_URL"),
+            "detail should name the missing var: {}",
+            short_term_line.detail
+        );
+        assert!(
+            short_term_line.detail.contains("desktop-agent-ephemeral"),
+            "detail should mention the no-infra alternative: {}",
+            short_term_line.detail
+        );
+    }
+
+    #[test]
+    fn knowledge_memory_readiness_missing_chronicle_vars_warns_with_long_term_chronicle_build() {
+        let env = EnvView::from_pairs([
+            ("GREENTIC_AW_REDIS_URL", "redis://localhost:6379"),
+            (
+                "GREENTIC_KNOWLEDGE_EMBED_BASE_URL",
+                "https://embed.example.com",
+            ),
+            ("GREENTIC_KNOWLEDGE_EMBED_API_KEY", "secret"),
+            ("GREENTIC_KNOWLEDGE_EMBED_MODEL", "text-embedding-3-small"),
+        ]);
+
+        let lines = knowledge_memory_readiness(&env);
+
+        let chronicle_line = lines
+            .iter()
+            .find(|line| line.label == "Long-term memory (Chronicle)")
+            .expect("chronicle readiness line present");
+
+        assert_eq!(chronicle_line.status, ReadinessStatus::Warn);
+        assert!(
+            chronicle_line.detail.contains("long-term-chronicle"),
+            "detail should mention the long-term-chronicle build requirement: {}",
+            chronicle_line.detail
+        );
     }
 }

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -5,7 +5,7 @@ use gtc::perf_targets::{
     rewrite_legacy_op_args as perf_rewrite_legacy_op_args,
 };
 
-use super::{DEV_BIN, OP_BIN, SETUP_BIN};
+use super::{DEV_BIN, DW_BIN, OP_BIN, SETUP_BIN};
 use crate::extensions::has_extension_flags;
 use crate::i18n_support::i18n;
 
@@ -66,6 +66,7 @@ pub(super) fn route_passthrough_subcommand(
         "op" => Some((OP_BIN, rewrite_legacy_op_args(tail))),
         "setup" => Some((SETUP_BIN, tail.to_vec())),
         "wizard" => Some((DEV_BIN, build_wizard_args(tail, locale))),
+        "worker" => Some((DW_BIN, tail.to_vec())),
         _ => None,
     }
 }

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -66,9 +66,18 @@ pub(super) fn route_passthrough_subcommand(
         "op" => Some((OP_BIN, rewrite_legacy_op_args(tail))),
         "setup" => Some((SETUP_BIN, tail.to_vec())),
         "wizard" => Some((DEV_BIN, build_wizard_args(tail, locale))),
-        "worker" => Some((DW_BIN, tail.to_vec())),
+        "worker" => Some((DW_BIN, build_worker_args(tail))),
         _ => None,
     }
+}
+
+/// Forward `gtc worker <args>` to `greentic-dw worker <args>` — the `worker`
+/// token must be re-added because `route_passthrough_subcommand` strips it
+/// (mirrors `build_wizard_args`, which re-adds `wizard`).
+pub(super) fn build_worker_args(args: &[String]) -> Vec<String> {
+    let mut forwarded = vec!["worker".to_string()];
+    forwarded.extend_from_slice(args);
+    forwarded
 }
 
 fn rewrite_legacy_op_args(args: &[String]) -> Vec<String> {

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -247,7 +247,15 @@ fn route_passthrough_subcommand_routes_worker_to_greentic_dw() {
     let (binary, args) = route_passthrough_subcommand("worker", &tail, "en").expect("worker route");
 
     assert_eq!(binary, DW_BIN);
-    assert_eq!(args, vec!["build".to_string(), "s.yaml".to_string()]);
+    // the `worker` token must be re-added so greentic-dw sees `worker build s.yaml`
+    assert_eq!(
+        args,
+        vec![
+            "worker".to_string(),
+            "build".to_string(),
+            "s.yaml".to_string()
+        ]
+    );
 }
 
 #[test]

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    AdminRegistryDocument, DEV_BIN, FLOW_BIN, StartTarget, admin_registry_path, build_cli,
+    AdminRegistryDocument, DEV_BIN, DW_BIN, FLOW_BIN, StartTarget, admin_registry_path, build_cli,
     build_wizard_args, collect_tail, default_install_channel_for_invocation, detect_bundle_root,
     detect_locale, ensure_admin_certs_ready, extract_tar_archive, fingerprint_bundle_dir,
     locale_from_args, normalize_bundle_fingerprint, normalize_expected_sha256,
@@ -239,6 +239,15 @@ fn route_passthrough_subcommand_routes_wizard_to_greentic_dev() {
             "--help".to_string()
         ]
     );
+}
+
+#[test]
+fn route_passthrough_subcommand_routes_worker_to_greentic_dw() {
+    let tail = vec!["build".to_string(), "s.yaml".to_string()];
+    let (binary, args) = route_passthrough_subcommand("worker", &tail, "en").expect("worker route");
+
+    assert_eq!(binary, DW_BIN);
+    assert_eq!(args, vec!["build".to_string(), "s.yaml".to_string()]);
 }
 
 #[test]


### PR DESCRIPTION
Adds the **`gtc worker`** subcommand (target **1.1.2**): a pass-through to the `greentic-dw` binary that authors all three agentic-worker types (single_turn / agent_graph / deep_worker) — including memory and knowledge — into a runner-loadable `.gtpack`.

This PR is the **gtc-routing slice** only (Group 4 of the plan): `gtc worker <args>` → `greentic-dw worker <args>` via `DW_BIN` + `build_worker_args` (mirrors the `gtc wizard` → `greentic-dev` pattern). No agent logic lives in gtc.

Also includes the feature **design spec** and **Slice 1 implementation plan** under `docs/superpowers/`.

### Depends on
The `greentic-dw worker` implementation (separate greentic-dw PR) + the new `greentic-dw-authoring` crate. `gtc worker` is a runtime pass-through, so this compiles and tests independently, but the end-to-end feature needs `greentic-dw` ≥ the worker release. **Do not merge until the greentic-dw side lands** so a released `gtc worker` has a real target.

### Verification
`cargo test -p gtc` green (router + integration). End-to-end smoke (built gtc + greentic-dw locally): `gtc worker init/validate/build` produces runner-loadable packs for all three kinds — this caught and fixed a routing bug (stripped `worker` token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)