### PR TITLE
gtc 6b: `start cloudrun` sugar → `op env up`

### DIFF
--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -52,6 +52,9 @@ use commands::default_install_channel_for_invocation;
 use commands::run;
 #[cfg(test)]
 #[allow(unused_imports)]
+use commands::start_cloudrun_rewrite;
+#[cfg(test)]
+#[allow(unused_imports)]
 use commands::start_k8s_rewrite;
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -843,7 +843,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.start.about",
                     "Start a bundle from local or remote reference.",
                 ))
-                .after_help("Use `gtc start k8s [FLAGS]` to provision a local Kind cluster and deploy an environment via `op env up`. All flags (including --answers) are forwarded to the operator. Only the exact first token `k8s` is reserved: a bundle of that name is still reachable by path (`./k8s`).")
+                .after_help("Use `gtc start k8s [FLAGS]` to provision a local Kind cluster and deploy an environment via `op env up`, or `gtc start cloudrun [FLAGS]` to deploy a scale-to-zero Google Cloud Run environment and print its live `run.app` URL. All flags (including --answers) are forwarded to the operator. Only the exact first tokens `k8s` and `cloudrun` are reserved: a bundle of either name is still reachable by path (`./k8s`, `./cloudrun`).")
                 .arg(cmd_args.clone()),
         )
         .subcommand(

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -112,10 +112,12 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 Ok(Some((handoff_path, rest))) => {
                     run_extension_start(&handoff_path, &rest, debug, &locale)
                 }
-                Ok(None) => match start_k8s_rewrite(&tail) {
-                    Some(args) => passthrough(super::OP_BIN, &args, debug, &locale),
-                    None => run_start(&tail, debug, &locale),
-                },
+                Ok(None) => {
+                    match start_k8s_rewrite(&tail).or_else(|| start_cloudrun_rewrite(&tail)) {
+                        Some(args) => passthrough(super::OP_BIN, &args, debug, &locale),
+                        None => run_start(&tail, debug, &locale),
+                    }
+                }
                 Err(err) => {
                     eprintln!("{err}");
                     2
@@ -590,16 +592,31 @@ fn escape_json_pointer_segment(segment: &str) -> String {
     segment.replace('~', "~0").replace('/', "~1")
 }
 
-/// Detect a leading `k8s` token in a `start` tail and rewrite it into an
-/// operator `env up` invocation. Returns `None` when the tail does not begin
-/// with `k8s` (a flag-prefixed tail like `["--answers", "k8s"]` is not a match).
-pub(super) fn start_k8s_rewrite(tail: &[String]) -> Option<Vec<String>> {
-    if tail.first().map(String::as_str) != Some("k8s") {
+/// Rewrite a `start` tail whose leading token is `target` into an operator
+/// `env up` invocation, dropping the token. Returns `None` when the tail does
+/// not begin with `target` (a flag-prefixed tail like `["--answers", "k8s"]` is
+/// not a match). The operator resolves the concrete deployer from the env
+/// manifest — the token only routes `gtc start <target>` to `op env up`.
+fn start_env_up_rewrite(tail: &[String], target: &str) -> Option<Vec<String>> {
+    if tail.first().map(String::as_str) != Some(target) {
         return None;
     }
     let mut args = vec!["op".to_string(), "env".to_string(), "up".to_string()];
     args.extend_from_slice(&tail[1..]);
     Some(args)
+}
+
+/// Detect a leading `k8s` token in a `start` tail and rewrite it into an
+/// operator `env up` invocation (provisions a local Kind cluster + deploys).
+pub(super) fn start_k8s_rewrite(tail: &[String]) -> Option<Vec<String>> {
+    start_env_up_rewrite(tail, "k8s")
+}
+
+/// Detect a leading `cloudrun` token in a `start` tail and rewrite it into an
+/// operator `env up` invocation (deploys a scale-to-zero Cloud Run environment
+/// and returns its live `run.app` URL). Sibling of [`start_k8s_rewrite`].
+pub(super) fn start_cloudrun_rewrite(tail: &[String]) -> Option<Vec<String>> {
+    start_env_up_rewrite(tail, "cloudrun")
 }
 
 fn run_help(sub_matches: &ArgMatches, locale: &str) -> i32 {

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -11,8 +11,8 @@ use super::{
     resolve_local_mutable_bundle_dir, resolve_target_provider_pack, resolve_tenant_key,
     rewrite_store_tenant_placeholder, route_passthrough_subcommand, run_admin_access,
     run_admin_health, run_admin_token, run_admin_tunnel, save_admin_registry, select_start_target,
-    should_send_auth_header, start_k8s_rewrite, tenant_env_var_name, upsert_admin_registry_entry,
-    verify_sha256_digest,
+    should_send_auth_header, start_cloudrun_rewrite, start_k8s_rewrite, tenant_env_var_name,
+    upsert_admin_registry_entry, verify_sha256_digest,
 };
 #[cfg(unix)]
 use super::{apply_default_deploy_env_for_target, extract_zip_bytes, validate_cloud_deploy_inputs};
@@ -1895,6 +1895,78 @@ fn start_k8s_rewrite_preserves_trailing_flags_in_order() {
             "--dry-run".to_string(),
         ]
     );
+}
+
+#[test]
+fn start_cloudrun_rewrite_rewrites_leading_cloudrun_token() {
+    let tail = vec!["cloudrun".to_string()];
+    let rewritten = start_cloudrun_rewrite(&tail).expect("should rewrite");
+    assert_eq!(
+        rewritten,
+        vec!["op".to_string(), "env".to_string(), "up".to_string()]
+    );
+}
+
+#[test]
+fn start_cloudrun_rewrite_does_not_rewrite_cloudrun_after_flag() {
+    let tail = vec!["--answers".to_string(), "cloudrun".to_string()];
+    assert!(start_cloudrun_rewrite(&tail).is_none());
+}
+
+#[test]
+fn start_cloudrun_rewrite_returns_none_without_cloudrun() {
+    let tail = vec!["my-bundle.gtbundle".to_string()];
+    assert!(start_cloudrun_rewrite(&tail).is_none());
+}
+
+/// Only the exact token `cloudrun` is reserved. A bundle named `cloudrun` stays
+/// reachable through any path form, so the sugar cannot swallow a real bundle ref.
+#[test]
+fn start_cloudrun_rewrite_leaves_path_form_bundle_refs_to_run_start() {
+    for bundle_ref in [
+        "./cloudrun",
+        "cloudrun/",
+        "cloudrun.gtbundle",
+        "/opt/bundles/cloudrun",
+        "CloudRun",
+    ] {
+        let tail = vec![bundle_ref.to_string()];
+        assert!(
+            start_cloudrun_rewrite(&tail).is_none(),
+            "`{bundle_ref}` must reach run_start as a bundle ref"
+        );
+    }
+}
+
+#[test]
+fn start_cloudrun_rewrite_preserves_trailing_flags_in_order() {
+    let tail = vec![
+        "cloudrun".to_string(),
+        "--answers".to_string(),
+        "/tmp/answers.json".to_string(),
+        "--dry-run".to_string(),
+    ];
+    let rewritten = start_cloudrun_rewrite(&tail).expect("should rewrite");
+    assert_eq!(
+        rewritten,
+        vec![
+            "op".to_string(),
+            "env".to_string(),
+            "up".to_string(),
+            "--answers".to_string(),
+            "/tmp/answers.json".to_string(),
+            "--dry-run".to_string(),
+        ]
+    );
+}
+
+/// The two target rewrites share one helper but must not cross-match: `k8s`
+/// only routes k8s, `cloudrun` only routes cloudrun. Guards the shared
+/// `start_env_up_rewrite` against a token-set regression.
+#[test]
+fn start_target_rewrites_do_not_cross_match() {
+    assert!(start_k8s_rewrite(&["cloudrun".to_string()]).is_none());
+    assert!(start_cloudrun_rewrite(&["k8s".to_string()]).is_none());
 }
 
 struct HttpRequest {


### PR DESCRIPTION
## gtc 6b — `start cloudrun` sugar → `op env up`

Item 6b of the Cloud Run deployment-target train (pairs with deployer #477 / item 6a). Base: `develop`.

### What
Adds the one-command `gtc start cloudrun [FLAGS]` entry point — the Cloud Run sibling of `gtc start k8s`. A leading `cloudrun` token in a `start` tail rewrites into an operator `op env up` invocation (which 6a taught to deploy a scale-to-zero Cloud Run env and return its live `run.app` URL). All flags, including `--answers`, are forwarded to the operator.

### DRY
Both target tokens rewrite **identically** to `op env up <rest>` — the operator resolves the concrete deployer from the env manifest, so the token only routes. The k8s and cloudrun entry points therefore share one private `start_env_up_rewrite(tail, target)` helper instead of duplicating the 4-line rewrite body. Only the exact first token `k8s` / `cloudrun` is reserved; a bundle of either name stays reachable by path (`./cloudrun`).

### Tests
Mirror the k8s rewrite suite for cloudrun (leading-token rewrite, flag-prefixed non-match, path-form bundle refs left to `run_start`, trailing-flag order preserved) plus a **cross-match guard** (`start_target_rewrites_do_not_cross_match`) proving the shared helper keeps the two tokens distinct. `after_help` documents the new form.

### Gate
`cargo fmt --check` clean; `cargo clippy --bin gtc --all-features -D warnings` clean; `cargo test --all-features --lib --bins --tests` green (63 + integration tests, incl. all `start_*_rewrite` cases). The `perf` bench fails to link under this machine's `mold` (a known local-env trap, `alloca`/`c_with_alloca` — unrelated to this change); CI links it with its own linker. No dep changes.

Runtime note: the end-to-end `gtc start cloudrun` needs 6a (deployer #477) merged + the nightly `greentic-deployer-dev` that `gtc` delegates to. This PR is the CLI-surface half and is self-contained for CI.
