### PR TITLE
ci(gtc): add bundle-dir mirror drift check

### DIFF
--- a/ci/check_bundle_dir_mirror.sh
+++ b/ci/check_bundle_dir_mirror.sh
@@ -18,7 +18,28 @@ set -euo pipefail
 #
 # Fails closed: exits non-zero when the sibling greentic-bundle checkout is
 # missing, when a source file is absent, or when a function body cannot be
-# extracted.
+# extracted. `local_check.sh` runs it by default; skipping requires an explicit
+# SKIP_BUNDLE_DIR_MIRROR_CHECK=1, so a missing sibling is never silently
+# equivalent to "no drift".
+#
+# Two limits a reader must not over-trust:
+#
+#   1. `extract_fn` takes the FIRST `fn <name>(` match in the file. There is
+#      exactly one definition of each in both files today, so it is correct as
+#      written; a second definition (a test helper, a doc example) would
+#      silently extract the wrong body.
+#   2. Textual identity is neither necessary nor sufficient for behavioural
+#      identity. A comment or a rustfmt reflow fails this check spuriously,
+#      while splitting the function into helpers — or
+#      `normalized_request_from_document` ceasing to call it at all — passes
+#      while real behaviour drifts.
+#
+# The durable fix is to stop mirroring: make the two functions `pub` in
+# greentic-bundle (its modules are already `pub`) and add that crate as a
+# DEV-dependency of gtc, then assert agreement over a vector table in a test.
+# Dev-dependencies are not shipped, so the heavy transitive tree costs
+# consumers nothing, and the comparison becomes behavioural. This script is
+# the interim local guard until that lands.
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 bundle_repo="${GREENTIC_BUNDLE_REPO:-$repo_root/../greentic-bundle}"

--- a/ci/check_bundle_dir_mirror.sh
+++ b/ci/check_bundle_dir_mirror.sh
@@ -42,11 +42,33 @@ set -euo pipefail
 # the interim local guard until that lands.
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-bundle_repo="${GREENTIC_BUNDLE_REPO:-$repo_root/../greentic-bundle}"
+
+# Locate the sibling checkout. An explicit GREENTIC_BUNDLE_REPO always wins and
+# is never second-guessed: a wrong explicit path must fail loudly rather than
+# silently resolve to some other checkout.
+#
+# Otherwise try beside this checkout, then beside the MAIN worktree. The second
+# candidate is what makes the check usable from a linked worktree
+# (`gt-worktrees/<branch>/`), where `..` is the worktree parent and holds no
+# sibling repos. Without it, running fail-closed would fail every worktree by
+# default — trading a silent skip for a false alarm, which trains people to
+# reach for the opt-out.
+if [[ -n "${GREENTIC_BUNDLE_REPO:-}" ]]; then
+  bundle_repo="$GREENTIC_BUNDLE_REPO"
+else
+  bundle_repo="$repo_root/../greentic-bundle"
+  if [[ ! -d "$bundle_repo" ]] && git -C "$repo_root" rev-parse --git-common-dir >/dev/null 2>&1; then
+    main_worktree="$(cd "$(git -C "$repo_root" rev-parse --git-common-dir)/.." && pwd)"
+    if [[ -d "$main_worktree/../greentic-bundle" ]]; then
+      bundle_repo="$main_worktree/../greentic-bundle"
+    fi
+  fi
+fi
 
 if [[ ! -d "$bundle_repo" ]]; then
   echo "error: greentic-bundle checkout not found at $bundle_repo" >&2
-  echo "  Set GREENTIC_BUNDLE_REPO or check out greentic-bundle as a sibling." >&2
+  echo "  Set GREENTIC_BUNDLE_REPO, or check out greentic-bundle beside this repo." >&2
+  echo "  To run without this check: SKIP_BUNDLE_DIR_MIRROR_CHECK=1" >&2
   exit 1
 fi
 

