### PR TITLE
feat(start): route `gtc start <bundle>` through the environment (B4b) (1.1.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.5"
+version = "1.1.6"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -4,9 +4,8 @@ use std::path::{Path, PathBuf};
 
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{
-    StartRequest, parse_runtime_config_start_request, parse_runtime_config_stop_request,
-    parse_start_request, parse_stop_request, required_value, start_flag_takes_value,
-    stop_flag_takes_value,
+    parse_runtime_config_start_request, parse_runtime_config_stop_request, parse_start_request,
+    parse_stop_request, required_value, start_flag_takes_value, stop_flag_takes_value,
 };
 use serde::Deserialize;
 
@@ -279,7 +278,7 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
     // which is where static assets, DirectLine, WebSocket and CORS live. The
     // env is created on demand (greentic-start bootstraps it), and the webchat
     // GUI is on by default for `local`.
-    let env_id = resolve_start_env(&request);
+    let env_id = resolve_env_id(request.env.as_deref());
     println!("Deployment mode: local runtime (environment `{env_id}`)");
     println!(
         "Starting tenant={} team={}",
@@ -303,6 +302,7 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
     // processes must agree on the same env even if the variable changes
     // between them.
     request.bundle = None;
+    request.config = None;
     request.env = Some(env_id);
     // The prepared bundle lives under a tempdir that gets cleaned on shutdown,
     // so default operator.log/flow.log into the source bundle dir where users
@@ -332,14 +332,14 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
     }
 }
 
-/// Resolve the environment a bundle is deployed into and served from.
+/// Resolve the environment id using greentic-start's precedence:
+/// explicit `--env` > `$GREENTIC_ENV` > `local`.
 ///
-/// Mirrors greentic-start's own precedence (`--env` > `$GREENTIC_ENV` >
-/// `local`) so that the env-deploy step and the serving process agree.
-fn resolve_start_env(request: &StartRequest) -> String {
-    request
-        .env
-        .clone()
+/// Used by both start and stop so the env-deploy/serve and stop paths
+/// agree on the same environment.
+fn resolve_env_id(explicit: Option<&str>) -> String {
+    explicit
+        .map(str::to_string)
         .or_else(|| {
             std::env::var("GREENTIC_ENV")
                 .ok()
@@ -509,6 +509,13 @@ pub(crate) fn run_stop(tail: &[String], debug: bool, locale: &str) -> i32 {
                 );
                 return 2;
             }
+            // B4b: start now launches a bundle-less env-backed runtime for
+            // bundle refs, so stop must target the same env rather than
+            // sending `--bundle` to a legacy path that no longer exists.
+            let mut request = request;
+            let env_id = resolve_env_id(request.env.as_deref());
+            request.bundle = None;
+            request.env = Some(env_id);
             let args = request.to_runtime_stop_args(locale);
             match run_binary_checked(START_BIN, &args, debug, locale, "stop bundle") {
                 Ok(()) => 0,

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{
-    parse_runtime_config_start_request, parse_runtime_config_stop_request, parse_start_request,
-    parse_stop_request, required_value, start_flag_takes_value, stop_flag_takes_value,
+    StartRequest, parse_runtime_config_start_request, parse_runtime_config_stop_request,
+    parse_start_request, parse_stop_request, required_value, start_flag_takes_value,
+    stop_flag_takes_value,
 };
 use serde::Deserialize;
 
@@ -13,10 +14,14 @@ use super::bundle_resolution::resolve_bundle_reference;
 use super::cloud_deploy::{destroy_deployment, ensure_started_or_deployed};
 use super::prepared_bundle::{prepare_bundle_for_start, print_prepared_bundle_debug};
 use super::{ChildProcessEnv, StartCliOptions, StartTarget, StopCliOptions};
-use crate::START_BIN;
 use crate::admin::ensure_admin_certs_ready;
 use crate::i18n_support::t_or;
 use crate::process::{run_binary_checked, run_binary_checked_with_target_and_env};
+use crate::{SETUP_BIN, START_BIN};
+
+/// Environment served when neither `--env` nor `$GREENTIC_ENV` is set. Must
+/// match greentic-start's own default, which bootstraps this env on demand.
+const DEFAULT_ENV_ID: &str = "local";
 
 const START_USAGE: &str = "usage: gtc start [BUNDLE_REF] [start flags...]\n\
   BUNDLE_REF: local path, file://, oci://, repo://, store:// (omit to serve the active env's deployed revisions)\n\
@@ -268,12 +273,37 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
             }
         }
     }
-    println!("Deployment mode: local runtime");
+    // B4b: a bundle ref no longer boots the legacy bundle-scoped ingress.
+    // Deploy it into the environment, then start greentic-start *bundle-less*
+    // so it serves the deployed revision through the env/revision runtime —
+    // which is where static assets, DirectLine, WebSocket and CORS live. The
+    // env is created on demand (greentic-start bootstraps it), and the webchat
+    // GUI is on by default for `local`.
+    let env_id = resolve_start_env(&request);
+    println!("Deployment mode: local runtime (environment `{env_id}`)");
     println!(
         "Starting tenant={} team={}",
         request.tenant.as_deref().unwrap_or("demo"),
         request.team.as_deref().unwrap_or("default")
     );
+    if let Err(err) = deploy_bundle_into_env(&prepared.prepared_root, &env_id, debug, locale) {
+        eprintln!(
+            "{}: {err}",
+            t_or(
+                locale,
+                "gtc.start.err.env_deploy_failed",
+                "failed to deploy bundle into environment"
+            )
+        );
+        return 1;
+    }
+    // The env-apply engine has staged its own copy of the revision, so the
+    // prepared tempdir is no longer the serving root. Pin the env explicitly
+    // rather than letting greentic-start re-resolve $GREENTIC_ENV: the two
+    // processes must agree on the same env even if the variable changes
+    // between them.
+    request.bundle = None;
+    request.env = Some(env_id);
     // The prepared bundle lives under a tempdir that gets cleaned on shutdown,
     // so default operator.log/flow.log into the source bundle dir where users
     // can actually find them.
@@ -300,6 +330,39 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
             1
         }
     }
