### PR TITLE
feat(gtc): add `gtc up`, the one-command bootstrap (1.1.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ This is the kind of result Greentic is built for: a real digital worker that can
 
 ![IT Helpdesk Digital Worker](greentic_readme_assets/helpdesk-webchat.png)
 
-After installing Greentic, you only need **three steps** to get a working digital worker running.
+`gtc up` does the whole thing in **one command** — it installs the toolchain,
+creates the bundle, sets it up, and starts it:
+
+```bash
+gtc up \
+  --answers https://github.com/greenticai/greentic-demo/releases/latest/download/helpdesk-itsm-create-answers.json \
+  --setup-answers https://github.com/greenticai/greentic-demo/releases/latest/download/helpdesk-itsm-setup-answers.json
+```
+
+It ends in a foreground server; Ctrl+C stops it. `--dry-run` prints the bundle
+directory it will create and every step it will run, without running any of
+them. Prefer the steps separately — or need a setup flag `up` does not forward,
+such as `--tenant` — then run them yourself:
 
 ## 1) Create a bundle
 
@@ -378,6 +390,9 @@ Install Greentic via `cargo-binstall`.
 cargo binstall gtc
 gtc install
 ```
+
+`gtc up` runs the install step itself, so for a demo those two lines collapse to
+`cargo binstall gtc` followed by a single `gtc up`.
 
 If you prefer installing from source:
 

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -130,5 +130,15 @@
   "gtc.wizard.prompt.select": "Select option:",
   "gtc.wizard.prompt.bundle_path": "Bundle directory (e.g. ./mybundle):",
   "gtc.wizard.err.bundle_path_required": "Bundle path is required.",
-  "gtc.wizard.err.bundle_exists": "Bundle path already exists: {path}"
+  "gtc.wizard.err.bundle_exists": "Bundle path already exists: {path}",
+  "gtc.cmd.up.about": "Create, set up and start a bundle in one command.",
+  "gtc.cmd.up.after_help": "Runs install -> wizard -> setup -> start as one command, ending in a foreground server (Ctrl+C to stop). Both answer documents are required; `up` never guesses the second one. Setup flags (--tenant, --team, --env, --advanced) are NOT forwarded — run the four commands separately if you need them. Everything after `--` is forwarded to the start step.",
+  "gtc.arg.up.answers.help": "Create-answers document for the wizard step. Accepts local paths, file://, http://, https://, oci://, store:// and repo:// JSON documents.",
+  "gtc.arg.up.setup_answers.help": "Setup-answers document for the setup step; same sources as --answers.",
+  "gtc.arg.up.bundle_dir.help": "Override the bundle directory predicted from the create-answers document.",
+  "gtc.arg.up.no_install.help": "Skip the install step; fail later if the toolchain is missing.",
+  "gtc.arg.up.no_start.help": "Stop after setup and print the start command instead of running it.",
+  "gtc.arg.up.dry_run.help": "Print the resolved bundle directory and every step, then exit without running any of them.",
+  "gtc.arg.up.force.help": "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.",
+  "gtc.arg.up.start_args.help": "Arguments after `--`, forwarded verbatim to the start step."
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -135,7 +135,7 @@
   "gtc.cmd.up.after_help": "Runs install -> wizard -> setup -> start as one command, ending in a foreground server (Ctrl+C to stop). Both answer documents are required; `up` never guesses the second one. Setup flags (--tenant, --team, --env, --advanced) are NOT forwarded — run the four commands separately if you need them. Everything after `--` is forwarded to the start step.",
   "gtc.arg.up.answers.help": "Create-answers document for the wizard step. Accepts local paths, file://, http://, https://, oci://, store:// and repo:// JSON documents.",
   "gtc.arg.up.setup_answers.help": "Setup-answers document for the setup step; same sources as --answers.",
-  "gtc.arg.up.bundle_dir.help": "Override the bundle directory predicted from the create-answers document.",
+  "gtc.arg.up.bundle_dir.help": "Where `up` looks for the bundle after the wizard runs, when the predicted path is wrong. It does NOT move the wizard: the wizard always writes where the create-answers document's `output_dir` says.",
   "gtc.arg.up.no_install.help": "Skip the install step; fail later if the toolchain is missing.",
   "gtc.arg.up.no_start.help": "Stop after setup and print the start command instead of running it.",
   "gtc.arg.up.dry_run.help": "Print the resolved bundle directory and every step, then exit without running any of them.",

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -28,6 +28,8 @@ mod release_cache;
 mod router;
 #[path = "gtc/toolchain.rs"]
 mod toolchain;
+#[path = "gtc/up.rs"]
+mod up;
 
 use std::path::Path;
 

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -867,7 +867,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                         .value_name("PATH")
                         .num_args(1)
                         .help_heading(options_heading)
-                        .help(t_or(locale, "gtc.arg.up.bundle_dir.help", "Override the bundle directory predicted from the create-answers document.")),
+                        .help(t_or(locale, "gtc.arg.up.bundle_dir.help", "Where `up` looks for the bundle after the wizard runs, when the predicted path is wrong. It does NOT move the wizard: the wizard always writes where the create-answers document's `output_dir` says.")),
                 )
                 .arg(
                     Arg::new("no-install")

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -828,6 +828,88 @@ pub(super) fn build_cli(locale: &str) -> Command {
                 ),
         )
         .subcommand(
+            // Unlike `start`, `up` is NOT a catch-all: its own flags are
+            // parsed by clap and only the tail after `--` is forwarded. A
+            // catch-all here would silently swallow a misspelled
+            // `--setup-answers` into the start tail.
+            Command::new("up")
+                .help_template(help_template)
+                .subcommand_help_heading(commands_heading)
+                .disable_help_flag(true)
+                .disable_version_flag(true)
+                .about(t_or(
+                    locale,
+                    "gtc.cmd.up.about",
+                    "Create, set up and start a bundle in one command.",
+                ))
+                .after_help(crate::up::after_help(locale))
+                .arg(
+                    Arg::new("answers")
+                        .long("answers")
+                        .value_name("SRC")
+                        .num_args(1)
+                        .required(true)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.answers.help", "Create-answers document for the wizard step. Accepts local paths, file://, http://, https://, oci://, store:// and repo:// JSON documents.")),
+                )
+                .arg(
+                    Arg::new("setup-answers")
+                        .long("setup-answers")
+                        .value_name("SRC")
+                        .num_args(1)
+                        .required(true)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.setup_answers.help", "Setup-answers document for the setup step; same sources as --answers.")),
+                )
+                .arg(
+                    Arg::new("bundle-dir")
+                        .long("bundle-dir")
+                        .value_name("PATH")
+                        .num_args(1)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.bundle_dir.help", "Override the bundle directory predicted from the create-answers document.")),
+                )
+                .arg(
+                    Arg::new("no-install")
+                        .long("no-install")
+                        .action(ArgAction::SetTrue)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.no_install.help", "Skip the install step; fail later if the toolchain is missing.")),
+                )
+                .arg(
+                    Arg::new("no-start")
+                        .long("no-start")
+                        .action(ArgAction::SetTrue)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.no_start.help", "Stop after setup and print the start command instead of running it.")),
+                )
+                .arg(
+                    Arg::new("dry-run")
+                        .long("dry-run")
+                        .action(ArgAction::SetTrue)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.dry_run.help", "Print the resolved bundle directory and every step, then exit without running any of them.")),
+                )
+                .arg(
+                    Arg::new("force")
+                        .long("force")
+                        .action(ArgAction::SetTrue)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.force.help", "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.")),
+                )
+                .arg(release_context_strict_arg(options_heading))
+                .arg(release_context_ignore_arg(options_heading))
+                .arg(
+                    Arg::new("args")
+                        .num_args(0..)
+                        .last(true)
+                        .allow_hyphen_values(true)
+                        .value_name("START_ARGS")
+                        .help_heading(arguments_heading)
+                        .help(t_or(locale, "gtc.arg.up.start_args.help", "Arguments after `--`, forwarded verbatim to the start step.")),
+                ),
+        )
+        .subcommand(
             // Pure catch-all (the `op` pattern): ONE tail parser owns the
             // whole start surface — positional bundle ref, gtc-specific
             // flags, and every forwarded greentic-start flag — so a leading

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -224,13 +224,12 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
     }
 }
 
-pub(super) struct ResolvedAnswersArgs {
-    pub(super) args: Vec<String>,
-    #[allow(dead_code)]
-    pub(super) tempdir: Option<TempDir>,
+struct ResolvedAnswersArgs {
+    args: Vec<String>,
+    tempdir: Option<TempDir>,
 }
 
-pub(super) fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
+fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
     let loader = DefaultAnswerSourceLoader;
     let mut rewritten = Vec::with_capacity(args.len());
     let mut tempdir: Option<TempDir> = None;

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -34,6 +34,7 @@ use crate::router::{
     route_passthrough_subcommand,
 };
 use crate::toolchain::{installed_toolchain_label, latest_release_context_warning};
+use crate::up::run_up;
 
 pub(super) fn run(raw_args: Vec<String>) -> i32 {
     let i18n = i18n();
@@ -102,6 +103,13 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 2
             }
         },
+        Some(("up", sub_matches)) => run_up(
+            sub_matches,
+            default_install_channel,
+            invocation.as_deref(),
+            debug,
+            &locale,
+        ),
         Some(("start", sub_matches)) => {
             // `start` is a pure catch-all at the clap layer — every flag
             // (including gtc-internal ones) is parsed from the tail by one
@@ -216,12 +224,13 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
     }
 }
 
-struct ResolvedAnswersArgs {
-    args: Vec<String>,
-    tempdir: Option<TempDir>,
+pub(super) struct ResolvedAnswersArgs {
+    pub(super) args: Vec<String>,
+    #[allow(dead_code)]
+    pub(super) tempdir: Option<TempDir>,
 }
 
-fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
+pub(super) fn resolve_answers_args(args: &[String]) -> gtc::error::GtcResult<ResolvedAnswersArgs> {
     let loader = DefaultAnswerSourceLoader;
     let mut rewritten = Vec::with_capacity(args.len());
     let mut tempdir: Option<TempDir> = None;
@@ -299,7 +308,7 @@ fn resolve_answers_arg_value(
     }
 }
 
-fn answers_error_exit_code(err: &gtc::error::GtcError) -> i32 {
+pub(super) fn answers_error_exit_code(err: &gtc::error::GtcError) -> i32 {
     if matches!(err, gtc::error::GtcError::InvalidData { context, .. } if context == "answers source")
     {
         2
@@ -365,7 +374,7 @@ fn release_context_flags(
     })
 }
 
-fn check_release_context(
+pub(super) fn check_release_context(
     channel: &str,
     invocation: Option<&str>,
     debug: bool,

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -1,0 +1,623 @@
+//! `gtc up` — the one-line bootstrap.
+//!
+//! Composes the four commands the README documents (`install`, `wizard`,
+//! `setup`, `start`) into one. It composes **gtc's own entry points**, not the
+//! companion binaries' argv: `gtc start <dir>` in particular is not a
+//! passthrough — it resolves the bundle ref, prepares it, generates admin
+//! certs, runs `greentic-setup env-deploy`, and only then starts
+//! `greentic-start` *bundle-less*. Rebuilding that argv here would start a
+//! server with nothing deployed, and it would fail at runtime rather than at
+//! parse time. Calling [`run_start`] keeps `up` correct for free as those
+//! steps change.
+
+use std::path::{Path, PathBuf};
+
+use clap::ArgMatches;
+use serde_json::{Map, Value};
+
+use crate::cli::build_cli;
+use crate::commands::{
+    ResolvedAnswersArgs, answers_error_exit_code, check_release_context, resolve_answers_args,
+};
+use crate::deploy::run_start;
+use crate::i18n_support::t_or;
+use crate::install::run_install;
+use crate::process::passthrough;
+use crate::router::route_passthrough_subcommand;
+
+/// Everything `run_up` needs from the command line, resolved once.
+struct UpPlan {
+    /// Absolute — `output_dir` in the create document is CWD-relative, and a
+    /// later step must not re-resolve it against a different directory.
+    bundle_dir: PathBuf,
+    create_answers: String,
+    setup_answers: String,
+    start_tail: Vec<String>,
+    install: bool,
+    start: bool,
+    dry_run: bool,
+    force: bool,
+    /// Held only for their `Drop`: a materialized `oci://` / `store://` /
+    /// `repo://` document lives in a tempdir that must outlive the child
+    /// process reading it. Dropping either early turns into a confusing
+    /// "file not found" from a companion binary.
+    _answers_tempdirs: Vec<ResolvedAnswersArgs>,
+}
+
+pub(super) fn run_up(
+    sub_matches: &ArgMatches,
+    default_channel: &'static str,
+    invocation: Option<&str>,
+    debug: bool,
+    locale: &str,
+) -> i32 {
+    let plan = match build_plan(sub_matches) {
+        Ok(plan) => plan,
+        Err(UpError { message, code }) => {
+            eprintln!("{message}");
+            return code;
+        }
+    };
+
+    // The bundle-directory guard runs before anything else mutates the
+    // machine: `up` hides which of its steps is destructive, so it must
+    // refuse earlier than the four commands it replaces would.
+    if plan.bundle_dir.exists() && !plan.force {
+        eprintln!(
+            "{} already exists. `up` runs the wizard in create mode, which \
+             overwrites a bundle you may have edited and orphans a tunnel \
+             still running against it. Pass --force to overwrite it, \
+             --bundle-dir <PATH> to build elsewhere, or run `gtc setup` and \
+             `gtc start` directly against it.",
+            plan.bundle_dir.display()
+        );
+        return 2;
+    }
+
+    // Once, not once per delegated step. `gtc wizard` and `gtc setup` each run
+    // this check today; the companion binaries know nothing about it, so there
+    // is no flag to suppress downstream — simply don't call it three times.
+    // It performs network I/O, so the dedup is a latency win too.
+    if !sub_matches.get_flag("ignore-release-context")
+        && let Some(status) = check_release_context(default_channel, invocation, debug, locale)
+    {
+        if sub_matches.get_flag("strict-release-context") {
+            eprintln!("error: {status}");
+            return 1;
+        }
+        eprintln!("warning: {status}");
+    }
+
+    if plan.dry_run {
+        print_dry_run(&plan);
+        return 0;
+    }
+
+    if plan.install
+        && let status = run_install_step(default_channel, debug, locale)
+        && status != 0
+    {
+        return fail(status, "install", "gtc install");
+    }
+
+    let wizard_tail = vec!["--answers".to_string(), plan.create_answers.clone()];
+    let status = run_passthrough_step("wizard", &wizard_tail, debug, locale);
+    if status != 0 {
+        return fail(
+            status,
+            "wizard",
+            &format!("gtc wizard --answers {}", plan.create_answers),
+        );
+    }
+
+    // The predicted path is a second implementation of a rule owned by
+    // greentic-bundle (`output_dir`, else `default_bundle_output_dir` over a
+    // normalized `bundle_id`). Confirm it rather than discovering the drift
+    // three steps later as "bundle not found".
+    if !plan.bundle_dir.is_dir() {
+        eprintln!(
+            "the wizard succeeded but {} does not exist. `up` predicts the \
+             bundle directory from the create-answers document; this one \
+             disagrees with what the wizard actually created. Re-run with \
+             --bundle-dir <PATH>, or run `gtc setup` and `gtc start` against \
+             the directory the wizard reported.",
+            plan.bundle_dir.display()
+        );
+        return 1;
+    }
+
+    let setup_tail = setup_tail(&plan.bundle_dir, &plan.setup_answers);
+    let status = run_passthrough_step("setup", &setup_tail, debug, locale);
+    if status != 0 {
+        return fail(
+            status,
+            "setup",
+            &format!(
+                "gtc setup {} --answers {} --non-interactive",
+                plan.bundle_dir.display(),
+                plan.setup_answers
+            ),
+        );
+    }
+
+    if !plan.start {
+        // The tail is only ever forwarded to start, so with --no-start it
+        // would silently vanish. Put it in the printed command instead.
+        let tail = start_tail_suffix(&plan.start_tail);
+        println!(
+            "{} is set up. Start it with:\n  gtc start {}{tail}",
+            plan.bundle_dir.display(),
+            plan.bundle_dir.display()
+        );
+        return 0;
+    }
+
+    let mut start_tail = vec![plan.bundle_dir.display().to_string()];
+    start_tail.extend(plan.start_tail.iter().cloned());
+    run_start(&start_tail, debug, locale)
+}
+
+struct UpError {
+    message: String,
+    code: i32,
+}
+
+impl UpError {
+    fn usage(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: 2,
+        }
+    }
+}
+
+fn build_plan(sub_matches: &ArgMatches) -> Result<UpPlan, UpError> {
+    let create_source = sub_matches
+        .get_one::<String>("answers")
+        .expect("clap requires --answers");
+    let setup_source = sub_matches
+        .get_one::<String>("setup-answers")
+        .expect("clap requires --setup-answers");
+
+    // Route both documents through the same resolver `gtc wizard` and
+    // `gtc setup` use, so `oci://`, `store://` and `repo://` behave here
+    // exactly as they do there.
+    let create = resolve_one(create_source)?;
+    let setup = resolve_one(setup_source)?;
+    let create_answers = answers_value(&create);
+    let setup_answers = answers_value(&setup);
+
+    let bundle_dir = match sub_matches.get_one::<String>("bundle-dir") {
+        Some(explicit) => PathBuf::from(explicit),
+        None => {
+            let document = crate::answer_resolver::load_answers(&create_answers)
+                .map_err(|err| UpError::usage(format!("--answers {create_answers}: {err}")))?;
+            predict_bundle_dir(&document).map_err(UpError::usage)?
+        }
+    };
+    let bundle_dir = absolutize(&bundle_dir)
+        .map_err(|err| UpError::usage(format!("resolving {}: {err}", bundle_dir.display())))?;
+
+    Ok(UpPlan {
+        bundle_dir,
+        create_answers,
+        setup_answers,
+        start_tail: sub_matches
+            .get_many::<String>("args")
+            .map(|values| values.cloned().collect())
+            .unwrap_or_default(),
+        install: !sub_matches.get_flag("no-install"),
+        start: !sub_matches.get_flag("no-start"),
+        dry_run: sub_matches.get_flag("dry-run"),
+        force: sub_matches.get_flag("force"),
+        _answers_tempdirs: vec![create, setup],
+    })
+}
+
+fn resolve_one(source: &str) -> Result<ResolvedAnswersArgs, UpError> {
+    resolve_answers_args(&["--answers".to_string(), source.to_string()]).map_err(|err| UpError {
+        message: format!("{err}"),
+        code: answers_error_exit_code(&err),
+    })
+}
+
+/// The resolved path `resolve_answers_args` rewrote `--answers <src>` into.
+fn answers_value(resolved: &ResolvedAnswersArgs) -> String {
+    resolved
+        .args
+        .get(1)
+        .cloned()
+        .expect("resolve_answers_args preserves the --answers value")
+}
+
+/// Predict the directory the bundle wizard will create.
+///
+/// The wizard child inherits stdio, so the path it creates cannot be read back
+/// from it — but the create-answers document already carries it, so `up` reads
+/// it up front. Mirrors `greentic-bundle`'s `normalize_bundle_id` /
+/// `default_bundle_output_dir`; the caller confirms the directory exists after
+/// the wizard runs, because this mirror can drift.
+pub(crate) fn predict_bundle_dir(document: &Map<String, Value>) -> Result<PathBuf, String> {
+    let answers = document.get("answers").and_then(Value::as_object).ok_or(
+        "create-answers document has no `answers` object — is this a \
+         greentic-dev launcher document?",
+    )?;
+
+    // `selected_action` is required by the launcher schema. A `pack` run
+    // delegates to the pack wizard, which creates no bundle directory, so
+    // there is nothing for setup or start to act on.
+    match answers.get("selected_action").and_then(Value::as_str) {
+        Some("bundle") => {}
+        Some(other) => {
+            return Err(format!(
+                "create-answers selects `{other}`, but `up` needs \
+                 `selected_action: \"bundle\"` — only a bundle run produces a \
+                 directory to set up and start."
+            ));
+        }
+        None => return Err("create-answers document declares no `selected_action`".to_string()),
+    }
+
+    let delegate = answers
+        .get("delegate_answer_document")
+        .and_then(|value| value.get("answers"))
+        .and_then(Value::as_object)
+        .ok_or(
+            "create-answers document has no `answers.delegate_answer_document.answers` \
+             object — `up` needs a non-interactive bundle document to predict the \
+             output directory",
+        )?;
+
+    if let Some(dir) = delegate
+        .get("output_dir")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|dir| !dir.is_empty())
+    {
+        return Ok(PathBuf::from(dir));
+    }
+
+    let bundle_id = delegate
+        .get("bundle_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or(
+            "create-answers document declares neither `output_dir` nor \
+             `bundle_id`, so the bundle directory cannot be predicted — pass \
+             --bundle-dir <PATH>",
+        )?;
+
+    Ok(default_bundle_output_dir(bundle_id))
+}
+
+/// Mirror of `greentic-bundle`'s `normalize_bundle_id`.
+fn normalize_bundle_id(raw: &str) -> String {
+    let normalized = raw
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>();
+    normalized.trim_matches('-').to_string()
+}
+
+/// Mirror of `greentic-bundle`'s `default_bundle_output_dir`.
+fn default_bundle_output_dir(bundle_id: &str) -> PathBuf {
+    let normalized = normalize_bundle_id(bundle_id);
+    if normalized.is_empty() {
+        PathBuf::from("./bundle")
+    } else {
+        PathBuf::from(format!("./{normalized}-bundle"))
+    }
+}
+
+/// Pin the predicted directory to the CWD once. `output_dir` is a relative
+/// path in the document, and `run_start` and the setup passthrough must not be
+/// able to resolve it against anything else.
+///
+/// Lexical only — no `canonicalize`, which fails on a path that does not exist
+/// yet, and the whole point is that this directory has not been created.
+fn absolutize(path: &Path) -> std::io::Result<PathBuf> {
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    // Rebuild from `components()`, which drops the `.` a document's `./foo`
+    // leaves behind. Worth doing because this path is printed in every error
+    // message and passed to two later steps, and `/work/./foo` reads like a
+    // bug in the tool. `Components` is what normalizes — there is deliberately
+    // no `CurDir` arm here, because adding one would be dead code.
+    Ok(joined.components().collect())
+}
+
+/// Build the `install` sub-matches from the real flag definitions rather than
+/// fabricating them, so `up` cannot drift from `gtc install`.
+///
+/// `--skip-self-update` is not optional here: `run_install` otherwise replaces
+/// the running gtc binary on disk mid-command, leaving the rest of `up` to
+/// finish on the old in-memory image.
+fn install_matches(locale: &str) -> Option<ArgMatches> {
+    build_cli(locale)
+        .try_get_matches_from(["gtc", "install", "--skip-self-update"])
+        .ok()
+        .and_then(|matches| matches.subcommand_matches("install").cloned())
+}
+
+fn run_install_step(default_channel: &'static str, debug: bool, locale: &str) -> i32 {
+    match install_matches(locale) {
+        Some(matches) => run_install(&matches, default_channel, debug, locale),
+        None => {
+            eprintln!("internal error: could not build the install step");
+            1
+        }
+    }
+}
+
+/// Delegate through the same router `gtc wizard` / `gtc setup` use.
+fn run_passthrough_step(name: &str, tail: &[String], debug: bool, locale: &str) -> i32 {
+    let Some((binary, args)) = route_passthrough_subcommand(name, tail, locale) else {
+        eprintln!("internal error: no route for `{name}`");
+        return 1;
+    };
+    passthrough(binary, &args, debug, locale)
+}
+
+/// A composite that fails opaquely is worse than the commands it replaces, so
+/// always name the step and how to re-run it by hand.
+fn fail(status: i32, step: &str, rerun: &str) -> i32 {
+    eprintln!("`gtc up` stopped at the {step} step (exit {status}). Re-run it with:\n  {rerun}");
+    status
+}
+
+/// The setup step's argv.
+///
+/// `--non-interactive` is mandatory, not defensive. Unlike the wizard —
+/// which infers `--yes --non-interactive` from `--answers` — `greentic-setup`
+/// does not: without the flag it launches a web UI or prompts on stdin, and
+/// the composite hangs with no indication why.
+fn setup_tail(bundle_dir: &Path, setup_answers: &str) -> Vec<String> {
+    vec![
+        bundle_dir.display().to_string(),
+        "--answers".to_string(),
+        setup_answers.to_string(),
+        "--non-interactive".to_string(),
+    ]
+}
+
+/// Render the `--` tail for a printed command line.
+fn start_tail_suffix(tail: &[String]) -> String {
+    if tail.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", tail.join(" "))
+    }
+}
+
+fn print_dry_run(plan: &UpPlan) {
+    println!("bundle directory: {}", plan.bundle_dir.display());
+    println!("steps:");
+    if plan.install {
+        println!("  install  gtc install --skip-self-update");
+    }
+    println!("  wizard   gtc wizard --answers {}", plan.create_answers);
+    println!("  verify   {} exists", plan.bundle_dir.display());
+    println!(
+        "  setup    gtc setup {} --answers {} --non-interactive",
+        plan.bundle_dir.display(),
+        plan.setup_answers
+    );
+    if plan.start {
+        let tail = start_tail_suffix(&plan.start_tail);
+        println!("  start    gtc start {}{tail}", plan.bundle_dir.display());
+    }
+}
+
+/// `up --help` after-text. Kept next to the implementation so the limitation
+/// and the code that imposes it move together.
+pub(super) fn after_help(locale: &str) -> String {
+    t_or(
+        locale,
+        "gtc.cmd.up.after_help",
+        "Runs install -> wizard -> setup -> start as one command, ending in a \
+         foreground server (Ctrl+C to stop). Both answer documents are \
+         required; `up` never guesses the second one. Setup flags (--tenant, \
+         --team, --env, --advanced) are NOT forwarded — run the four commands \
+         separately if you need them. Everything after `--` is forwarded to \
+         the start step.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::SETUP_BIN;
+
+    fn create_doc(answers: Value) -> Value {
+        json!({
+            "wizard_id": "greentic-dev.wizard.launcher.main",
+            "schema_id": "greentic-dev.launcher.main",
+            "schema_version": "1.0.0",
+            "locale": "en",
+            "answers": answers,
+        })
+    }
+
+    fn bundle_doc(delegate: Value) -> Value {
+        create_doc(json!({
+            "selected_action": "bundle",
+            "delegate_answer_document": { "answers": delegate },
+        }))
+    }
+
+    #[test]
+    fn output_dir_is_taken_verbatim_from_the_create_document() {
+        let doc = bundle_doc(json!({
+            "bundle_id": "helpdesk-itsm-demo",
+            "output_dir": "helpdesk-itsm-demo-bundle",
+        }));
+        assert_eq!(
+            predict_bundle_dir(doc.as_object().unwrap()).unwrap(),
+            PathBuf::from("helpdesk-itsm-demo-bundle")
+        );
+    }
+
+    #[test]
+    fn output_dir_wins_over_the_derived_default() {
+        // The two disagree on purpose: whatever the document says the wizard
+        // will use, so a derived guess must never override it.
+        let doc = bundle_doc(json!({
+            "bundle_id": "helpdesk-itsm-demo",
+            "output_dir": "/opt/bundles/helpdesk",
+        }));
+        assert_eq!(
+            predict_bundle_dir(doc.as_object().unwrap()).unwrap(),
+            PathBuf::from("/opt/bundles/helpdesk")
+        );
+    }
+
+    #[test]
+    fn an_absent_output_dir_falls_back_to_the_normalized_bundle_id() {
+        let doc = bundle_doc(json!({ "bundle_id": "helpdesk-itsm-demo" }));
+        assert_eq!(
+            predict_bundle_dir(doc.as_object().unwrap()).unwrap(),
+            PathBuf::from("./helpdesk-itsm-demo-bundle")
+        );
+    }
+
+    #[test]
+    fn a_blank_output_dir_falls_back_rather_than_predicting_the_cwd() {
+        // greentic-bundle maps an empty output_dir to "."; predicting the CWD
+        // would make the exists-guard fire on every run.
+        let doc = bundle_doc(json!({
+            "bundle_id": "quickstart",
+            "output_dir": "   ",
+        }));
+        assert_eq!(
+            predict_bundle_dir(doc.as_object().unwrap()).unwrap(),
+            PathBuf::from("./quickstart-bundle")
+        );
+    }
+
+    #[test]
+    fn bundle_id_normalization_matches_greentic_bundle() {
+        assert_eq!(
+            default_bundle_output_dir("  Helpdesk ITSM Demo  "),
+            PathBuf::from("./helpdesk-itsm-demo-bundle")
+        );
+        assert_eq!(
+            default_bundle_output_dir("--weird--"),
+            PathBuf::from("./weird-bundle")
+        );
+        assert_eq!(default_bundle_output_dir("!!!"), PathBuf::from("./bundle"));
+    }
+
+    #[test]
+    fn a_pack_run_is_refused_because_it_creates_no_bundle_directory() {
+        let doc = create_doc(json!({ "selected_action": "pack" }));
+        let err = predict_bundle_dir(doc.as_object().unwrap()).unwrap_err();
+        assert!(err.contains("selected_action"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_document_with_no_delegate_is_refused_before_any_step_runs() {
+        let doc = create_doc(json!({ "selected_action": "bundle" }));
+        let err = predict_bundle_dir(doc.as_object().unwrap()).unwrap_err();
+        assert!(
+            err.contains("delegate_answer_document"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn neither_output_dir_nor_bundle_id_is_an_error_not_a_guess() {
+        let doc = bundle_doc(json!({ "bundle_name": "helpdesk" }));
+        let err = predict_bundle_dir(doc.as_object().unwrap()).unwrap_err();
+        assert!(err.contains("--bundle-dir"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_relative_prediction_is_pinned_to_the_cwd() {
+        let pinned = absolutize(Path::new("./demo-bundle")).unwrap();
+        assert!(pinned.is_absolute());
+        assert!(pinned.ends_with("demo-bundle"));
+    }
+
+    #[test]
+    fn an_absolute_prediction_is_left_alone() {
+        let pinned = absolutize(Path::new("/opt/bundles/demo")).unwrap();
+        assert_eq!(pinned, PathBuf::from("/opt/bundles/demo"));
+    }
+
+    #[test]
+    fn a_leading_dot_component_is_dropped_from_the_pinned_path() {
+        // `./demo-bundle` is the shape greentic-bundle's own default emits, so
+        // without this every printed path and both delegated argvs carry a
+        // `/./` that reads as a bug in the tool.
+        let pinned = absolutize(Path::new("./demo-bundle")).unwrap();
+        assert!(
+            !pinned.to_string_lossy().contains("/./"),
+            "{} still carries a dot component",
+            pinned.display()
+        );
+    }
+
+    #[test]
+    fn the_setup_step_always_passes_non_interactive() {
+        // greentic-setup does NOT infer this from --answers the way the wizard
+        // does. Without it the composite opens a web UI or blocks on stdin,
+        // which in CI looks like a hang rather than a failure.
+        let tail = setup_tail(Path::new("/work/demo-bundle"), "/tmp/setup.json");
+        assert_eq!(
+            tail,
+            vec![
+                "/work/demo-bundle".to_string(),
+                "--answers".to_string(),
+                "/tmp/setup.json".to_string(),
+                "--non-interactive".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_setup_step_routes_to_greentic_setup() {
+        // Guards the composition boundary: `up` must reach setup through the
+        // same router `gtc setup` uses, not a hand-built argv.
+        let tail = setup_tail(Path::new("/work/demo-bundle"), "/tmp/setup.json");
+        let (binary, args) = route_passthrough_subcommand("setup", &tail, "en").unwrap();
+        assert_eq!(binary, SETUP_BIN);
+        assert_eq!(args, tail);
+    }
+
+    #[test]
+    fn the_install_step_skips_the_self_update() {
+        // run_install would otherwise replace the running gtc binary on disk
+        // mid-command, leaving wizard/setup/start to finish on the old image.
+        let matches = install_matches("en").expect("install matches");
+        assert!(matches.get_flag("skip-self-update"));
+        // and nothing else is narrowed: a phase selector here would silently
+        // install less than `gtc install` does.
+        for selector in [
+            "install-binaries-only",
+            "install-packs-only",
+            "install-components-only",
+            "install-tenant-only",
+        ] {
+            assert!(!matches.get_flag(selector), "{selector} should be unset");
+        }
+        assert!(!matches.get_flag("dry-run"));
+    }
+
+    #[test]
+    fn the_start_tail_is_rendered_only_when_present() {
+        assert_eq!(start_tail_suffix(&[]), "");
+        assert_eq!(
+            start_tail_suffix(&["--cloudflared".to_string(), "off".to_string()]),
+            " --cloudflared off"
+        );
+    }
+}

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -14,11 +14,11 @@ use std::path::{Path, PathBuf};
 
 use clap::ArgMatches;
 use serde_json::{Map, Value};
+use tempfile::TempDir;
 
+use crate::answer_resolver::{DefaultAnswerSourceLoader, load_answer_bytes, parse_answers_bytes};
 use crate::cli::build_cli;
-use crate::commands::{
-    ResolvedAnswersArgs, answers_error_exit_code, check_release_context, resolve_answers_args,
-};
+use crate::commands::{answers_error_exit_code, check_release_context};
 use crate::deploy::run_start;
 use crate::i18n_support::t_or;
 use crate::install::run_install;
@@ -27,8 +27,14 @@ use crate::router::route_passthrough_subcommand;
 
 /// Everything `run_up` needs from the command line, resolved once.
 struct UpPlan {
-    /// Absolute — `output_dir` in the create document is CWD-relative, and a
-    /// later step must not re-resolve it against a different directory.
+    /// Where the WIZARD will write, from the create document. Always known:
+    /// the wizard requires `bundle_id`, so a document it could accept is a
+    /// document `up` can predict from. This is the path the overwrite guard
+    /// exists to protect, and `--bundle-dir` does not move it.
+    wizard_dir: PathBuf,
+    /// Where setup and start operate — `wizard_dir` unless `--bundle-dir`
+    /// corrects a prediction that drifted. Absolute: `output_dir` is
+    /// CWD-relative and a later step must not re-resolve it elsewhere.
     bundle_dir: PathBuf,
     create_answers: String,
     setup_answers: String,
@@ -37,11 +43,10 @@ struct UpPlan {
     start: bool,
     dry_run: bool,
     force: bool,
-    /// Held only for their `Drop`: a materialized `oci://` / `store://` /
-    /// `repo://` document lives in a tempdir that must outlive the child
-    /// process reading it. Dropping either early turns into a confusing
-    /// "file not found" from a companion binary.
-    _answers_tempdirs: Vec<ResolvedAnswersArgs>,
+    /// Held only for its `Drop`: both documents are snapshotted into it, and
+    /// it must outlive the child processes reading them. Dropping it early
+    /// turns into a confusing "file not found" from a companion binary.
+    _snapshot: TempDir,
 }
 
 pub(super) fn run_up(
@@ -59,19 +64,26 @@ pub(super) fn run_up(
         }
     };
 
-    // The bundle-directory guard runs before anything else mutates the
-    // machine: `up` hides which of its steps is destructive, so it must
-    // refuse earlier than the four commands it replaces would.
-    if plan.bundle_dir.exists() && !plan.force {
-        eprintln!(
-            "{} already exists. `up` runs the wizard in create mode, which \
-             overwrites a bundle you may have edited and orphans a tunnel \
-             still running against it. Pass --force to overwrite it, \
-             --bundle-dir <PATH> to build elsewhere, or run `gtc setup` and \
-             `gtc start` directly against it.",
-            plan.bundle_dir.display()
-        );
-        return 2;
+    // The overwrite guard runs before anything else mutates the machine:
+    // `up` hides which of its steps is destructive, so it must refuse earlier
+    // than the four commands it replaces would.
+    //
+    // Every directory a step may write is checked, not just the one setup and
+    // start use. `--bundle-dir` does NOT redirect the wizard, so guarding only
+    // it would leave the wizard free to overwrite the document's directory
+    // without `--force` — the exact data loss this guard exists to prevent.
+    for dir in guarded_dirs(&plan) {
+        if dir.exists() && !plan.force {
+            eprintln!(
+                "{} already exists. `up` runs the wizard in create mode, which \
+                 overwrites a bundle you may have edited and orphans a tunnel \
+                 still running against it. Pass --force to overwrite it, change \
+                 `output_dir` in the create-answers document to build elsewhere, \
+                 or run `gtc setup` and `gtc start` directly against it.",
+                dir.display()
+            );
+            return 2;
+        }
     }
 
     // Once, not once per delegated step. `gtc wizard` and `gtc setup` each run
@@ -179,26 +191,27 @@ fn build_plan(sub_matches: &ArgMatches) -> Result<UpPlan, UpError> {
         .get_one::<String>("setup-answers")
         .expect("clap requires --setup-answers");
 
-    // Route both documents through the same resolver `gtc wizard` and
-    // `gtc setup` use, so `oci://`, `store://` and `repo://` behave here
-    // exactly as they do there.
-    let create = resolve_one(create_source)?;
-    let setup = resolve_one(setup_source)?;
-    let create_answers = answers_value(&create);
-    let setup_answers = answers_value(&setup);
+    // Snapshot BOTH documents once, then hand those files to every step.
+    // `gtc wizard --answers <url>` re-fetches on each invocation, and the
+    // README's `releases/latest` URLs are mutable — so without this the
+    // overwrite guard would be decided on one version of the create document
+    // while the wizard acted on another, and setup could receive a version
+    // incompatible with the bundle the wizard built.
+    let snapshot = TempDir::new()
+        .map_err(|err| UpError::usage(format!("creating the answers snapshot directory: {err}")))?;
+    let (create_answers, document) = snapshot_answers(snapshot.path(), "create", create_source)?;
+    let (setup_answers, _) = snapshot_answers(snapshot.path(), "setup", setup_source)?;
 
+    // Predicted unconditionally, even under `--bundle-dir`: this is where the
+    // wizard writes, so the guard needs it whatever the later steps use.
+    let wizard_dir = pin(&predict_bundle_dir(&document).map_err(UpError::usage)?)?;
     let bundle_dir = match sub_matches.get_one::<String>("bundle-dir") {
-        Some(explicit) => PathBuf::from(explicit),
-        None => {
-            let document = crate::answer_resolver::load_answers(&create_answers)
-                .map_err(|err| UpError::usage(format!("--answers {create_answers}: {err}")))?;
-            predict_bundle_dir(&document).map_err(UpError::usage)?
-        }
+        Some(explicit) => pin(Path::new(explicit))?,
+        None => wizard_dir.clone(),
     };
-    let bundle_dir = absolutize(&bundle_dir)
-        .map_err(|err| UpError::usage(format!("resolving {}: {err}", bundle_dir.display())))?;
 
     Ok(UpPlan {
+        wizard_dir,
         bundle_dir,
         create_answers,
         setup_answers,
@@ -210,24 +223,47 @@ fn build_plan(sub_matches: &ArgMatches) -> Result<UpPlan, UpError> {
         start: !sub_matches.get_flag("no-start"),
         dry_run: sub_matches.get_flag("dry-run"),
         force: sub_matches.get_flag("force"),
-        _answers_tempdirs: vec![create, setup],
+        _snapshot: snapshot,
     })
 }
 
-fn resolve_one(source: &str) -> Result<ResolvedAnswersArgs, UpError> {
-    resolve_answers_args(&["--answers".to_string(), source.to_string()]).map_err(|err| UpError {
+/// Every directory a step may write, deduplicated.
+///
+/// `bundle_dir` differs from `wizard_dir` only under `--bundle-dir`, and then
+/// both are live: the wizard writes one, setup and start the other.
+fn guarded_dirs(plan: &UpPlan) -> Vec<&Path> {
+    let mut dirs = vec![plan.wizard_dir.as_path()];
+    if plan.bundle_dir != plan.wizard_dir {
+        dirs.push(plan.bundle_dir.as_path());
+    }
+    dirs
+}
+
+/// Fetch a document once, keep the exact bytes, and return the path every
+/// later step reads plus the parsed document for prediction.
+///
+/// The snapshot directory is `tempfile`'s 0700, which is what keeps the
+/// setup document's provider credentials off a shared machine.
+fn snapshot_answers(
+    dir: &Path,
+    name: &str,
+    source: &str,
+) -> Result<(String, Map<String, Value>), UpError> {
+    let loader = DefaultAnswerSourceLoader;
+    let to_err = |err: gtc::error::GtcError| UpError {
         message: format!("{err}"),
         code: answers_error_exit_code(&err),
-    })
+    };
+    let bytes = load_answer_bytes(source, &loader).map_err(to_err)?;
+    let document = parse_answers_bytes(source, &bytes).map_err(to_err)?;
+    let path = dir.join(format!("{name}-answers.json"));
+    std::fs::write(&path, &bytes)
+        .map_err(|err| UpError::usage(format!("writing {}: {err}", path.display())))?;
+    Ok((path.display().to_string(), document))
 }
 
-/// The resolved path `resolve_answers_args` rewrote `--answers <src>` into.
-fn answers_value(resolved: &ResolvedAnswersArgs) -> String {
-    resolved
-        .args
-        .get(1)
-        .cloned()
-        .expect("resolve_answers_args preserves the --answers value")
+fn pin(path: &Path) -> Result<PathBuf, UpError> {
+    absolutize(path).map_err(|err| UpError::usage(format!("resolving {}: {err}", path.display())))
 }
 
 /// Predict the directory the bundle wizard will create.
@@ -398,12 +434,21 @@ fn start_tail_suffix(tail: &[String]) -> String {
 
 fn print_dry_run(plan: &UpPlan) {
     println!("bundle directory: {}", plan.bundle_dir.display());
+    if plan.bundle_dir != plan.wizard_dir {
+        // Surface the split: the wizard writes one directory and setup/start
+        // read another, and a dry run that showed only one would hide it.
+        println!("wizard writes to:  {}", plan.wizard_dir.display());
+    }
     println!("steps:");
     if plan.install {
         println!("  install  gtc install --skip-self-update");
     }
     println!("  wizard   gtc wizard --answers {}", plan.create_answers);
     println!("  verify   {} exists", plan.bundle_dir.display());
+    println!(
+        "  guard    {} must not already exist",
+        plan.wizard_dir.display()
+    );
     println!(
         "  setup    gtc setup {} --answers {} --non-interactive",
         plan.bundle_dir.display(),
@@ -423,10 +468,10 @@ pub(super) fn after_help(locale: &str) -> String {
         "gtc.cmd.up.after_help",
         "Runs install -> wizard -> setup -> start as one command, ending in a \
          foreground server (Ctrl+C to stop). Both answer documents are \
-         required; `up` never guesses the second one. Setup flags (--tenant, \
-         --team, --env, --advanced) are NOT forwarded — run the four commands \
-         separately if you need them. Everything after `--` is forwarded to \
-         the start step.",
+         required; `up` never guesses the second one, and both are fetched \
+         once and reused by every step. Setup flags (--tenant, --team, --env, \
+         --advanced) are NOT forwarded — run the four commands separately if \
+         you need them. Everything after `--` is forwarded to the start step.",
     )
 }
 
@@ -491,8 +536,10 @@ mod tests {
 
     #[test]
     fn a_blank_output_dir_falls_back_rather_than_predicting_the_cwd() {
-        // greentic-bundle maps an empty output_dir to "."; predicting the CWD
-        // would make the exists-guard fire on every run.
+        // Mirrors `normalized_request_from_document` in greentic-bundle, which
+        // trims `output_dir`, discards it when empty, and falls back to the
+        // derived default. NOT `normalize_output_dir`'s empty-maps-to-"." rule
+        // — that guards other seed paths and never sees a value from here.
         let doc = bundle_doc(json!({
             "bundle_id": "quickstart",
             "output_dir": "   ",
@@ -610,6 +657,142 @@ mod tests {
             assert!(!matches.get_flag(selector), "{selector} should be unset");
         }
         assert!(!matches.get_flag("dry-run"));
+    }
+
+    fn plan_with(wizard: &str, bundle: &str) -> UpPlan {
+        UpPlan {
+            wizard_dir: PathBuf::from(wizard),
+            bundle_dir: PathBuf::from(bundle),
+            create_answers: String::new(),
+            setup_answers: String::new(),
+            start_tail: Vec::new(),
+            install: false,
+            start: false,
+            dry_run: true,
+            force: false,
+            _snapshot: TempDir::new().unwrap(),
+        }
+    }
+
+    #[test]
+    fn the_guard_covers_the_wizard_directory_even_under_bundle_dir() {
+        // --bundle-dir does NOT redirect the wizard, so guarding only it would
+        // leave the document's directory free to be overwritten without
+        // --force. Both must be checked.
+        let plan = plan_with("/work/from-document", "/work/override");
+        assert_eq!(
+            guarded_dirs(&plan),
+            vec![
+                Path::new("/work/from-document"),
+                Path::new("/work/override")
+            ]
+        );
+    }
+
+    #[test]
+    fn the_guard_does_not_repeat_a_single_directory() {
+        let plan = plan_with("/work/demo-bundle", "/work/demo-bundle");
+        assert_eq!(guarded_dirs(&plan), vec![Path::new("/work/demo-bundle")]);
+    }
+
+    #[test]
+    fn a_snapshot_is_byte_identical_and_read_back_from_disk() {
+        // Every step must see the SAME bytes: a `releases/latest` URL can
+        // change between the guard decision and the wizard's own fetch.
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("origin.json");
+        let raw = br#"{"answers":{"selected_action":"bundle"},"note":"kept verbatim"}"#;
+        std::fs::write(&source, raw).unwrap();
+
+        let (path, document) =
+            snapshot_answers(dir.path(), "create", &source.display().to_string())
+                .map_err(|err| err.message)
+                .unwrap();
+        assert_ne!(path, source.display().to_string(), "must be a copy");
+        assert_eq!(std::fs::read(&path).unwrap(), raw);
+        assert_eq!(document["note"], "kept verbatim");
+
+        // Mutating the origin afterwards must not reach any step.
+        std::fs::write(&source, br#"{"answers":{"selected_action":"pack"}}"#).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), raw);
+    }
+
+    /// Build a real `UpPlan` the way `run_up` does: through clap, from files
+    /// on disk. Without this, the guard's most important property — that
+    /// `--bundle-dir` cannot detach it from the wizard — is only asserted
+    /// against a hand-built struct, and a `build_plan` that wired the two
+    /// together would sail through.
+    fn build_plan_from(dir: &Path, extra: &[&str]) -> UpPlan {
+        let create = dir.join("create.json");
+        let setup = dir.join("setup.json");
+        std::fs::write(
+            &create,
+            serde_json::to_vec(&bundle_doc(json!({
+                "bundle_id": "helpdesk-itsm-demo",
+                "output_dir": "from-document",
+            })))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(&setup, br#"{"tenant":"demo"}"#).unwrap();
+
+        let mut argv = vec![
+            "gtc".to_string(),
+            "up".to_string(),
+            "--answers".to_string(),
+            create.display().to_string(),
+            "--setup-answers".to_string(),
+            setup.display().to_string(),
+        ];
+        argv.extend(extra.iter().map(|value| value.to_string()));
+
+        let matches = build_cli("en")
+            .try_get_matches_from(argv)
+            .expect("up parses");
+        let sub = matches
+            .subcommand_matches("up")
+            .expect("up matches")
+            .clone();
+        build_plan(&sub).map_err(|err| err.message).expect("plan")
+    }
+
+    #[test]
+    fn bundle_dir_never_detaches_the_guard_from_the_wizard() {
+        // The whole point of the guard: `--bundle-dir` moves where setup and
+        // start look, NOT where the wizard writes. If build_plan ever sets
+        // wizard_dir from the override, the document's directory becomes
+        // overwritable without --force.
+        let dir = TempDir::new().unwrap();
+        let plan = build_plan_from(dir.path(), &["--bundle-dir", "/work/override"]);
+        assert!(
+            plan.wizard_dir.ends_with("from-document"),
+            "wizard_dir must come from the document, got {}",
+            plan.wizard_dir.display()
+        );
+        assert_eq!(plan.bundle_dir, PathBuf::from("/work/override"));
+        assert_eq!(guarded_dirs(&plan).len(), 2);
+    }
+
+    #[test]
+    fn without_an_override_both_directories_are_the_documents() {
+        let dir = TempDir::new().unwrap();
+        let plan = build_plan_from(dir.path(), &[]);
+        assert_eq!(plan.bundle_dir, plan.wizard_dir);
+        assert!(plan.wizard_dir.ends_with("from-document"));
+        assert_eq!(guarded_dirs(&plan).len(), 1);
+    }
+
+    #[test]
+    fn build_plan_hands_every_step_a_snapshot_not_the_original() {
+        let dir = TempDir::new().unwrap();
+        let plan = build_plan_from(dir.path(), &[]);
+        for answers in [&plan.create_answers, &plan.setup_answers] {
+            assert!(
+                !answers.starts_with(&dir.path().display().to_string()),
+                "{answers} is the original, not a snapshot"
+            );
+            assert!(Path::new(answers).is_file(), "{answers} is missing");
+        }
     }
 
     #[test]

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -16,7 +16,10 @@ use clap::ArgMatches;
 use serde_json::{Map, Value};
 use tempfile::TempDir;
 
-use crate::answer_resolver::{DefaultAnswerSourceLoader, load_answer_bytes, parse_answers_bytes};
+use crate::answer_resolver::{
+    AnswerSourceKind, AnswerSourceLoader, DefaultAnswerSourceLoader, classify_answers_source,
+    load_answer_bytes, parse_answers_bytes,
+};
 use crate::cli::build_cli;
 use crate::commands::{answers_error_exit_code, check_release_context};
 use crate::deploy::run_start;
@@ -199,8 +202,13 @@ fn build_plan(sub_matches: &ArgMatches) -> Result<UpPlan, UpError> {
     // incompatible with the bundle the wizard built.
     let snapshot = TempDir::new()
         .map_err(|err| UpError::usage(format!("creating the answers snapshot directory: {err}")))?;
-    let (create_answers, document) = snapshot_answers(snapshot.path(), "create", create_source)?;
-    let (setup_answers, _) = snapshot_answers(snapshot.path(), "setup", setup_source)?;
+    let loader = DefaultAnswerSourceLoader;
+    let (create_answers, document) =
+        snapshot_answers(snapshot.path(), "create", create_source, &loader)?;
+    // The setup document's parse is discarded, but not wasted: it is what makes
+    // a malformed setup document fail here rather than at the setup step, after
+    // the wizard has already created a bundle.
+    let (setup_answers, _) = snapshot_answers(snapshot.path(), "setup", setup_source, &loader)?;
 
     // Predicted unconditionally, even under `--bundle-dir`: this is where the
     // wizard writes, so the guard needs it whatever the later steps use.
@@ -239,23 +247,43 @@ fn guarded_dirs(plan: &UpPlan) -> Vec<&Path> {
     dirs
 }
 
-/// Fetch a document once, keep the exact bytes, and return the path every
-/// later step reads plus the parsed document for prediction.
+/// Read a document once and return the path every later step reads, plus the
+/// parsed document for prediction.
 ///
-/// The snapshot directory is `tempfile`'s 0700, which is what keeps the
-/// setup document's provider credentials off a shared machine.
+/// A **remote** source is materialized into `dir` so all three readers see the
+/// same bytes: `gtc wizard --answers <url>` re-fetches on every invocation, and
+/// the README's `releases/latest` URLs are mutable, so otherwise the overwrite
+/// guard could be decided on one version while the wizard acted on another.
+/// The snapshot directory is `tempfile`'s 0700, which keeps the setup
+/// document's provider credentials off a shared machine.
+///
+/// A **local** source is validated and passed through at its original path. It
+/// must not be relocated: greentic-bundle resolves relative pack and provider
+/// references against the answers file's own directory
+/// (`local_reference_base_dir`), and only *remote* documents are required to
+/// carry absolute references. Copying a local document into a tempdir would
+/// silently break every relative reference in it.
 fn snapshot_answers(
     dir: &Path,
     name: &str,
     source: &str,
+    loader: &dyn AnswerSourceLoader,
 ) -> Result<(String, Map<String, Value>), UpError> {
-    let loader = DefaultAnswerSourceLoader;
     let to_err = |err: gtc::error::GtcError| UpError {
         message: format!("{err}"),
         code: answers_error_exit_code(&err),
     };
-    let bytes = load_answer_bytes(source, &loader).map_err(to_err)?;
+    let kind = classify_answers_source(source).map_err(to_err)?;
+    let bytes = load_answer_bytes(source, loader).map_err(to_err)?;
     let document = parse_answers_bytes(source, &bytes).map_err(to_err)?;
+
+    if matches!(
+        kind,
+        AnswerSourceKind::LocalPath | AnswerSourceKind::FileUrl
+    ) {
+        return Ok((source.to_string(), document));
+    }
+
     let path = dir.join(format!("{name}-answers.json"));
     std::fs::write(&path, &bytes)
         .map_err(|err| UpError::usage(format!("writing {}: {err}", path.display())))?;
@@ -695,26 +723,76 @@ mod tests {
         assert_eq!(guarded_dirs(&plan), vec![Path::new("/work/demo-bundle")]);
     }
 
+    #[derive(Default)]
+    struct CountingLoader {
+        http_calls: std::cell::Cell<usize>,
+    }
+
+    impl crate::answer_resolver::AnswerSourceLoader for CountingLoader {
+        fn load_http(&self, _source: &str) -> gtc::error::GtcResult<Vec<u8>> {
+            self.http_calls.set(self.http_calls.get() + 1);
+            Ok(br#"{"answers":{"selected_action":"bundle"},"note":"fetched once"}"#.to_vec())
+        }
+
+        fn load_distributor(&self, _source: &str) -> gtc::error::GtcResult<Vec<u8>> {
+            unreachable!("not exercised")
+        }
+    }
+
     #[test]
-    fn a_snapshot_is_byte_identical_and_read_back_from_disk() {
-        // Every step must see the SAME bytes: a `releases/latest` URL can
-        // change between the guard decision and the wizard's own fetch.
+    fn a_remote_document_is_fetched_once_and_materialized() {
+        // The point of the snapshot: `gtc wizard --answers <url>` re-fetches on
+        // every invocation and `releases/latest` is mutable, so the guard could
+        // otherwise be decided on different bytes than the wizard acts on.
+        let dir = TempDir::new().unwrap();
+        let loader = CountingLoader::default();
+        let (path, document) = snapshot_answers(
+            dir.path(),
+            "create",
+            "https://example.com/create-answers.json",
+            &loader,
+        )
+        .map_err(|err| err.message)
+        .unwrap();
+
+        assert_eq!(loader.http_calls.get(), 1, "fetched exactly once");
+        assert!(
+            Path::new(&path).starts_with(dir.path()),
+            "{path} is not inside the snapshot directory"
+        );
+        assert_eq!(document["note"], "fetched once");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            br#"{"answers":{"selected_action":"bundle"},"note":"fetched once"}"#,
+            "bytes must be written verbatim, not re-serialized"
+        );
+    }
+
+    #[test]
+    fn a_local_document_is_never_relocated() {
+        // greentic-bundle resolves relative pack/provider references against
+        // the answers file's OWN directory (`local_reference_base_dir`).
+        // Copying a local document into a tempdir would move that base and
+        // silently break every relative reference in it.
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("origin.json");
         let raw = br#"{"answers":{"selected_action":"bundle"},"note":"kept verbatim"}"#;
         std::fs::write(&source, raw).unwrap();
 
-        let (path, document) =
-            snapshot_answers(dir.path(), "create", &source.display().to_string())
-                .map_err(|err| err.message)
-                .unwrap();
-        assert_ne!(path, source.display().to_string(), "must be a copy");
-        assert_eq!(std::fs::read(&path).unwrap(), raw);
+        let (path, document) = snapshot_answers(
+            dir.path(),
+            "create",
+            &source.display().to_string(),
+            &CountingLoader::default(),
+        )
+        .map_err(|err| err.message)
+        .unwrap();
+        assert_eq!(
+            path,
+            source.display().to_string(),
+            "a local document must be passed through at its original path"
+        );
         assert_eq!(document["note"], "kept verbatim");
-
-        // Mutating the origin afterwards must not reach any step.
-        std::fs::write(&source, br#"{"answers":{"selected_action":"pack"}}"#).unwrap();
-        assert_eq!(std::fs::read(&path).unwrap(), raw);
     }
 
     /// Build a real `UpPlan` the way `run_up` does: through clap, from files
@@ -783,14 +861,10 @@ mod tests {
     }
 
     #[test]
-    fn build_plan_hands_every_step_a_snapshot_not_the_original() {
+    fn build_plan_hands_every_step_a_readable_document() {
         let dir = TempDir::new().unwrap();
         let plan = build_plan_from(dir.path(), &[]);
         for answers in [&plan.create_answers, &plan.setup_answers] {
-            assert!(
-                !answers.starts_with(&dir.path().display().to_string()),
-                "{answers} is the original, not a snapshot"
-            );
             assert!(Path::new(answers).is_file(), "{answers} is missing");
         }
     }


### PR DESCRIPTION
Ask 4 of the did:web train: collapse the documented five-command quickstart to
two lines.

```bash
cargo binstall gtc
gtc up \
  --answers https://…/helpdesk-itsm-create-answers.json \
  --setup-answers https://…/helpdesk-itsm-setup-answers.json
```

Works with all 18 existing demo documents unchanged. No new answers format, no
demo-repo change, and no change to `greentic-dev`, `greentic-setup`,
`greentic-start` or `greentic-bundle` — this is composition inside `gtc`.

Both documents are required. There is deliberately no single-flag form that
derives the second URL from the first: every demo names them
`-create-answers.json` / `-setup-answers.json` today, and guessing on that
pattern fails confusingly the first time one does not.

## The design gate's structural finding

`gtc start <dir>` looks like a passthrough to `greentic-start` and is not. It
resolves the bundle ref, prepares it, generates admin certs, runs
`greentic-setup env-deploy`, and only then starts `greentic-start`
**bundle-less** — a bundle ref no longer boots the legacy bundle-scoped
ingress. An `up` that rebuilt `greentic-start <dir>` would start a server with
nothing deployed, and it would fail at *runtime*, so tests asserting argv would
have passed.

`up` therefore composes gtc's own entry points: `run_install`, the wizard and
setup passthroughs, `run_start`. Flag changes in those paths cannot drift it.

## What the composition must add

| | why |
|---|---|
| `--non-interactive` on setup | The wizard infers `--yes --non-interactive` from `--answers`; **`greentic-setup` does not**. Without it setup opens a web UI or blocks on stdin, and in CI that reads as a hang, not a failure. |
| `--skip-self-update` on install | `run_install` otherwise replaces the running gtc binary on disk mid-command, leaving the remaining steps on the old in-memory image. |

The install matches are produced by re-parsing through the real `install`
definitions rather than fabricating an `ArgMatches`, so `up` cannot drift from
`gtc install` — and a test asserts no phase selector sneaks in, which would
silently install less.

## Predicting the bundle directory

The wizard child inherits stdio, so the path it creates cannot be read back.
The create document already carries it at
`answers.delegate_answer_document.answers.output_dir`; `up` reads it up front
and pins it to the CWD **once**, since `output_dir` is relative and a later step
must not resolve it against a different directory.

Absent `output_dir`, `up` mirrors greentic-bundle's `normalize_bundle_id` /
`default_bundle_output_dir`. That mirror can drift — so after the wizard runs,
`up` confirms the directory exists and fails naming the predicted path, instead
of surfacing the drift two steps later as "bundle not found". A
`selected_action: "pack"` document is refused before anything runs: a pack run
produces no directory for setup or start to act on.

## Refusing to overwrite

`up` refuses when the predicted directory exists, naming `--force` and
`--bundle-dir`. Stricter than the four commands it replaces, on purpose: a
composite hides which step is destructive, and setup persists state into the
bundle directory (`tunnel-handoff.json`, `static-routes.json`, endpoints) that
the answers documents do not reproduce — re-running the wizard in create mode
over it orphans a tunnel still bound to the old port. `--force` says so.

Release context is checked **once**. Both `gtc wizard` and `gtc setup` check it
today and the companion binaries know nothing about it, so there is no flag to
suppress downstream — the composite simply must not ask three times. It is a
network call, so this is also a latency win.

Setup's `--tenant`, `--team`, `--env`, `--advanced` are **not** forwarded, and
`up --help` says so rather than leaving it to be discovered. Everything after
`--` goes to the start step; with `--no-start` it appears in the printed
command instead of vanishing.

## Verification

Run against the **live** greentic-demo release documents over https, not
fixtures:

```
bundle directory: …/upwork/helpdesk-itsm-demo-bundle
steps:
  install  gtc install --skip-self-update
  wizard   gtc wizard --answers https://…/helpdesk-itsm-create-answers.json
  verify   …/upwork/helpdesk-itsm-demo-bundle exists
  setup    gtc setup …/upwork/helpdesk-itsm-demo-bundle --answers https://…/helpdesk-itsm-setup-answers.json --non-interactive
  start    gtc start …/upwork/helpdesk-itsm-demo-bundle
```

The exists-guard exits 2; `--force` clears it; a pack document and a missing
`--setup-answers` exit 2; an unreadable source exits 1.

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D
warnings`, and **497 tests** across lib/bins/tests pass.

Two caveats, stated rather than buried:

- The `perf` bench does not link locally (mold vs the `alloca` crate). I
  reproduced it on a stashed clean tree, so it predates this change and is an
  environment issue, not a regression.
- Eight mutations proved, each compiling and then failing a **named** test:
  drop `--non-interactive`; drop `--skip-self-update`; narrow install to
  binaries-only; ignore `output_dir`; accept a pack document; skip the path
  rebuild; treat a blank `output_dir` as the CWD; guess a directory when both
  fields are absent. A ninth — swapping the setup argv at its call site inside
  `run_up` — is **not** caught: the tests cover `setup_tail` in isolation, and
  covering the call site needs process injection, a larger refactor than this
  change warrants.

## Deliberately not here

`gtc up --updates`, which would apply `{"updates": {}}` so a fresh environment
anchors on `did:web:trust.greentic.cloud` and subscribes to the fleet channel.
That turns `up` from "compose three commands" into "compose three commands and
mutate a trust root", so it gets its own PR and its own review. Follows
immediately.
