### PR TITLE
feat(provider): serve provider add/list/remove via `gtc setup`; deprecate operator messaging ops (1.1.8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -49,6 +49,12 @@ use cli::build_cli;
 #[cfg(test)]
 #[allow(unused_imports)]
 use commands::default_install_channel_for_invocation;
+#[cfg(test)]
+#[allow(unused_imports)]
+use commands::operator_messaging_op_deprecation;
+#[cfg(test)]
+#[allow(unused_imports)]
+use commands::promote_setup_provider;
 use commands::run;
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -888,6 +888,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.op.about").into_owned())
+                .after_help("Deprecated: `gtc op messaging endpoint …` (per-environment messaging providers). Use `gtc setup provider …` (add/list/remove) instead — it manages the same environment surface.")
                 .arg(cmd_args.clone()),
         )
         .subcommand(
@@ -940,7 +941,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 .disable_help_flag(true)
                 .disable_version_flag(true)
                 .about(t(locale, "gtc.cmd.setup.about").into_owned())
-                .after_help("Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
+                .after_help("Add providers to an environment with `gtc setup provider add <kind>` (list/remove too); surface a provider's setup questions with `gtc setup provider add <kind> --schema` (emits JSON for a UI to render). Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.")
                 .arg(
                     Arg::new("extension-setup-handoff")
                         .long("extension-setup-handoff")
@@ -966,6 +967,9 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.provider.about",
                     "Manage messaging providers (passthrough to greentic-setup).",
                 ))
+                .after_help(
+                    "Surface a provider's setup questions with `gtc provider add <name> --schema` (emits JSON for a UI to render). Answers sources: --answers accepts local paths, file://, http://, https://, oci://, store://, and repo:// JSON object documents.",
+                )
                 .arg(cmd_args),
         )
         .subcommand(

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use clap::ArgMatches;
 use serde_json::Value;
@@ -149,6 +150,13 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
         },
         Some((name @ ("dev" | "op" | "wizard" | "setup" | "worker" | "provider"), sub_matches)) => {
             let tail = collect_tail(sub_matches);
+            // `gtc setup provider …` is sugar for `gtc provider …`: promote it to
+            // the provider path so the same `--schema` capture and `--answers`
+            // materialization apply and greentic-setup receives `provider <verb> …`
+            // (the token is re-prepended by `build_provider_args`). It also drops
+            // the setup-only release-context / extension-handoff handling, which do
+            // not apply to a provider tail — matching the standalone `gtc provider`.
+            let (name, tail) = promote_setup_provider(name, tail);
             let tail = if matches!(name, "wizard" | "setup") {
                 let release_context =
                     match release_context_flags(sub_matches, &tail, default_install_channel) {
@@ -178,7 +186,10 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 tail
             };
             let mut answers_tempdir = None;
-            let tail = if matches!(name, "wizard" | "setup") {
+            // `provider` joins `wizard`/`setup` here: a UI collects answers for
+            // the questions surfaced by `--schema` and hands them back via
+            // `--answers`, so remote references must be materialized the same way.
+            let tail = if matches!(name, "wizard" | "setup" | "provider") {
                 match resolve_answers_args(&tail) {
                     Ok(resolved) => {
                         answers_tempdir = resolved.tempdir;
@@ -208,6 +219,12 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                     return run_wizard_schema_full(binary, &args, debug, &locale);
                 }
                 return run_wizard_schema(binary, &args, debug, &locale);
+            }
+            if name == "provider" && has_schema_flag(&args) {
+                return run_provider_schema(binary, &args, debug, &locale);
+            }
+            if name == "op" {
+                warn_deprecated_operator_messaging_op(&args);
             }
             let _answers_tempdir = answers_tempdir;
             passthrough(binary, &args, debug, &locale)
@@ -426,6 +443,40 @@ fn run_wizard_schema(binary: &str, args: &[String], debug: bool, locale: &str) -
     }
 }
 
+/// Surface the provider setup question/secret schema emitted by
+/// `greentic-setup` so a UI can render a form. gtc runs
+/// `greentic-setup provider … --schema`, captures the JSON document, and
+/// re-emits it pretty-printed. Answers collected by the UI are handed back via
+/// `--answers` (resolved by `resolve_answers_args`, same as `setup`). Unlike
+/// `run_wizard_schema`, no nested `$ref` rewriting is needed — the provider
+/// schema is a flat question document, forwarded as-is apart from formatting.
+fn run_provider_schema(binary: &str, args: &[String], debug: bool, locale: &str) -> i32 {
+    let raw = match run_binary_capture(binary, args, debug, locale) {
+        Ok(raw) => raw,
+        Err(err) => {
+            eprintln!("{err}");
+            return 1;
+        }
+    };
+    let schema: Value = match serde_json::from_str(&raw) {
+        Ok(schema) => schema,
+        Err(err) => {
+            eprintln!("invalid provider schema JSON from {binary}: {err}");
+            return 1;
+        }
+    };
+    match serde_json::to_string_pretty(&schema) {
+        Ok(rendered) => {
+            println!("{rendered}");
+            0
+        }
+        Err(err) => {
+            eprintln!("failed to render provider schema JSON: {err}");
+            1
+        }
+    }
+}
+
 fn has_schema_flag(args: &[String]) -> bool {
     args.iter()
         .any(|arg| arg == "--schema" || arg.starts_with("--schema="))
@@ -588,6 +639,56 @@ fn json_pointer_path(path: &[String]) -> String {
 
 fn escape_json_pointer_segment(segment: &str) -> String {
     segment.replace('~', "~0").replace('/', "~1")
+}
+
+/// Promote `gtc setup provider …` to the `provider` passthrough path. When a
+/// `setup` invocation leads with the `provider` token, strip it and re-target
+/// the subcommand as `provider` so the shared `--schema` capture and `--answers`
+/// materialization apply and greentic-setup receives `provider <verb> …` (the
+/// token is re-prepended by `build_provider_args`). Any other invocation is
+/// returned unchanged.
+pub(super) fn promote_setup_provider(name: &str, tail: Vec<String>) -> (&str, Vec<String>) {
+    if name == "setup" && tail.first().map(String::as_str) == Some("provider") {
+        ("provider", tail[1..].to_vec())
+    } else {
+        (name, tail)
+    }
+}
+
+/// Fires at most once per process so a single invocation, or a batch of them,
+/// does not spam the deprecation notice.
+static OPERATOR_MESSAGING_OP_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// The operator `op messaging endpoint …` verbs manage per-environment
+/// messaging providers — the surface now owned by `gtc setup provider …` (the
+/// new env path). Return the migration hint when `args` (the operator-bound
+/// argv after [`rewrite_legacy_op_args`], e.g.
+/// `["op", "messaging", "endpoint", "add", …]`) targets that group; otherwise
+/// return `None`. The op is *not* rewritten — callers still forward it — so the
+/// deprecated path keeps working while it is being retired.
+pub(super) fn operator_messaging_op_deprecation(args: &[String]) -> Option<&'static str> {
+    let mut tokens = args.iter().map(String::as_str);
+    if tokens.next() == Some("op")
+        && tokens.next() == Some("messaging")
+        && tokens.next() == Some("endpoint")
+    {
+        Some(
+            "`gtc op messaging endpoint …` is deprecated; manage messaging providers with \
+             `gtc setup provider …` (add/list/remove) against the environment.",
+        )
+    } else {
+        None
+    }
+}
+
+/// Emit the messaging-op deprecation notice at most once per process. Called on
+/// the `op` passthrough right before the operator binary is spawned.
+fn warn_deprecated_operator_messaging_op(args: &[String]) {
+    if let Some(message) = operator_messaging_op_deprecation(args)
+        && !OPERATOR_MESSAGING_OP_WARNED.swap(true, Ordering::SeqCst)
+    {
+        eprintln!("warning: {message}");
+    }
 }
 
 /// Detect a leading `k8s` token in a `start` tail and rewrite it into an

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -67,6 +67,11 @@ pub(super) fn route_passthrough_subcommand(
         "setup" => Some((SETUP_BIN, tail.to_vec())),
         "wizard" => Some((DEV_BIN, build_wizard_args(tail, locale))),
         "worker" => Some((DW_BIN, build_worker_args(tail))),
+        // `provider` re-prepends its token, then `commands::run` treats the
+        // tail like `setup`'s: `--schema` is intercepted to surface the
+        // provider's question/secret schema for a UI, and `--answers` sources
+        // (oci://, store://, repo://, http://) are materialized before the tail
+        // reaches greentic-setup. It still skips the release-context check.
         "provider" => Some((SETUP_BIN, build_provider_args(tail))),
         _ => None,
     }

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -3,16 +3,16 @@ use super::{
     build_cli, build_wizard_args, collect_tail, default_install_channel_for_invocation,
     detect_bundle_root, detect_locale, ensure_admin_certs_ready, extract_tar_archive,
     fingerprint_bundle_dir, locale_from_args, normalize_bundle_fingerprint,
-    normalize_expected_sha256, normalize_install_arch, parse_prompt_choice,
-    parse_start_cli_options, parse_start_request, parse_stop_cli_options, parse_stop_request,
-    remove_admin_registry_entry, resolve_admin_cert_dir,
-    resolve_canonical_target_provider_pack_from, resolve_companion_binary_from,
-    resolve_companion_binary_from_invocation, resolve_deploy_app_pack_path,
-    resolve_local_mutable_bundle_dir, resolve_target_provider_pack, resolve_tenant_key,
-    rewrite_store_tenant_placeholder, route_passthrough_subcommand, run_admin_access,
-    run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry, select_start_target,
-    should_send_auth_header, start_k8s_rewrite, tenant_env_var_name, upsert_admin_registry_entry,
-    verify_sha256_digest,
+    normalize_expected_sha256, normalize_install_arch, operator_messaging_op_deprecation,
+    parse_prompt_choice, parse_start_cli_options, parse_start_request, parse_stop_cli_options,
+    parse_stop_request, promote_setup_provider, remove_admin_registry_entry,
+    resolve_admin_cert_dir, resolve_canonical_target_provider_pack_from,
+    resolve_companion_binary_from, resolve_companion_binary_from_invocation,
+    resolve_deploy_app_pack_path, resolve_local_mutable_bundle_dir, resolve_target_provider_pack,
+    resolve_tenant_key, rewrite_store_tenant_placeholder, route_passthrough_subcommand,
+    run_admin_access, run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry,
+    select_start_target, should_send_auth_header, start_k8s_rewrite, tenant_env_var_name,
+    upsert_admin_registry_entry, verify_sha256_digest,
 };
 #[cfg(unix)]
 use super::{apply_default_deploy_env_for_target, extract_zip_bytes, validate_cloud_deploy_inputs};
@@ -275,6 +275,84 @@ fn route_passthrough_subcommand_routes_provider_to_greentic_setup() {
             "telegram".to_string()
         ]
     );
+}
+
+#[test]
+fn route_passthrough_subcommand_routes_provider_remove_to_greentic_setup() {
+    let tail = vec!["remove".to_string(), "telegram".to_string()];
+    let (binary, args) =
+        route_passthrough_subcommand("provider", &tail, "en").expect("provider route");
+
+    assert_eq!(binary, SETUP_BIN);
+    // the `provider` token must be re-added so greentic-setup sees `provider remove telegram`
+    assert_eq!(
+        args,
+        vec![
+            "provider".to_string(),
+            "remove".to_string(),
+            "telegram".to_string()
+        ]
+    );
+}
+
+#[test]
+fn promote_setup_provider_rewrites_setup_provider_to_provider() {
+    let tail = vec![
+        "provider".to_string(),
+        "add".to_string(),
+        "telegram".to_string(),
+    ];
+    let (name, rewritten) = promote_setup_provider("setup", tail);
+
+    assert_eq!(name, "provider");
+    // the leading `provider` token is stripped; `build_provider_args` re-prepends it later
+    assert_eq!(rewritten, vec!["add".to_string(), "telegram".to_string()]);
+}
+
+#[test]
+fn promote_setup_provider_leaves_plain_setup_untouched() {
+    let tail = vec!["./my-bundle".to_string()];
+    let (name, rewritten) = promote_setup_provider("setup", tail);
+
+    assert_eq!(name, "setup");
+    assert_eq!(rewritten, vec!["./my-bundle".to_string()]);
+}
+
+#[test]
+fn promote_setup_provider_leaves_standalone_provider_untouched() {
+    let tail = vec!["add".to_string(), "telegram".to_string()];
+    let (name, rewritten) = promote_setup_provider("provider", tail);
+
+    assert_eq!(name, "provider");
+    assert_eq!(rewritten, vec!["add".to_string(), "telegram".to_string()]);
+}
+
+#[test]
+fn operator_messaging_op_deprecation_flags_endpoint_verbs() {
+    // Post-rewrite operator argv: `gtc op messaging endpoint add …`.
+    let args = vec![
+        "op".to_string(),
+        "messaging".to_string(),
+        "endpoint".to_string(),
+        "add".to_string(),
+    ];
+    let hint = operator_messaging_op_deprecation(&args).expect("deprecation hint");
+    assert!(hint.contains("gtc setup provider"));
+}
+
+#[test]
+fn operator_messaging_op_deprecation_ignores_other_ops() {
+    // Non-messaging operator ops keep working with no notice.
+    for args in [
+        vec!["op".to_string(), "env".to_string(), "up".to_string()],
+        vec!["op".to_string(), "env-packs".to_string(), "add".to_string()],
+        vec!["op".to_string(), "messaging".to_string()],
+    ] {
+        assert!(
+            operator_messaging_op_deprecation(&args).is_none(),
+            "unexpected deprecation for {args:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/gtc_router_integration.rs
+++ b/tests/gtc_router_integration.rs
@@ -700,6 +700,274 @@ fn provider_passthrough_preserves_exit_code() {
 }
 
 #[test]
+fn provider_remove_passthrough_routes_to_greentic_setup_with_provider_token() {
+    let sandbox = TestSandbox::new(
+        "provider_remove_passthrough_routes_to_greentic_setup_with_provider_token",
+    );
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(["provider", "remove", "telegram"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    // greentic-setup must receive `provider remove telegram` — the `provider`
+    // token is re-prepended by the router (same pattern as `add`).
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["provider", "remove", "telegram"]),
+        "expected greentic-setup to receive `provider remove telegram`, got: {logged}"
+    );
+}
+
+#[test]
+fn provider_remove_passthrough_preserves_exit_code() {
+    let sandbox = TestSandbox::new("provider_remove_passthrough_preserves_exit_code");
+    sandbox.write_exit_tool("greentic-setup", 7);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let status = sandbox.run_gtc(["provider", "remove", "telegram"], HashMap::new());
+    assert_eq!(status.code(), Some(7));
+}
+
+#[test]
+fn provider_schema_surfaces_questions_from_greentic_setup() {
+    let sandbox = TestSandbox::new("provider_schema_surfaces_questions_from_greentic_setup");
+    // greentic-setup emits the provider's question/secret schema on stdout when
+    // asked with `--schema`; gtc captures it and re-emits it for a UI.
+    let schema = r#"{"title":"telegram","questions":[{"id":"bot_token","secret":true}]}"#;
+    sandbox.write_stdout_tool("greentic-setup", schema, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let output =
+        sandbox.run_gtc_capture(["provider", "add", "telegram", "--schema"], HashMap::new());
+    assert_eq!(output.status.code(), Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // gtc pretty-prints the captured schema, so match on stable substrings.
+    assert!(
+        stdout.contains("\"bot_token\"") && stdout.contains("\"questions\""),
+        "expected gtc to surface the provider schema, got: {stdout}"
+    );
+}
+
+#[test]
+fn provider_answers_local_file_is_resolved_and_forwarded() {
+    let sandbox = TestSandbox::new("provider_answers_local_file_is_resolved_and_forwarded");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // A valid local answers document is validated by gtc, then forwarded to
+    // greentic-setup — `provider` now participates in answers resolution.
+    let answers_path = sandbox.path().join("answers.json");
+    fs::write(&answers_path, r#"{"bot_token":"secret-123"}"#).expect("write answers");
+    let answers_str = answers_path.to_str().expect("utf8 answers path");
+
+    let status = sandbox.run_gtc(
+        ["provider", "add", "telegram", "--answers", answers_str],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["provider", "add", "telegram", "--answers", answers_str]),
+        "expected greentic-setup to receive the resolved answers path, got: {logged}"
+    );
+}
+
+#[test]
+fn provider_answers_missing_source_fails_before_greentic_setup() {
+    let sandbox = TestSandbox::new("provider_answers_missing_source_fails_before_greentic_setup");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // Because gtc now resolves `--answers` for `provider`, an unreadable source
+    // fails inside gtc — greentic-setup must never be invoked. (Before this
+    // change the bad source passed straight through and the stub would run.)
+    let missing = sandbox.path().join("does-not-exist.json");
+    let status = sandbox.run_gtc(
+        [
+            "provider",
+            "add",
+            "telegram",
+            "--answers",
+            missing.to_str().expect("utf8 path"),
+        ],
+        HashMap::new(),
+    );
+    assert_ne!(
+        status.code(),
+        Some(0),
+        "expected gtc to fail on the bad answers source"
+    );
+    assert!(
+        !log_file.exists(),
+        "greentic-setup must not run when answers resolution fails"
+    );
+}
+
+#[test]
+fn setup_provider_add_routes_to_greentic_setup_with_provider_token() {
+    let sandbox =
+        TestSandbox::new("setup_provider_add_routes_to_greentic_setup_with_provider_token");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // `gtc setup provider add telegram` is sugar for `gtc provider add telegram`:
+    // the leading `provider` token is stripped, then re-prepended, so
+    // greentic-setup still receives `provider add telegram`.
+    let status = sandbox.run_gtc(["setup", "provider", "add", "telegram"], HashMap::new());
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["provider", "add", "telegram"]),
+        "expected greentic-setup to receive `provider add telegram`, got: {logged}"
+    );
+}
+
+#[test]
+fn setup_provider_schema_surfaces_questions_from_greentic_setup() {
+    let sandbox = TestSandbox::new("setup_provider_schema_surfaces_questions_from_greentic_setup");
+    // Same `--schema` capture path as the standalone `gtc provider` surface,
+    // reached via `gtc setup provider add … --schema`.
+    let schema = r#"{"title":"telegram","questions":[{"id":"bot_token","secret":true}]}"#;
+    sandbox.write_stdout_tool("greentic-setup", schema, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    let output = sandbox.run_gtc_capture(
+        ["setup", "provider", "add", "telegram", "--schema"],
+        HashMap::new(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"bot_token\"") && stdout.contains("\"questions\""),
+        "expected gtc to surface the provider schema, got: {stdout}"
+    );
+}
+
+#[test]
+fn setup_provider_answers_local_file_is_resolved_and_forwarded() {
+    let sandbox = TestSandbox::new("setup_provider_answers_local_file_is_resolved_and_forwarded");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // `gtc setup provider …` participates in answers resolution just like the
+    // standalone `provider` surface.
+    let answers_path = sandbox.path().join("answers.json");
+    fs::write(&answers_path, r#"{"bot_token":"secret-123"}"#).expect("write answers");
+    let answers_str = answers_path.to_str().expect("utf8 answers path");
+
+    let status = sandbox.run_gtc(
+        [
+            "setup",
+            "provider",
+            "add",
+            "telegram",
+            "--answers",
+            answers_str,
+        ],
+        HashMap::new(),
+    );
+    assert_eq!(status.code(), Some(0));
+
+    let logged = fs::read_to_string(log_file).expect("read setup log");
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["provider", "add", "telegram", "--answers", answers_str]),
+        "expected greentic-setup to receive the resolved answers path, got: {logged}"
+    );
+}
+
+#[test]
+fn setup_provider_answers_missing_source_fails_before_greentic_setup() {
+    let sandbox =
+        TestSandbox::new("setup_provider_answers_missing_source_fails_before_greentic_setup");
+    let log_file = sandbox.path().join("setup.log");
+    sandbox.write_arg_logger_tool("greentic-setup", &log_file, 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+    sandbox.write_exit_tool("greentic-operator", 0);
+
+    // A bad `--answers` source fails inside gtc before greentic-setup is spawned,
+    // just as on the standalone `provider` surface.
+    let missing = sandbox.path().join("does-not-exist.json");
+    let status = sandbox.run_gtc(
+        [
+            "setup",
+            "provider",
+            "add",
+            "telegram",
+            "--answers",
+            missing.to_str().expect("utf8 path"),
+        ],
+        HashMap::new(),
+    );
+    assert_ne!(
+        status.code(),
+        Some(0),
+        "expected gtc to fail on the bad answers source"
+    );
+    assert!(
+        !log_file.exists(),
+        "greentic-setup must not run when answers resolution fails"
+    );
+}
+
+#[test]
+fn op_messaging_endpoint_warns_deprecated_and_still_forwards_to_operator() {
+    let sandbox =
+        TestSandbox::new("op_messaging_endpoint_warns_deprecated_and_still_forwards_to_operator");
+    let log_file = sandbox.path().join("operator.log");
+    sandbox.write_arg_logger_tool("greentic-operator", &log_file, 0);
+    sandbox.write_exit_tool("greentic-setup", 0);
+    sandbox.write_exit_tool("greentic-dev", 0);
+
+    let output = sandbox.run_gtc_capture(
+        ["op", "messaging", "endpoint", "add", "--env", "local"],
+        HashMap::new(),
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    // The deprecated op still works, but prints a migration notice to stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("deprecated") && stderr.contains("gtc setup provider"),
+        "expected a deprecation warning pointing to `gtc setup provider`, got: {stderr}"
+    );
+
+    // The rewriter prepends `op`, so the operator receives the verb verbatim.
+    let logged = fs::read_to_string(log_file).expect("read operator log");
+    assert!(
+        logged
+            .split_whitespace()
+            .eq(["op", "messaging", "endpoint", "add", "--env", "local"]),
+        "expected operator to receive `op messaging endpoint add --env local`, got: {logged}"
+    );
+}
+
+#[test]
 fn op_help_passthrough_routes_to_greentic_operator() {
     let sandbox = TestSandbox::new("op_help_passthrough_routes_to_greentic_operator");
     let log_file = sandbox.path().join("op.log");


### PR DESCRIPTION
## Summary

Consolidate messaging-provider management on the **greentic-setup** binary and mark the redundant **greentic-operator** front door as deprecated. Both surfaces are porcelains over the same `greentic-deployer` engine writing `messaging.endpoint` records to `~/.greentic/environments`, so the operator's `op messaging endpoint` is a duplicate — not unique functionality.

### Changes

- **`gtc setup provider …` is now a first-class surface.** `promote_setup_provider` re-targets a `setup` tail that leads with `provider` onto the provider path, so `gtc setup provider add/list/remove` gets the same `--schema` capture (`run_provider_schema`) and `--answers` materialization as the standalone `gtc provider …`. The `provider` token is re-prepended by `build_provider_args`; the `setup` `after_help` documents it.
- **Operator duplicate deprecated (non-breaking).** `gtc op messaging endpoint …` still forwards to greentic-operator but prints a **once-per-process** stderr notice pointing at `gtc setup provider …`; the `op` `after_help` notes it. Non-messaging ops (`op env …`, etc.) are unaffected.
- **Folds in the in-progress `gtc provider` passthrough work**: `provider remove` routing, `--schema` capture, and `--answers` resolution.

### Why this shape

The two front doors are **not** arg-compatible (`list <ENV_ID>` positional vs `--env`; `--provider-type` vs positional `<KIND>`; `--endpoint-id` vs positional), so a transparent reroute would break callers. This PR takes the non-breaking path: make `gtc setup provider` canonical and deprecate-forward the operator surface. Fully retiring the `op messaging endpoint` routing is a deliberate follow-up.

## Testing

- `cargo test --bin gtc` → 391 passed
- `cargo test --test gtc_router_integration` → 73 passed
- `cargo fmt --check` clean, `cargo clippy --bin gtc --tests` clean
- New tests:
  - unit: `promote_setup_provider_*`, `operator_messaging_op_deprecation_*`
  - integration: `setup_provider_{add,schema,answers_*}`, `op_messaging_endpoint_warns_deprecated_and_still_forwards_to_operator`
- Verified live against the installed greentic-setup 1.1.18 / greentic-operator 1.1.3:
  - `gtc setup provider list --env local` → `{"noun":"messaging.endpoint",…}`
  - `gtc op messaging endpoint list local` → warns on stderr **and** returns the operator result
  - `gtc op env show local` → no warning