### PR TITLE
Forward --no-updates to greentic-start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -612,6 +612,7 @@ mod tests {
             verbose: false,
             quiet: false,
             no_browser: false,
+            no_updates: false,
             admin: false,
             admin_port: 8443,
             admin_certs_dir: None,

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -24,7 +24,7 @@ const START_USAGE: &str = "usage: gtc start [BUNDLE_REF] [start flags...]\n\
               --deploy-bundle-source <src> --upload-bundle <url> --upload-bundle-presign-expires <secs>\n\
               --extension-start-handoff <path>\n\
   runtime flags are forwarded to greentic-start (e.g. --env, --tenant, --team, --nats, --cloudflared, --ngrok,\n\
-  --admin, --restart, --verbose, --quiet); see `greentic-start start --help` for the full list";
+  --admin, --restart, --verbose, --quiet, --no-updates); see `greentic-start start --help` for the full list";
 
 const STOP_USAGE: &str = "usage: gtc stop [BUNDLE_REF] [stop flags...]\n\
   BUNDLE_REF: bundle to stop (omit to stop the active env's serving runtime)\n\
@@ -951,6 +951,7 @@ mod tests {
             team: Some("ops".to_string()),
             no_nats: false,
             no_browser: true,
+            no_updates: false,
             nats: NatsModeArg::External,
             nats_url: Some("nats://demo".to_string()),
             config: Some(PathBuf::from("/tmp/config.yaml")),
@@ -989,6 +990,27 @@ mod tests {
         assert!(args.contains(&"--no-browser".to_string()));
         assert!(args.contains(&"ops,local".to_string()));
         assert!(args.contains(&"gateway,nats".to_string()));
+        assert!(
+            !args.contains(&"--no-updates".to_string()),
+            "the updater is on unless the operator opts out"
+        );
+    }
+
+    #[test]
+    fn no_updates_round_trips_through_parse_and_serialize() {
+        // `gtc start` re-parses its tail by hand — a flag that is not in both
+        // `parse_start_request` and `to_runtime_start_args` silently vanishes
+        // before greentic-start ever sees it.
+        let tail = vec!["--no-updates".to_string()];
+        let request =
+            parse_start_request(&tail, PathBuf::from("/tmp/bundle")).expect("--no-updates parses");
+        assert!(request.no_updates);
+        assert!(
+            request
+                .to_runtime_start_args("en")
+                .contains(&"--no-updates".to_string())
+        );
+        assert!(!start_flag_takes_value("--no-updates"));
     }
 
     #[test]
@@ -1178,6 +1200,7 @@ mod tests {
         for flag in [
             "--no-nats",
             "--no-browser",
+            "--no-updates",
             "--verbose",
             "--quiet",
             "--admin",

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -42,6 +42,10 @@ pub struct StartRequest {
     pub team: Option<String>,
     pub no_nats: bool,
     pub no_browser: bool,
+    /// Forwarded as `--no-updates`: opts the runtime out of its environment's
+    /// update channel on this box. A kill switch, not a policy change — the
+    /// env's `update-channel.json` is untouched.
+    pub no_updates: bool,
     pub nats: NatsModeArg,
     pub nats_url: Option<String>,
     pub config: Option<PathBuf>,
@@ -100,6 +104,9 @@ impl StartRequest {
         }
         if self.no_browser {
             args.push("--no-browser".to_string());
+        }
+        if self.no_updates {
+            args.push("--no-updates".to_string());
         }
         args.push("--nats".to_string());
         args.push(self.nats.as_cli_value().to_string());
@@ -213,6 +220,7 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
         team: None,
         no_nats: false,
         no_browser: false,
+        no_updates: false,
         nats: NatsModeArg::Off,
         nats_url: None,
         config: None,
@@ -250,6 +258,7 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
             }
             "--no-nats" => request.no_nats = true,
             "--no-browser" => request.no_browser = true,
+            "--no-updates" => request.no_updates = true,
             "--nats" => {
                 idx += 1;
                 request.nats = parse_nats_mode(&required_value(tail, idx, "--nats")?)?;


### PR DESCRIPTION
Fifth PR in the demo-simplification train.

`gtc start` re-parses its tail by hand (`parse_start_request` →
`to_runtime_start_args`) — there is no passthrough. A flag missing from
either half silently vanishes before `greentic-start` ever sees it, which is
what the new round-trip test pins down.

`--no-updates` opts the runtime out of its environment's update channel on
this box: no poll loop, and `/v1/updates/notify` is not reserved. It is a
kill switch, not a policy knob — the env's `update-channel.json` is
untouched, so a restart without the flag resumes whatever the operator
declared.

## Merge order

Requires `greentic-start >= 1.1.9`
([greentic-start#361](https://github.com/greenticai/greentic-start/pull/361)),
which is where the flag is consumed. Merging this first would let
`gtc start --no-updates` reach a 1.1.8 binary that rejects the flag. **Hold
until start 1.1.9 is published.**

## Verification

```
cargo fmt --all --check     # clean
cargo clippy --lib --bins --tests --all-features -- -D warnings   # exit 0
cargo test --lib --bins     # 32 passed + 375 passed; 0 failed
```

`ci/local_check.sh` cannot run to completion on this machine: `cargo build
--bench perf` fails to link (`mold: undefined symbol: c_with_alloca`). That
reproduces on an unmodified `origin/main` checkout, so it is a local
toolchain issue, not this change. Everything the gate runs before the bench
is green above.
