### PR TITLE
ci: force-reinstall binstall tools in nightly coverage

### DIFF
--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -35,9 +35,15 @@ jobs:
 
       - name: Install coverage toolchain
         run: |
-          cargo binstall -y cargo-llvm-cov
-          cargo binstall -y cargo-nextest
-          cargo binstall -y greentic-dev
+          # rust-cache restores ~/.cargo/.crates.toml but prunes ~/.cargo/bin of
+          # binstall-installed binaries, so binstall says "already installed"
+          # while the binary is gone. --force sidesteps that.
+          cargo binstall -y --force cargo-llvm-cov
+          cargo binstall -y --force cargo-nextest
+          cargo binstall -y --force greentic-dev
+          command -v cargo-llvm-cov
+          command -v cargo-nextest
+          greentic-dev --version
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview


### PR DESCRIPTION
## Problem

Nightly Coverage on `main` failed with exit 127:

```
/home/runner/work/_temp/….sh: line 1: greentic-dev: command not found
```

([run 29073375803](https://github.com/greenticai/greentic/actions/runs/29073375803))

The `Install coverage toolchain` step reported **success** — it just didn't install anything:

```
INFO resolve: greentic-dev v1.1.2 is already installed, use --force to override
```

## Root cause

`Swatinem/rust-cache@v2` caches `~/.cargo/bin` **together with** `~/.cargo/.crates.toml`. Before saving, its `cleanBin()` deletes every file in `~/.cargo/bin` that is not recorded in `~/.cargo/.crates2.json`. `cargo-binstall` writes `.crates.toml` and its own `binstall/crates-v1.json`, but **never** `.crates2.json` — so the cache is saved with the install *record* intact and the *binaries* pruned.

The two runs bracket it exactly:

| Run | Cache | binstall | Result |
|---|---|---|---|
| [2026-07-09](https://github.com/greenticai/greentic/actions/runs/28998247609) | `No cache found.` | `greentic-dev => /home/runner/.cargo/bin/greentic-dev` | pass, poisoned cache saved |
| [2026-07-10](https://github.com/greenticai/greentic/actions/runs/29073375803) | `Cache hit … full match: true` | `already installed, use --force` | `command not found`, exit 127 |

Nothing regressed in the coverage policy or the test suite — the gate never ran.

## Fix

`--force` the three binstall targets and assert they are on `PATH`, so a failed install dies at the install step rather than as a phantom coverage failure. This is the same fix already carried by `greentic-deployer`, `greentic-bundle`, `greentic-setup`, `greentic-pack`, `greentic-operala` and `greentic-distributor-client`.

## Verification

`nightly-coverage.yml` dispatched on this branch — it restores the same poisoned cache from `main`, so it reproduces the failure conditions directly.