--- a/ci/check_bundle_dir_mirror.sh
+++ b/ci/check_bundle_dir_mirror.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci/check_bundle_dir_mirror.sh
+#
+# Verifies that gtc's mirror copies of greentic-bundle's bundle-directory
+# prediction functions have not drifted from the canonical implementation
+# in the wizard (greentic-bundle/src/wizard/mod.rs).
+#
+# Compared functions:
+#   - normalize_bundle_id
+#   - default_bundle_output_dir
+#
+# The output_dir trim/empty-check chain in predict_bundle_dir is structurally
+# different from normalized_request_from_document (different function shape,
+# same semantics) and is covered by the unit tests in up.rs rather than by
+# this source-level check.
+#
+# Fails closed: exits non-zero when the sibling greentic-bundle checkout is
+# missing, when a source file is absent, or when a function body cannot be
+# extracted.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle_repo="${GREENTIC_BUNDLE_REPO:-$repo_root/../greentic-bundle}"
+
+if [[ ! -d "$bundle_repo" ]]; then
+  echo "error: greentic-bundle checkout not found at $bundle_repo" >&2
+  echo "  Set GREENTIC_BUNDLE_REPO or check out greentic-bundle as a sibling." >&2
+  exit 1
+fi
+
+gtc_source="$repo_root/src/bin/gtc/up.rs"
+bundle_source="$bundle_repo/src/wizard/mod.rs"
+
+for f in "$gtc_source" "$bundle_source"; do
+  if [[ ! -f "$f" ]]; then
+    echo "error: source file not found: $f" >&2
+    exit 1
+  fi
+done
+
+# Extract a Rust function body by name: from "fn $name(" through its closing
+# "}" at brace-depth zero.  Handles nested blocks and balanced braces in
+# format strings.  Does NOT parse strings/comments, but the target functions
+# contain only balanced braces in both contexts, so this is safe.
+extract_fn() {
+  local file="$1" name="$2"
+  awk -v name="$name" '
+    BEGIN { found = 0; depth = 0 }
+    !found && $0 ~ "fn " name "\\(" { found = 1 }
+    found {
+      print
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "{") depth = depth + 1
+        else if (c == "}") {
+          depth = depth - 1
+          if (depth == 0) exit
+        }
+      }
+    }
+  ' "$file"
+}
+
+failures=0
+
+check_fn() {
+  local name="$1"
+  local gtc_body bundle_body
+
+  gtc_body="$(extract_fn "$gtc_source" "$name")"
+  bundle_body="$(extract_fn "$bundle_source" "$name")"
+
+  if [[ -z "$gtc_body" ]]; then
+    echo "error: could not extract $name from $gtc_source" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ -z "$bundle_body" ]]; then
+    echo "error: could not extract $name from $bundle_source" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [[ "$gtc_body" != "$bundle_body" ]]; then
+    echo "DRIFT: $name differs between gtc and greentic-bundle" >&2
+    echo "" >&2
+    echo "--- greentic-bundle (canonical)" >&2
+    echo "$bundle_body" >&2
+    echo "" >&2
+    echo "+++ gtc (mirror)" >&2
+    echo "$gtc_body" >&2
+    echo "" >&2
+    diff <(echo "$bundle_body") <(echo "$gtc_body") >&2 || true
+    failures=$((failures + 1))
+  else
+    echo "ok: $name matches"
+  fi
+}
+
+check_fn "normalize_bundle_id"
+check_fn "default_bundle_output_dir"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "" >&2
+  echo "error: $failures function(s) drifted from greentic-bundle" >&2
+  echo "  Update the mirror in src/bin/gtc/up.rs to match" >&2
+  echo "  $bundle_source" >&2
+  exit 1
+fi
+
+echo "bundle-dir mirror check passed"

--- a/ci/local_check.sh
+++ b/ci/local_check.sh
@@ -17,8 +17,9 @@ if [[ "${SKIP_BUNDLE_DIR_MIRROR_CHECK:-}" == "1" ]]; then
   echo "[1c/6] bundle-dir mirror check (skipped: SKIP_BUNDLE_DIR_MIRROR_CHECK=1)"
 else
   echo "[1c/6] bundle-dir mirror check"
-  bundle_mirror_repo="${GREENTIC_BUNDLE_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/greentic-bundle}"
-  GREENTIC_BUNDLE_REPO="$bundle_mirror_repo" bash ci/check_bundle_dir_mirror.sh
+  # Let the script resolve the sibling: it also handles the linked-worktree
+  # layout. Forcing GREENTIC_BUNDLE_REPO here would defeat that fallback.
+  bash ci/check_bundle_dir_mirror.sh
 fi
 
 echo "[2/6] cargo fmt --all -- --check"

--- a/ci/local_check.sh
+++ b/ci/local_check.sh
@@ -13,6 +13,14 @@ fi
 echo "[1b/6] validate canonical doc examples"
 bash ci/validate_doc_examples.sh
 
+bundle_mirror_repo="${GREENTIC_BUNDLE_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/greentic-bundle}"
+if [[ -d "$bundle_mirror_repo" ]]; then
+  echo "[1c/6] bundle-dir mirror check"
+  GREENTIC_BUNDLE_REPO="$bundle_mirror_repo" bash ci/check_bundle_dir_mirror.sh
+else
+  echo "warning: greentic-bundle sibling not found; skipping bundle-dir mirror check" >&2
+fi
+
 echo "[2/6] cargo fmt --all -- --check"
 cargo fmt --all -- --check
 

--- a/ci/local_check.sh
+++ b/ci/local_check.sh
@@ -13,12 +13,12 @@ fi
 echo "[1b/6] validate canonical doc examples"
 bash ci/validate_doc_examples.sh
 
-bundle_mirror_repo="${GREENTIC_BUNDLE_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/greentic-bundle}"
-if [[ -d "$bundle_mirror_repo" ]]; then
-  echo "[1c/6] bundle-dir mirror check"
-  GREENTIC_BUNDLE_REPO="$bundle_mirror_repo" bash ci/check_bundle_dir_mirror.sh
+if [[ "${SKIP_BUNDLE_DIR_MIRROR_CHECK:-}" == "1" ]]; then
+  echo "[1c/6] bundle-dir mirror check (skipped: SKIP_BUNDLE_DIR_MIRROR_CHECK=1)"
 else