+}
+
+/// Resolve the environment a bundle is deployed into and served from.
+///
+/// Mirrors greentic-start's own precedence (`--env` > `$GREENTIC_ENV` >
+/// `local`) so that the env-deploy step and the serving process agree.
+fn resolve_start_env(request: &StartRequest) -> String {
+    request
+        .env
+        .clone()
+        .or_else(|| {
+            std::env::var("GREENTIC_ENV")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| DEFAULT_ENV_ID.to_string())
+}
+
+/// Deploy a prepared bundle into `env_id` via `greentic-setup env-deploy`.
+///
+/// `--env` and `--non-interactive` are global flags on the setup CLI, so they
+/// precede the subcommand.
+fn deploy_bundle_into_env(bundle: &Path, env_id: &str, debug: bool, locale: &str) -> GtcResult<()> {
+    let args = vec![
+        "--locale".to_string(),
+        locale.to_string(),
+        "--env".to_string(),
+        env_id.to_string(),
+        "--non-interactive".to_string(),
+        "env-deploy".to_string(),
+        bundle.display().to_string(),
+    ];
+    run_binary_checked(SETUP_BIN, &args, debug, locale, "env-deploy bundle")
 }
 
 fn local_runtime_secret_env(bundle_dir: &Path) -> Option<ChildProcessEnv> {

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -285,6 +285,46 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
         request.tenant.as_deref().unwrap_or("demo"),
         request.team.as_deref().unwrap_or("default")
     );
+    // `--admin` without an explicit cert dir generates a dev CA plus server and
+    // client PRIVATE keys inside the prepared root. The legacy path kept that
+    // root in a tempdir that died on shutdown; env-deploy instead stages a
+    // persistent copy of whatever it is handed, and an environment store can be
+    // remote. Keep the keys out of the deployed revision and serve them from the
+    // source bundle, which greentic-start reads via `--admin-certs-dir`.
+    if request
+        .admin_certs_dir
+        .as_deref()
+        .is_some_and(|dir| dir.starts_with(&prepared.prepared_root))
+    {
+        let staged_admin = prepared.prepared_root.join(".greentic").join("admin");
+        if staged_admin.is_dir()
+            && let Err(err) = fs::remove_dir_all(&staged_admin)
+        {
+            eprintln!(
+                "{}: {err}",
+                t_or(
+                    locale,
+                    "gtc.start.err.admin_certs_failed",
+                    "failed to prepare admin certificates"
+                )
+            );
+            return 1;
+        }
+        match ensure_admin_certs_ready(&resolved.bundle_dir, None) {
+            Ok(cert_dir) => request.admin_certs_dir = Some(cert_dir),
+            Err(err) => {
+                eprintln!(
+                    "{}: {err}",
+                    t_or(
+                        locale,
+                        "gtc.start.err.admin_certs_failed",
+                        "failed to prepare admin certificates"
+                    )
+                );
+                return 1;
+            }
+        }
+    }
     if let Err(err) = deploy_bundle_into_env(&prepared.prepared_root, &env_id, debug, locale) {
         eprintln!(
             "{}: {err}",

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -1079,6 +1079,69 @@ fn runtime_start_deploys_bundle_into_env_then_starts_bundle_less() {
     assert!(logged.contains("--admin"));
 }
 
+/// `--admin` generates a dev CA plus server and client PRIVATE keys. Under the
+/// legacy path those lived in a tempdir that died on shutdown. B4b hands the
+/// prepared root to `env-deploy`, which stages a PERSISTENT copy — and an
+/// environment store can be remote. The keys must never enter the deployed
+/// revision; greentic-start reads them from the source bundle via
+/// `--admin-certs-dir` instead.
+#[test]
+fn admin_private_keys_are_not_staged_into_the_environment() {
+    let sandbox = TestSandbox::new("admin_private_keys_are_not_staged_into_the_environment");
+    let bundle_dir = sandbox.path().join("bundle");
+    create_minimal_bundle_dir(&bundle_dir);
+    let start_log = sandbox.path().join("start.log");
+    let setup_log = sandbox.path().join("setup.log");
+
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_bundle_build_tool("greentic-bundle", &sandbox.path().join("bundle.log"));
+    sandbox.write_env_deploy_probe_tool("greentic-setup", &setup_log);
+    sandbox.write_arg_logger_tool("greentic-start", &start_log, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "start",
+            bundle_dir.to_str().expect("bundle utf8"),
+            "--target",
+            "runtime",
+            "--admin",
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let deployed = fs::read_to_string(&setup_log).expect("read setup log");
+    assert!(
+        deployed.contains("env-deploy"),
+        "env-deploy must run; got: {deployed}"
+    );
+    assert!(
+        !deployed.contains("LEAKED_PRIVATE_KEY"),
+        "admin private keys must never be staged into the environment store \
+         (it can be remote); probe reported: {deployed}"
+    );
+    assert!(
+        deployed.contains("ADMIN_DIR_IN_DEPLOYED_BUNDLE=false"),
+        "the deployed bundle must carry no .greentic/admin directory; got: {deployed}"
+    );
+
+    // The admin server still gets its certs — from the source bundle, which is
+    // never handed to env-deploy.
+    let served = fs::read_to_string(&start_log).expect("read start log");
+    assert!(served.contains("--admin"), "admin mode still enabled");
+    let bundle_str = bundle_dir.to_str().expect("bundle utf8");
+    assert!(
+        served.contains(&format!("--admin-certs-dir {bundle_str}")),
+        "certs must be served from the source bundle, not the prepared root; got: {served}"
+    );
+}
+
 /// The env-deploy step and the serving process must agree on one env, even if
 /// `$GREENTIC_ENV` changes between the two spawns — so `gtc` resolves it once
 /// and pins it explicitly on both.
@@ -2435,6 +2498,11 @@ impl TestSandbox {
         self.compile_rust_tool_at(&path, &rust_arg_logger_program(log_file, exit_code));
     }
 
+    fn write_env_deploy_probe_tool(&self, name: &str, log_file: &Path) {
+        let path = self.binary_path(name);
+        self.compile_rust_tool_at(&path, &rust_env_deploy_probe_program(log_file));
+    }
+
     fn write_arg_env_logger_tool(
         &self,
         name: &str,
@@ -3129,6 +3197,46 @@ fn write_test_release_index(cache_dir: &Path, channel: &str, release: &str) {
 
 fn rust_exit_tool_program(exit_code: i32) -> String {
     format!("fn main() {{ std::process::exit({exit_code}); }}",)
+}
+
+/// A `greentic-setup` stand-in that logs its argv AND inspects the bundle it was
+/// handed by `env-deploy`, recording whether admin private keys are inside it.
+/// The prepared root is a tempdir that gets cleaned up, so the only way to know
+/// what was actually staged into the environment is to look from in here.
+fn rust_env_deploy_probe_program(log_file: &Path) -> String {
+    let log_literal = rust_string_literal(&log_file.display().to_string());
+    format!(
+        r#"
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {{
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open({log_literal})
+        .expect("open log");
+    writeln!(file, "{{}}", args.join(" ")).expect("write log");
+
+    if let Some(idx) = args.iter().position(|a| a == "env-deploy")
+        && let Some(bundle) = args.get(idx + 1)
+    {{
+        let admin = Path::new(bundle).join(".greentic").join("admin");
+        writeln!(file, "ADMIN_DIR_IN_DEPLOYED_BUNDLE={{}}", admin.exists())
+            .expect("write log");
+        for key in ["ca.key", "server.key", "client.key"] {{
+            let path = admin.join("certs").join(key);
+            if path.exists() {{
+                writeln!(file, "LEAKED_PRIVATE_KEY={{}}", key).expect("write log");
+            }}
+        }}
+    }}
+    std::process::exit(0);
+}}
+"#
+    )
 }
 
 fn rust_arg_logger_program(log_file: &Path, exit_code: i32) -> String {

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1004,16 +1005,27 @@ fn op_start_routes_to_demo_start_with_default_tenant_team_and_cloudflared_off() 
     assert!(logged.contains("--cloudflared off"));
 }
 
+/// B4b: `gtc start <bundle>` no longer boots the legacy bundle-scoped ingress.
+/// It deploys the bundle into the environment via `greentic-setup env-deploy`,
+/// then starts greentic-start *bundle-less* so the env/revision runtime serves
+/// it (static assets, DirectLine, WebSocket, CORS — none of which the legacy
+/// ingress has on the revision path).
+///
+/// The `--bundle` assertions here are inverted on purpose: a `--bundle` on the
+/// start argv means the reroute regressed and the runtime silently loses the
+/// webchat GUI's socket. That is the whole point of this test.
 #[test]
-fn runtime_start_routes_to_greentic_start_cli() {
-    let sandbox = TestSandbox::new("runtime_start_routes_to_greentic_start_cli");
+fn runtime_start_deploys_bundle_into_env_then_starts_bundle_less() {
+    let sandbox = TestSandbox::new("runtime_start_deploys_bundle_into_env_then_starts_bundle_less");
     let bundle_dir = sandbox.path().join("bundle");
     create_minimal_bundle_dir(&bundle_dir);
-    let log_file = sandbox.path().join("start.log");
+    let start_log = sandbox.path().join("start.log");
+    let setup_log = sandbox.path().join("setup.log");
 
     sandbox.write_exit_tool("greentic-dev", 0);
     sandbox.write_bundle_build_tool("greentic-bundle", &sandbox.path().join("bundle.log"));
-    sandbox.write_arg_logger_tool("greentic-start", &log_file, 0);
+    sandbox.write_arg_logger_tool("greentic-setup", &setup_log, 0);
+    sandbox.write_arg_logger_tool("greentic-start", &start_log, 0);
 
     let output = sandbox.run_gtc_capture(
         [
@@ -1038,19 +1050,74 @@ fn runtime_start_routes_to_greentic_start_cli() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let logged = fs::read_to_string(log_file).expect("read start log");
-    assert!(logged.contains("--locale en start"));
-    assert!(logged.contains("--bundle"));
-    // `--bundle` must rewrite to prepared-root; source dir may appear under `--log-dir`.
-    let bundle_str = bundle_dir.to_str().expect("bundle utf8");
+    // The bundle is deployed into the env before anything is served.
+    let deployed = fs::read_to_string(&setup_log).expect("read setup log");
     assert!(
-        !logged.contains(&format!("--bundle {bundle_str}")),
-        "--bundle should be rewritten to prepared-root, not the source dir; got: {logged}"
+        deployed.contains("env-deploy"),
+        "greentic-setup must be invoked with env-deploy; got: {deployed}"
+    );
+    assert!(
+        deployed.contains("--env local"),
+        "env-deploy must target the resolved env; got: {deployed}"
+    );
+
+    // greentic-start is then booted bundle-less against that same env.
+    let logged = fs::read_to_string(&start_log).expect("read start log");
+    assert!(logged.contains("--locale en start"));
+    assert!(
+        !logged.contains("--bundle"),
+        "start must be bundle-less so the env/revision runtime serves the \
+         revision (a --bundle here silently drops the webchat WebSocket); got: {logged}"
+    );
+    assert!(
+        logged.contains("--env local"),
+        "start must be pinned to the same env the bundle was deployed into; got: {logged}"
     );
     assert!(logged.contains("--tenant demo"));
     assert!(logged.contains("--team ops"));
     assert!(logged.contains("--cloudflared off"));
     assert!(logged.contains("--admin"));
+}
+
+/// The env-deploy step and the serving process must agree on one env, even if
+/// `$GREENTIC_ENV` changes between the two spawns — so `gtc` resolves it once
+/// and pins it explicitly on both.
+#[test]
+fn runtime_start_pins_explicit_env_on_both_deploy_and_serve() {
+    let sandbox = TestSandbox::new("runtime_start_pins_explicit_env_on_both_deploy_and_serve");
+    let bundle_dir = sandbox.path().join("bundle");
+    create_minimal_bundle_dir(&bundle_dir);
+    let start_log = sandbox.path().join("start.log");
+    let setup_log = sandbox.path().join("setup.log");
+
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_bundle_build_tool("greentic-bundle", &sandbox.path().join("bundle.log"));
+    sandbox.write_arg_logger_tool("greentic-setup", &setup_log, 0);
+    sandbox.write_arg_logger_tool("greentic-start", &start_log, 0);
+
+    let output = sandbox.run_gtc_capture(
+        [
+            "start",
+            bundle_dir.to_str().expect("bundle utf8"),
+            "--target",
+            "runtime",
+            "--env",
+            "staging",
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let deployed = fs::read_to_string(&setup_log).expect("read setup log");
+    let served = fs::read_to_string(&start_log).expect("read start log");
+    assert!(
+        deployed.contains("--env staging"),
+        "env-deploy must honor --env; got: {deployed}"
+    );
+    assert!(
+        served.contains("--env staging"),
+        "serve must honor --env; got: {served}"
+    );
 }
 
 #[test]
@@ -2499,7 +2566,22 @@ impl TestSandbox {
             cmd.env(k, v);
         }
 
-        cmd.output().expect("run gtc")
+        // ETXTBSY guard. These tests compile helper executables while other
+        // test threads are spawning processes. Between `fork()` and `execve()`
+        // a child transiently inherits the writable fd of an executable another
+        // thread is still creating, and exec'ing that file returns ETXTBSY.
+        // The window is short, so a bounded retry is enough; without it the
+        // suite fails roughly one run in four, on a different test each time.
+        for attempt in 0..10 {
+            match cmd.output() {
+                Ok(output) => return output,
+                Err(err) if err.kind() == io::ErrorKind::ExecutableFileBusy => {
+                    std::thread::sleep(std::time::Duration::from_millis(20 * (attempt + 1)));
+                }
+                Err(err) => panic!("run gtc: {err:?}"),
+            }
+        }
+        panic!("run gtc: still ETXTBSY after retries");
     }
 }
 


### PR DESCRIPTION
## B4b — `gtc start <x>.gtbundle` boots an environment, with a working chat UI

This is the last mile of the one-bundle-one-command plan. `gtc start ./x.gtbundle` on a clean machine now creates an environment, deploys the bundle into it, and serves it through the env/revision runtime with the webchat GUI on by default.

### What was wrong

A bundle ref took the **legacy** boot path: prepare the bundle → set `--bundle <prepared-root>` → hand to greentic-start, which then took its `bundle_less == false` branch and served from `http_ingress`.

That path has no revision-scoped static assets, no DirectLine, no WebSocket, and no CORS. The webchat GUI cannot work on it. One line — `start_stop.rs:218`, `request.bundle = Some(prepared.prepared_root)` — was what pinned it there.

Those four surfaces now exist on the revision path (A.2 #378, A.3 #379, A.4 #380, A.5 #382), so the reroute is finally safe. **This PR is the reason A.2–A.5 were built.**

### What it does now

A bundle ref:
1. deploys the prepared bundle into the environment via `greentic-setup env-deploy` — the env-apply engine stages its own copy of the revision, so the prepared tempdir stops being the serving root;
2. starts greentic-start **bundle-less**, so the env/revision runtime serves it.

The environment is created on demand (greentic-start's `bootstrap_local_environment` already runs on every start), and `resolved_gui_enabled()` already defaults the webchat GUI on for `local`. Nothing new was needed for either — the machinery was already there, pointed at by nothing.

The env is resolved once (`--env` > `$GREENTIC_ENV` > `local`) and pinned explicitly on **both** the deploy and the serve. Letting each process re-read `$GREENTIC_ENV` independently would let them disagree if the variable changed between the two spawns.

### Preserved from the legacy path

Admin cert preparation (both passes), deploy-target selection, bundle preparation, the log-dir default into the source bundle dir (the prepared root is a tempdir that gets cleaned), and `GREENTIC_DEV_SECRETS_PATH` injection. Non-runtime targets (aws/gcp/azure) are untouched and still deploy via `ensure_started_or_deployed`.

### Tests — mutation-verified

`runtime_start_routes_to_greentic_start_cli` asserted the **old** contract (`assert!(logged.contains("--bundle"))`). It is replaced by two tests asserting the new one. Both were verified to actually fail when the reroute regresses:

| Mutation | Result |
|---|---|
| re-pin `request.bundle` to the prepared root | `runtime_start_deploys_bundle_into_env_then_starts_bundle_less` **FAILS** |
| skip the `env-deploy` step | **both** tests **FAIL** |

A `--bundle` on the start argv means the runtime silently loses the webchat socket, so that assertion is inverted on purpose.

### Drive-by: a real flake in the test harness

The integration harness compiles helper executables while other test threads spawn processes. A child transiently inherits a writable fd across `fork`/`exec`, and exec'ing that file returns **ETXTBSY** ("Text file busy"). This is pre-existing, but the two new tests each compile four stub binaries, which widened the window enough to fail **~1 run in 4** — on a different test each time, which is exactly how a race disguises itself as an unrelated flake.

Fixed with a bounded retry on `ExecutableFileBusy`. 8/8 consecutive full-suite runs clean afterwards (previously 1 failure in 4 runs).

### Verification

- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features` — 0 findings
- 480 tests pass (32 + 382 + 62 + 1 + 3)
- Both mutations confirmed red; control green
- `ci/local_check.sh` cannot complete on this machine: the `perf` bench fails to link under `mold` (`undefined symbol: c_with_alloca`). Confirmed **pre-existing** — it fails identically on pristine `main` with none of these changes applied. Everything local_check runs *other than* the bench is green above.

### Sequencing

Requires **greentic-start 1.1.16** (A.5, merged as `7381f24`) at runtime — `gtc` spawns the installed `greentic-start` binary rather than linking the crate, so an older binary would boot the GUI onto a runtime with no WebSocket. 1.1.16 is on `main` and tagged but **not yet on crates.io**; publish it before this reaches users via binstall.
