### PR TITLE
feat(start): add `gtc start k8s` sugar for `op env up` (1.1.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -52,6 +52,9 @@ use commands::default_install_channel_for_invocation;
 use commands::run;
 #[cfg(test)]
 #[allow(unused_imports)]
+use commands::start_k8s_rewrite;
+#[cfg(test)]
+#[allow(unused_imports)]
 use deploy::resolve_local_mutable_bundle_dir;
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -843,7 +843,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.start.about",
                     "Start a bundle from local or remote reference.",
                 ))
-                .after_help("Use `gtc start k8s [FLAGS]` to provision a local Kind cluster and deploy an environment via `op env up`. All flags (including --answers) are forwarded to the operator.")
+                .after_help("Use `gtc start k8s [FLAGS]` to provision a local Kind cluster and deploy an environment via `op env up`. All flags (including --answers) are forwarded to the operator. Only the exact first token `k8s` is reserved: a bundle of that name is still reachable by path (`./k8s`).")
                 .arg(cmd_args.clone()),
         )
         .subcommand(

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -843,6 +843,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.start.about",
                     "Start a bundle from local or remote reference.",
                 ))
+                .after_help("Use `gtc start k8s [FLAGS]` to provision a local Kind cluster and deploy an environment via `op env up`. All flags (including --answers) are forwarded to the operator.")
                 .arg(cmd_args.clone()),
         )
         .subcommand(

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -112,7 +112,12 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 Ok(Some((handoff_path, rest))) => {
                     run_extension_start(&handoff_path, &rest, debug, &locale)
                 }
-                Ok(None) => run_start(&tail, debug, &locale),
+                Ok(None) => {
+                    if let Some(args) = start_k8s_rewrite(&tail) {
+                        return passthrough(super::OP_BIN, &args, debug, &locale);
+                    }
+                    run_start(&tail, debug, &locale)
+                }
                 Err(err) => {
                     eprintln!("{err}");
                     2
@@ -585,6 +590,18 @@ fn json_pointer_path(path: &[String]) -> String {
 
 fn escape_json_pointer_segment(segment: &str) -> String {
     segment.replace('~', "~0").replace('/', "~1")
+}
+
+/// Detect a leading `k8s` token in a `start` tail and rewrite it into an
+/// operator `env up` invocation. Returns `None` when the tail does not begin
+/// with `k8s` (a flag-prefixed tail like `["--answers", "k8s"]` is not a match).
+pub(super) fn start_k8s_rewrite(tail: &[String]) -> Option<Vec<String>> {
+    if tail.first().map(String::as_str) != Some("k8s") {
+        return None;
+    }
+    let mut args = vec!["op".to_string(), "env".to_string(), "up".to_string()];
+    args.extend_from_slice(&tail[1..]);
+    Some(args)
 }
 
 fn run_help(sub_matches: &ArgMatches, locale: &str) -> i32 {

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -112,12 +112,10 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 Ok(Some((handoff_path, rest))) => {
                     run_extension_start(&handoff_path, &rest, debug, &locale)
                 }
-                Ok(None) => {
-                    if let Some(args) = start_k8s_rewrite(&tail) {
-                        return passthrough(super::OP_BIN, &args, debug, &locale);
-                    }
-                    run_start(&tail, debug, &locale)
-                }
+                Ok(None) => match start_k8s_rewrite(&tail) {
+                    Some(args) => passthrough(super::OP_BIN, &args, debug, &locale),
+                    None => run_start(&tail, debug, &locale),
+                },
                 Err(err) => {
                     eprintln!("{err}");
                     2

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -10,8 +10,8 @@ use super::{
     resolve_deploy_app_pack_path, resolve_local_mutable_bundle_dir, resolve_target_provider_pack,
     resolve_tenant_key, rewrite_store_tenant_placeholder, route_passthrough_subcommand,
     run_admin_access, run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry,
-    select_start_target, should_send_auth_header, tenant_env_var_name, upsert_admin_registry_entry,
-    verify_sha256_digest,
+    select_start_target, should_send_auth_header, start_k8s_rewrite, tenant_env_var_name,
+    upsert_admin_registry_entry, verify_sha256_digest,
 };
 #[cfg(unix)]
 use super::{apply_default_deploy_env_for_target, extract_zip_bytes, validate_cloud_deploy_inputs};
@@ -1813,6 +1813,56 @@ fn fingerprint_bundle_dir_skips_symlink_cycles() {
 
     assert!(fingerprint.contains("file:packs/cards-demo.gtpack"));
     assert!(!fingerprint.contains("loop"));
+}
+
+#[test]
+fn start_k8s_rewrite_rewrites_leading_k8s_token() {
+    let tail = vec!["k8s".to_string()];
+    let rewritten = start_k8s_rewrite(&tail).expect("should rewrite");
+    assert_eq!(
+        rewritten,
+        vec!["op".to_string(), "env".to_string(), "up".to_string()]
+    );
+}
+
+#[test]
+fn start_k8s_rewrite_does_not_rewrite_k8s_after_flag() {
+    let tail = vec!["--answers".to_string(), "k8s".to_string()];
+    assert!(start_k8s_rewrite(&tail).is_none());
+}
+
+#[test]
+fn start_k8s_rewrite_returns_none_without_k8s() {
+    let tail = vec!["my-bundle.gtbundle".to_string()];
+    assert!(start_k8s_rewrite(&tail).is_none());
+}
+
+#[test]
+fn start_k8s_rewrite_returns_none_for_empty_tail() {
+    let tail: Vec<String> = vec![];
+    assert!(start_k8s_rewrite(&tail).is_none());
+}
+
+#[test]
+fn start_k8s_rewrite_preserves_trailing_flags_in_order() {
+    let tail = vec![
+        "k8s".to_string(),
+        "--answers".to_string(),
+        "/tmp/answers.json".to_string(),
+        "--dry-run".to_string(),
+    ];
+    let rewritten = start_k8s_rewrite(&tail).expect("should rewrite");
+    assert_eq!(
+        rewritten,
+        vec![
+            "op".to_string(),
+            "env".to_string(),
+            "up".to_string(),
+            "--answers".to_string(),
+            "/tmp/answers.json".to_string(),
+            "--dry-run".to_string(),
+        ]
+    );
 }
 
 struct HttpRequest {

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -1837,6 +1837,19 @@ fn start_k8s_rewrite_returns_none_without_k8s() {
     assert!(start_k8s_rewrite(&tail).is_none());
 }
 
+/// Only the exact token `k8s` is reserved. A bundle named `k8s` stays reachable
+/// through any path form, so the sugar cannot swallow a real bundle ref.
+#[test]
+fn start_k8s_rewrite_leaves_path_form_bundle_refs_to_run_start() {
+    for bundle_ref in ["./k8s", "k8s/", "k8s.gtbundle", "/opt/bundles/k8s", "K8s"] {
+        let tail = vec![bundle_ref.to_string()];
+        assert!(
+            start_k8s_rewrite(&tail).is_none(),
+            "`{bundle_ref}` must reach run_start as a bundle ref"
+        );
+    }
+}
+
 #[test]
 fn start_k8s_rewrite_returns_none_for_empty_tail() {
     let tail: Vec<String> = vec![];


### PR DESCRIPTION
## What

`gtc start k8s --answers env.json --yes` → `greentic-operator op env up --answers env.json --yes`.

Thin sugar over the new `op env up` verb (greenticai/greentic-deployer#446). Release 1 of
`plans/one-command-k8s-deployment.md`. Targets stable `main` deliberately.

## Why the interception sits exactly where it does

`start` is **not** a passthrough — it has its own orchestration (bundle resolution, `StartTarget`,
admin certs) and eventually spawns `greentic-start`, not the operator. Two constraints pin the
placement inside the `("start", _)` arm:

- **After `take_extension_start_handoff`.** That path requires an explicit
  `--extension-start-handoff <path>` flag, so a bare `k8s` token can never trigger it — checking
  handoff first is safe and keeps extension starts working.
- **Before `run_start`.** `parse_start_cli_options` treats any non-flag token as a positional
  `bundle_ref`, so `k8s` reaching `run_start` would be resolved as a bundle and fail.

`start`'s clap definition is a pure `trailing_var_arg` catch-all, so `k8s` arrives in the tail intact.

## Scope

- `gtc op env up` **already works** today via the existing `op` passthrough
  (`rewrite_legacy_op_args` sends `env` through its default branch), so
  `route_passthrough_subcommand` is untouched.
- gtc has **no** Cargo dependency on the deployer or operator — it spawns them as binaries — so there
  is no dep bump here. The verb does require `greentic-operator` to be rebuilt against
  `greentic-deployer` 1.1.11, which is a separate PR.
- `--answers` is forwarded **raw**; the `start` arm does no answers-file resolution (only
  `wizard | setup` does), and the operator resolves it.

## Tests

The rewrite is a pure function (`start_k8s_rewrite`), so the routing rules are unit-tested directly
rather than through a spawn:

- leading `k8s` rewrites to `["op", "env", "up", ...]`
- `k8s` **after** a flag does not rewrite (`["--answers", "k8s"]` is a value, not the verb)
- no `k8s` ⇒ `None` (falls through to `run_start` unchanged)
- empty tail ⇒ `None`
- trailing flags preserved in order

## Verification

`cargo fmt --all -- --check` ✓ · `cargo clippy --all-targets --all-features -- -D warnings` ✓ ·
`cargo test --all` ✓ (475 tests, 0 failures) · `cargo publish --dry-run --allow-dirty` ✓ at 1.1.4 ·
`ci/validate_doc_examples.sh` ✓.

Note: `ci/local_check.sh` step 4 (`cargo test --all-targets`) fails to **link the `perf` bench** on my
machine with `mold: undefined symbol: c_with_alloca`. I reproduced this on a pristine `origin/main`
worktree with zero changes (exit 101), so it is a local linker/`alloca` interaction, not a regression
from this PR. `mold` comes from a user-global `~/.cargo/config.toml`, not repo config.

`ci/local_check.sh` step 1 (`sync_schema_docs.sh`) regenerates `docs/04-schemas/*` against the
*installed* `gtc` binary and produced machine-specific churn (a toolchain-version warning, and a
provenance bump from an already-stale `1.1.1`). That churn is unrelated to this change and is not
included.
