### PR TITLE
feat(provider): add `gtc provider` passthrough to greentic-setup (B4a) (1.1.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -11,6 +11,7 @@
   "gtc.cmd.op.about": "Pass through to greentic-operator.",
   "gtc.cmd.wizard.about": "Open the Greentic wizard menu.",
   "gtc.cmd.setup.about": "Pass through to greentic-setup (bundle lifecycle management).",
+  "gtc.cmd.provider.about": "Manage messaging providers (passthrough to greentic-setup).",
   "gtc.cmd.start.about": "Start a bundle from local or remote reference.",
   "gtc.cmd.stop.about": "Stop a bundle runtime or destroy a deployed environment.",
   "gtc.cmd.add_admin.about": "Register an admin client certificate identity for a local bundle.",

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -953,6 +953,19 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 )
                 .arg(release_context_strict_arg(options_heading))
                 .arg(release_context_ignore_arg(options_heading))
+                .arg(cmd_args.clone()),
+        )
+        .subcommand(
+            Command::new("provider")
+                .help_template(help_template)
+                .subcommand_help_heading(commands_heading)
+                .disable_help_flag(true)
+                .disable_version_flag(true)
+                .about(t_or(
+                    locale,
+                    "gtc.cmd.provider.about",
+                    "Manage messaging providers (passthrough to greentic-setup).",
+                ))
                 .arg(cmd_args),
         )
         .subcommand(

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -147,7 +147,7 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 2
             }
         },