-  echo "warning: greentic-bundle sibling not found; skipping bundle-dir mirror check" >&2
+  echo "[1c/6] bundle-dir mirror check"
+  bundle_mirror_repo="${GREENTIC_BUNDLE_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/greentic-bundle}"
+  GREENTIC_BUNDLE_REPO="$bundle_mirror_repo" bash ci/check_bundle_dir_mirror.sh
 fi
 
 echo "[2/6] cargo fmt --all -- --check"


### PR DESCRIPTION
## Summary

`gtc up` must know where the wizard will write the bundle *before* running it, so it can refuse to clobber an existing directory. `predict_bundle_dir` (`src/bin/gtc/up.rs`, added by #260) does that by re-implementing greentic-bundle's rule. That rule now exists in three places, and a silent divergence is not cosmetic: the overwrite guard checks the directory it *predicted*, so drift means the guard protects one path while the wizard writes another.

- Adds `ci/check_bundle_dir_mirror.sh`: extracts `normalize_bundle_id` and `default_bundle_output_dir` from both `src/bin/gtc/up.rs` and the sibling `greentic-bundle/src/wizard/mod.rs`, diffs them, and fails with the offending diff when they diverge.
- Wires it into `ci/local_check.sh` as step 1c, **run by default**. Skipping requires an explicit `SKIP_BUNDLE_DIR_MIRROR_CHECK=1`; a missing sibling checkout fails with an actionable message rather than passing quietly.

The first revision let an absent sibling print a warning and continue. That made the gate default-off for exactly the developer most likely to drift the mirror unnoticed — the one without greentic-bundle checked out. A check that green-lights on absence reads as coverage while providing none.

Running fail-closed only helps if the sibling can actually be found, so resolution also falls back to the **main worktree's** sibling via `git rev-parse --git-common-dir`. Under `gt-worktrees/<branch>/` the parent directory holds other worktrees, not sibling repos — without the fallback, fail-closed would fail every linked worktree by default, trading a silent skip for a false alarm and teaching people to reach for the opt-out. An explicit `GREENTIC_BUNDLE_REPO` still wins outright and is never second-guessed: a wrong explicit path fails loudly rather than quietly resolving elsewhere.

## Scope: this is a local guard, not a CI gate

No workflow in this repo runs `ci/local_check.sh` — `ci.yml` delegates wholly to the shared `greenticai/.github` `host-crate-ci.yml`. That is true of every check in that file, not just this one. This addition is exactly as enforceable as `validate_doc_examples.sh` beside it. Making it a real CI gate means changing the shared org workflow, which is deliberately out of scope here.

## Why a check instead of deleting the duplication

`normalize_bundle_id` and `default_bundle_output_dir` are private (`fn`, not `pub fn`) in `greentic-bundle/src/wizard/mod.rs`, and no member crate re-exports them — so gtc cannot call them today.

The durable fix is nevertheless deletion, and it is small: greentic-bundle's modules are already `pub`, so making those two functions `pub` upstream and adding the crate as a **dev-dependency** of gtc would allow a behavioural vector test instead of a source-text diff. The "it drags in backhand, ed25519-dalek, ciborium" objection applies only to a *runtime* dependency; dev-dependencies are not shipped and cost consumers nothing. That needs a small PR against greentic-bundle first, so this script is the interim guard until it lands. Recorded in the script header so the next reader does not re-derive it.

## Two limits of the comparison, documented in the script

1. `extract_fn` takes the **first** `fn <name>(` match. There is exactly one definition of each in both files today, so it is correct as written; a second definition (a test helper, a doc example) would silently shadow it.
2. Textual identity is neither necessary nor sufficient for behavioural identity. A comment or a rustfmt reflow fails the check spuriously, while splitting the function into helpers — or `normalized_request_from_document` ceasing to call it at all — passes while real behaviour drifts.

## Known divergence in greentic-bundle (not fixed here)

`greentic-bundle/src/cli/init.rs` carries its own `normalize_bundle_id` that **diverges** from the wizard's: it returns `"bundle"` when the normalized result is empty, where the wizard returns `""` and lets `default_bundle_output_dir` handle the empty case. The resulting directory is `./bundle` either way, so it is latent rather than live — but it is a second implementation already drifting inside greentic-bundle. Their repo, their PR.

## Version bump

Deliberately omitted. A sibling PR is bumping 1.1.8 → 1.1.9 concurrently, and three branches editing `Cargo.toml` would guarantee a three-way conflict. This PR changes no crate code.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — all clean (63 tests)
- Matching bodies → passes
- `normalize_bundle_id` mutated (`'-'` → `'_'`) → fails with the diff, exit 1, then restores and passes again
- Sibling checkout missing → exit 1 with the actionable message, which now names the opt-out (previously a silent skip)
- `SKIP_BUNDLE_DIR_MIRROR_CHECK=1` → skips, and says so
- Run from a linked worktree with no environment set → resolves via the main worktree and passes (failed before the third commit)
- Explicit but wrong `GREENTIC_BUNDLE_REPO` → still exit 1, never silently re-resolved

The `perf` bench linker failure under mold (`undefined symbol: c_with_alloca`) reproduces on a clean tree and is environmental.