-        Some((name @ ("dev" | "op" | "wizard" | "setup" | "worker"), sub_matches)) => {
+        Some((name @ ("dev" | "op" | "wizard" | "setup" | "worker" | "provider"), sub_matches)) => {
             let tail = collect_tail(sub_matches);
             let tail = if matches!(name, "wizard" | "setup") {
                 let release_context =

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -72,22 +72,20 @@ pub(super) fn route_passthrough_subcommand(
     }
 }
 
-/// Forward `gtc worker <args>` to `greentic-dw worker <args>` — the `worker`
-/// token must be re-added because `route_passthrough_subcommand` strips it
-/// (mirrors `build_wizard_args`, which re-adds `wizard`).
-pub(super) fn build_worker_args(args: &[String]) -> Vec<String> {
-    let mut forwarded = vec!["worker".to_string()];
+/// Re-add a subcommand token that `route_passthrough_subcommand` strips,
+/// then forward the remaining args verbatim.
+fn prepend_subcommand(token: &str, args: &[String]) -> Vec<String> {
+    let mut forwarded = vec![token.to_string()];
     forwarded.extend_from_slice(args);
     forwarded
 }
 
-/// Forward `gtc provider <args>` to `greentic-setup provider <args>` — the
-/// `provider` token must be re-added because `route_passthrough_subcommand`
-/// strips it (mirrors `build_worker_args`).
+pub(super) fn build_worker_args(args: &[String]) -> Vec<String> {
+    prepend_subcommand("worker", args)
+}
+
 pub(super) fn build_provider_args(args: &[String]) -> Vec<String> {
-    let mut forwarded = vec!["provider".to_string()];
-    forwarded.extend_from_slice(args);
-    forwarded
+    prepend_subcommand("provider", args)
 }
 
 fn rewrite_legacy_op_args(args: &[String]) -> Vec<String> {

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -67,6 +67,7 @@ pub(super) fn route_passthrough_subcommand(
         "setup" => Some((SETUP_BIN, tail.to_vec())),
         "wizard" => Some((DEV_BIN, build_wizard_args(tail, locale))),
         "worker" => Some((DW_BIN, build_worker_args(tail))),
+        "provider" => Some((SETUP_BIN, build_provider_args(tail))),
         _ => None,
     }
 }
@@ -76,6 +77,15 @@ pub(super) fn route_passthrough_subcommand(
 /// (mirrors `build_wizard_args`, which re-adds `wizard`).
 pub(super) fn build_worker_args(args: &[String]) -> Vec<String> {
     let mut forwarded = vec!["worker".to_string()];
+    forwarded.extend_from_slice(args);
+    forwarded
+}
+
+/// Forward `gtc provider <args>` to `greentic-setup provider <args>` — the
+/// `provider` token must be re-added because `route_passthrough_subcommand`
+/// strips it (mirrors `build_worker_args`).
+pub(super) fn build_provider_args(args: &[String]) -> Vec<String> {
+    let mut forwarded = vec!["provider".to_string()];
     forwarded.extend_from_slice(args);
     forwarded
 }

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -1,17 +1,18 @@
 use super::{
-    AdminRegistryDocument, DEV_BIN, DW_BIN, FLOW_BIN, StartTarget, admin_registry_path, build_cli,
-    build_wizard_args, collect_tail, default_install_channel_for_invocation, detect_bundle_root,
-    detect_locale, ensure_admin_certs_ready, extract_tar_archive, fingerprint_bundle_dir,
-    locale_from_args, normalize_bundle_fingerprint, normalize_expected_sha256,
-    normalize_install_arch, parse_prompt_choice, parse_start_cli_options, parse_start_request,
-    parse_stop_cli_options, parse_stop_request, remove_admin_registry_entry,
-    resolve_admin_cert_dir, resolve_canonical_target_provider_pack_from,
-    resolve_companion_binary_from, resolve_companion_binary_from_invocation,
-    resolve_deploy_app_pack_path, resolve_local_mutable_bundle_dir, resolve_target_provider_pack,
-    resolve_tenant_key, rewrite_store_tenant_placeholder, route_passthrough_subcommand,
-    run_admin_access, run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry,
-    select_start_target, should_send_auth_header, start_k8s_rewrite, tenant_env_var_name,
-    upsert_admin_registry_entry, verify_sha256_digest,
+    AdminRegistryDocument, DEV_BIN, DW_BIN, FLOW_BIN, SETUP_BIN, StartTarget, admin_registry_path,
+    build_cli, build_wizard_args, collect_tail, default_install_channel_for_invocation,
+    detect_bundle_root, detect_locale, ensure_admin_certs_ready, extract_tar_archive,
+    fingerprint_bundle_dir, locale_from_args, normalize_bundle_fingerprint,
+    normalize_expected_sha256, normalize_install_arch, parse_prompt_choice,
+    parse_start_cli_options, parse_start_request, parse_stop_cli_options, parse_stop_request,
+    remove_admin_registry_entry, resolve_admin_cert_dir,
+    resolve_canonical_target_provider_pack_from, resolve_companion_binary_from,
+    resolve_companion_binary_from_invocation, resolve_deploy_app_pack_path,
+    resolve_local_mutable_bundle_dir, resolve_target_provider_pack, resolve_tenant_key,
+    rewrite_store_tenant_placeholder, route_passthrough_subcommand, run_admin_access,
+    run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry, select_start_target,
+    should_send_auth_header, start_k8s_rewrite, tenant_env_var_name, upsert_admin_registry_entry,
+    verify_sha256_digest,
 };
 #[cfg(unix)]
 use super::{apply_default_deploy_env_for_target, extract_zip_bytes, validate_cloud_deploy_inputs};
@@ -254,6 +255,24 @@ fn route_passthrough_subcommand_routes_worker_to_greentic_dw() {
             "worker".to_string(),
             "build".to_string(),
             "s.yaml".to_string()
+        ]
+    );
+}
+
+#[test]
+fn route_passthrough_subcommand_routes_provider_to_greentic_setup() {
+    let tail = vec!["add".to_string(), "telegram".to_string()];
+    let (binary, args) =
+        route_passthrough_subcommand("provider", &tail, "en").expect("provider route");
+
+    assert_eq!(binary, SETUP_BIN);
+    // the `provider` token must be re-added so greentic-setup sees `provider add telegram`
+    assert_eq!(
+        args,
+        vec![
+            "provider".to_string(),
+            "add".to_string(),
+            "telegram".to_string()
         ]
     );
 }

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -665,6 +665,40 @@ fn setup_help_passthrough_routes_to_greentic_setup() {
 }
 
 #[test]
+fn provider_passthrough_routes_to_greentic_setup_with_provider_token() {
+    let sandbox =
+        TestSandbox::new("provider_passthrough_routes_to_greentic_setup_with_provider_token");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(["provider", "add", "telegram"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    // greentic-setup must receive `provider add telegram` — the `provider`
+    // token is re-prepended by the router (same pattern as `worker`).
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["provider", "add", "telegram"]),
+        "expected greentic-setup to receive `provider add telegram`, got: {logged}"
+    );
+}
+
+#[test]
+fn provider_passthrough_preserves_exit_code() {
+    let sandbox = TestSandbox::new("provider_passthrough_preserves_exit_code");
+    sandbox.write_exit_tool("greentic-setup", 42);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(["provider", "list"], HashMap::new());
+    assert_eq!(status.code(), Some(42));
+}
+
+#[test]
 fn op_help_passthrough_routes_to_greentic_operator() {
     let sandbox = TestSandbox::new("op_help_passthrough_routes_to_greentic_operator");
     let log_file = sandbox.path().join("op.log");


### PR DESCRIPTION
Adds a top-level `gtc provider` verb that routes through to the `greentic-setup` binary, exactly like the
existing `dev` / `op` / `wizard` / `setup` / `worker` passthroughs.

greentic-setup **v1.1.14 already implements `provider add|list|remove`** (shipped in greentic-setup#197).
Today there is simply no way to reach it through `gtc` — this PR closes that gap, so
`gtc provider add telegram` works.

Part of the "one bundle, one command" plan
(`plans/one-bundle-one-command-env-backed-start-and-provider-add.md`).

## Scope — deliberately narrow

The plan's original "B4" bundled two changes. **This is only the first half.** It does **not** touch
`start_stop.rs`, and it does **not** reroute `gtc start <bundle>` through `greentic-setup env-deploy`.

That second half (**B4b**) is now gated, because the plan's premise for it was wrong. The plan asserted
*"e2e bypasses `gtc` entirely, so B4 is safe."* That is true of the **Playwright** fixture (which spawns
`greentic-start --config` directly), but **not** of the **shell** e2e suites:

- `greentic-e2e/scripts/run_telemetry_e2e.sh:187` → `gtc start "${E2E_BUNDLE_DIR}"`
- `greentic-e2e/scripts/run_agentic_e2e.sh:159` → `gtc start "${E2E_BUNDLE_DIR}"`
- plus several `provider-e2e.yml` steps

Rerouting `gtc start <bundle>` onto the revision runtime **before** static-asset (A.3), DirectLine (A.4) and
WebSocket (A.5) parity lands would boot those suites onto a runtime that cannot serve them. B4b is therefore
blocked on A.5 + the e2e migration (A.8).

## Changes

Follows the `gtc worker` → `greentic-dw` passthrough pattern exactly:

- `router.rs` — `"provider"` arm in `route_passthrough_subcommand` → `SETUP_BIN`, re-prepending the
  `provider` token (same shape as `build_worker_args`).
- `commands.rs:150` — `"provider"` added to the passthrough match arm. (The plan said line 147; that is a
  literal `2` exit code. The real arm is 150.)
- `cli.rs` — the `provider` subcommand with trailing var-arg passthrough.
- `assets/i18n/en.json` — `gtc.cmd.provider.about`.

## Tests

- `route_passthrough_subcommand_routes_provider_to_greentic_setup` (unit) — asserts the contract: subcommand
  `provider` + tail `[add, telegram]` → `(SETUP_BIN, [provider, add, telegram])`. Fails before: the router
  returns `None` for `provider`.
- `provider_passthrough_routes_to_greentic_setup_with_provider_token` (integration) — a fake arg-logging
  `greentic-setup` binary; asserts it actually receives `provider add telegram`. Fails before: clap rejects
  `provider` as unknown (exit 2), and the setup binary is never invoked.
- `provider_passthrough_preserves_exit_code` (integration) — exit code 42 survives the passthrough.

## Known gap (pre-existing, not introduced here)

**No companion-binary version negotiation exists in `gtc`, for any verb.** A user who upgrades `gtc` but
still has greentic-setup < 1.1.14 will get a raw clap "unrecognized subcommand" error emitted by
greentic-setup — confusing, and it looks like a `gtc` bug. `process.rs:199-214` handles binary-*missing*
cleanly but not binary-*too-old*.

None of `dev` / `op` / `wizard` / `setup` / `worker` version-check either, so inventing a mechanism for
`provider` alone would be inconsistent and is unrequested scope. Flagging it as a follow-up rather than
solving it here.

## Verification

`ci/local_check.sh` aborts at step [4/6] on a **pre-existing** linker error in the `perf` bench target
(`mold: error: undefined symbol: c_with_alloca`) — confirmed pre-existing by reproducing it on the
unmodified base commit (v1.1.4). Every substantive step was therefore run individually:

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy --all-targets --all-features -- -D warnings` → exit 0
- `cargo test --lib --bins --tests --all-features --no-fail-fast` → **61 passed; 0 failed**
- `cargo publish --dry-run` → exit 0

Lane: `main` (stable). Version 1.1.4 → **1.1.5**, `Cargo.lock` refreshed in the same commit.
