### PR TITLE
fix(gtc): harden answer_resolver HTTP fetch

### DIFF
--- a/ci/local_check.sh
+++ b/ci/local_check.sh
@@ -25,6 +25,14 @@ cargo test --all-targets --all-features
 echo "[4b/6] cargo test --test perf_scaling hashing_scaling_should_not_collapse -- --ignored --exact"
 cargo test --test perf_scaling hashing_scaling_should_not_collapse -- --ignored --exact
 
+# The socket-binding tests are `#[ignore]`d so a sandbox without loopback can
+# still run `cargo test`. They are also the ONLY tests that drive the real HTTP
+# fetch paths end to end — everything else calls the validation helpers
+# directly, so a guard could be deleted from its call site with the whole suite
+# still green. Run them here or they never run at all.
+echo "[4c/6] cargo test --bin gtc -- --ignored (socket-binding fetch tests)"
+cargo test --bin gtc -- --ignored
+
 echo "[5/6] cargo publish --dry-run --allow-dirty"
 cargo publish --dry-run --allow-dirty
 

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Read;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -95,11 +96,32 @@ impl AnswerSourceLoader for DefaultAnswerSourceLoader {
                     .and_then(|v| v.to_str().ok()),
                 source,
             )?;
-            let bytes = response.bytes().map_err(|err| {
-                GtcError::message(format!("failed to read answers {source}: {err}"))
-            })?;
-            validate_response_size(bytes.len(), source)?;
-            return Ok(bytes.to_vec());
+            // Fast-path: reject immediately when Content-Length declares a
+            // body larger than the cap, avoiding any body read.
+            if let Some(declared) = response
+                .content_length()
+                .filter(|&len| len > HTTP_MAX_BYTES as u64)
+            {
+                return Err(GtcError::invalid_data(
+                    "answers fetch",
+                    format!(
+                        "{source} Content-Length is {declared} bytes, \
+                         exceeding the {HTTP_MAX_BYTES} byte limit",
+                    ),
+                ));
+            }
+            // Stream at most cap+1 bytes so a hostile or misconfigured
+            // endpoint cannot exhaust memory regardless of what
+            // Content-Length claims (or whether it is present at all).
+            let mut buf = Vec::new();
+            response
+                .take(HTTP_MAX_BYTES as u64 + 1)
+                .read_to_end(&mut buf)
+                .map_err(|err| {
+                    GtcError::message(format!("failed to read answers {source}: {err}"))
+                })?;
+            validate_response_size(buf.len(), source)?;
+            return Ok(buf);
         }
 
         Err(GtcError::invalid_data(
@@ -758,5 +780,177 @@ mod tests {
         let err = map_oci_answers_reference("repo:///answers:stable", &options).unwrap_err();
 
         assert!(err.to_string().contains("GREENTIC_REPO_REGISTRY_BASE"));
+    }
+
+    // -- call-site integration tests (drive load_http against a local server) --
+    //
+    // These prove the guards are wired into DefaultAnswerSourceLoader::load_http,
+    // not just that the validation functions work in isolation.
+
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn drain_http_request(stream: &mut std::net::TcpStream) {
+        let mut buf = [0u8; 4096];
+        let mut request = Vec::new();
+        loop {
+            let n = std::io::Read::read(stream, &mut buf).expect("read request");
+            request.extend_from_slice(&buf[..n]);
+            if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires local socket binding"]
+    fn load_http_rejects_html_content_type() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            drain_http_request(&mut stream);
+            let body = r#"<html><body>Not Found</body></html>"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: text/html\r\n\
+                 Content-Length: {}\r\n\r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let loader = super::DefaultAnswerSourceLoader;
+        let err = loader
+            .load_http(&format!("http://{addr}/answers.json"))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Content-Type"));
+        handle.join().expect("join");
+    }
+
+    #[test]
+    #[ignore = "requires local socket binding"]
+    fn load_http_rejects_oversized_content_length() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            drain_http_request(&mut stream);
+            // Declare a Content-Length far above the cap. The client should
+            // reject before reading any body, so we never send body bytes.
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\r\n",
+                super::HTTP_MAX_BYTES + 1_000_000,
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let loader = super::DefaultAnswerSourceLoader;
+        let err = loader
+            .load_http(&format!("http://{addr}/answers.json"))
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Content-Length"),
+            "expected Content-Length rejection, got: {err}"
+        );
+        handle.join().expect("join");
+    }
+
+    #[test]
+    #[ignore = "requires local socket binding"]
+    fn load_http_caps_body_without_content_length() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (tx, rx) = mpsc::channel::<usize>();
+        let cap = super::HTTP_MAX_BYTES;
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            drain_http_request(&mut stream);
+            // No Content-Length header. The client must enforce the cap via
+            // the streaming .take() guard.
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      Content-Type: application/json\r\n\
+                      Transfer-Encoding: identity\r\n\r\n",
+                )
+                .unwrap();
+            let chunk = vec![b'x'; 8192];
+            let mut written = 0usize;
+            // Send cap + 8192 bytes — more than the cap but not so much that
+            // the test is slow.
+            let target = cap + 8192;
+            while written < target {
+                let n = std::cmp::min(8192, target - written);
+                if stream.write_all(&chunk[..n]).is_err() {
+                    break; // client closed the connection
+                }
+                written += n;
+            }
+            tx.send(written).ok();
+        });
+
+        let loader = super::DefaultAnswerSourceLoader;
+        let err = loader
+            .load_http(&format!("http://{addr}/answers.json"))
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("exceeding"),
+            "expected size-cap rejection, got: {err}"
+        );
+        // The server may or may not have finished sending before the client
+        // closed. Either way, the client read at most cap+1 bytes.
+        let _ = rx.recv();
+        handle.join().expect("join");
+    }
+
+    #[test]
+    #[ignore = "requires local socket binding"]
+    fn load_http_follows_redirect_to_json() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handle = thread::spawn(move || {
+            // First request: redirect.
+            let (mut stream, _) = listener.accept().expect("accept first");
+            drain_http_request(&mut stream);
+            let response = "HTTP/1.1 302 Found\r\n\
+                            Location: /final\r\n\
+                            Connection: close\r\n\
+                            Content-Length: 0\r\n\r\n";
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+
+            // Second request: serve JSON.
+            let (mut stream, _) = listener.accept().expect("accept second");
+            drain_http_request(&mut stream);
+            let body = br#"{"ok":true}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(body).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let loader = super::DefaultAnswerSourceLoader;
+        let bytes = loader
+            .load_http(&format!("http://{addr}/start"))
+            .expect("should follow redirect and return JSON");
+
+        assert_eq!(bytes, br#"{"ok":true}"#);
+        handle.join().expect("join");
     }
 }

--- a/src/bin/gtc/answer_resolver.rs
+++ b/src/bin/gtc/answer_resolver.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use greentic_distributor_client::{
     DistClient, DistOptions, PackFetchOptions, default_pack_layer_media_types,
@@ -9,6 +10,18 @@ use gtc::error::{GtcError, GtcResult};
 use oci_distribution::Reference;
 use reqwest::blocking::Client;
 use serde_json::{Map, Value};
+
+/// Maximum size of an answers document fetched over HTTP (10 MiB).
+const HTTP_MAX_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum number of HTTP redirects to follow.
+const HTTP_MAX_REDIRECTS: usize = 10;
+
+/// HTTP connect timeout for answers fetches.
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Total HTTP timeout for answers fetches.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(super) trait AnswerSourceLoader {
     fn load_http(&self, source: &str) -> GtcResult<Vec<u8>>;
@@ -20,24 +33,79 @@ pub(super) struct DefaultAnswerSourceLoader;
 impl AnswerSourceLoader for DefaultAnswerSourceLoader {
     fn load_http(&self, source: &str) -> GtcResult<Vec<u8>> {
         let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_TIMEOUT)
             .build()
             .map_err(|err| GtcError::message(format!("failed to create HTTP client: {err}")))?;
-        let response = client
-            .get(source)
-            .header("Accept", "application/json")
-            .header("User-Agent", format!("gtc/{}", env!("CARGO_PKG_VERSION")))
-            .send()
-            .map_err(|err| GtcError::message(format!("failed to fetch answers {source}: {err}")))?;
-        let status = response.status();
-        if !status.is_success() {
-            return Err(GtcError::message(format!(
-                "failed to fetch answers {source}: HTTP {status}"
-            )));
+
+        let mut current = reqwest::Url::parse(source).map_err(|err| {
+            GtcError::invalid_data("answers source", format!("invalid URL {source}: {err}"))
+        })?;
+        let original_scheme = current.scheme().to_string();
+
+        for _ in 0..HTTP_MAX_REDIRECTS {
+            let response = client
+                .get(current.clone())
+                .header("Accept", "application/json")
+                .header("User-Agent", format!("gtc/{}", env!("CARGO_PKG_VERSION")))
+                .send()
+                .map_err(|err| {
+                    GtcError::message(format!("failed to fetch answers {source}: {err}"))
+                })?;
+
+            if response.status().is_redirection() {
+                let location = response
+                    .headers()
+                    .get(reqwest::header::LOCATION)
+                    .ok_or_else(|| {
+                        GtcError::invalid_data(
+                            "answers fetch",
+                            format!("redirect from {current} has no Location header"),
+                        )
+                    })?
+                    .to_str()
+                    .map_err(|err| {
+                        GtcError::invalid_data(
+                            "answers fetch",
+                            format!("invalid Location header from {current}: {err}"),
+                        )
+                    })?;
+                let next = current.join(location).map_err(|err| {
+                    GtcError::invalid_data(
+                        "answers fetch",
+                        format!("invalid redirect target {location}: {err}"),
+                    )
+                })?;
+                validate_redirect_scheme(&original_scheme, next.scheme(), &next)?;
+                current = next;
+                continue;
+            }
+
+            let status = response.status();
+            if !status.is_success() {
+                return Err(GtcError::message(format!(
+                    "failed to fetch answers {source}: HTTP {status}"
+                )));
+            }
+            validate_content_type(
+                response
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok()),
+                source,
+            )?;
+            let bytes = response.bytes().map_err(|err| {
+                GtcError::message(format!("failed to read answers {source}: {err}"))
+            })?;
+            validate_response_size(bytes.len(), source)?;
+            return Ok(bytes.to_vec());
         }
-        response
-            .bytes()
-            .map(|bytes| bytes.to_vec())
-            .map_err(|err| GtcError::message(format!("failed to read answers {source}: {err}")))
+
+        Err(GtcError::invalid_data(
+            "answers fetch",
+            format!("too many redirects while fetching {source}"),
+        ))
     }
 
     fn load_distributor(&self, source: &str) -> GtcResult<Vec<u8>> {
@@ -267,6 +335,59 @@ where
 
 fn is_json_media_type(media_type: &str) -> bool {
     media_type == "application/json" || media_type.ends_with("+json")
+}
+
+/// Reject HTTPS-to-HTTP scheme downgrades during redirect following.
+fn validate_redirect_scheme(
+    original_scheme: &str,
+    target_scheme: &str,
+    target: &reqwest::Url,
+) -> GtcResult<()> {
+    if original_scheme == "https" && target_scheme != "https" {
+        return Err(GtcError::invalid_data(
+            "answers fetch",
+            format!("refusing redirect to {target}: HTTPS to HTTP downgrade"),
+        ));
+    }
+    Ok(())
+}
+
+/// Reject responses whose Content-Type is clearly not JSON (e.g. HTML error
+/// pages). Missing Content-Type is allowed because some CDNs and GitHub raw
+/// URLs omit it.
+fn validate_content_type(content_type: Option<&str>, source: &str) -> GtcResult<()> {
+    let Some(ct) = content_type else {
+        return Ok(());
+    };
+    let media_type = ct.split(';').next().unwrap_or("").trim();
+    if media_type.is_empty()
+        || media_type == "application/json"
+        || media_type.ends_with("+json")
+        || media_type == "application/octet-stream"
+        || media_type == "text/plain"
+    {
+        return Ok(());
+    }
+    Err(GtcError::invalid_data(
+        "answers fetch",
+        format!(
+            "{source} returned Content-Type '{ct}'; expected application/json or a +json variant"
+        ),
+    ))
+}
+
+/// Reject responses that exceed the size cap.
+fn validate_response_size(len: usize, source: &str) -> GtcResult<()> {
+    if len > HTTP_MAX_BYTES {
+        return Err(GtcError::invalid_data(
+            "answers fetch",
+            format!(
+                "{source} response is {len} bytes, exceeding the {} byte limit",
+                HTTP_MAX_BYTES
+            ),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -520,6 +641,104 @@ mod tests {
             map_oci_answers_reference("repo:///answers:stable", &options).unwrap(),
             "ghcr.io/acme/answers:stable"
         );
+    }
+
+    // -- redirect scheme validation --
+
+    #[test]
+    fn rejects_https_to_http_redirect() {
+        let target = reqwest::Url::parse("http://evil.test/answers.json").unwrap();
+        let err = super::validate_redirect_scheme("https", "http", &target).unwrap_err();
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("HTTPS to HTTP downgrade"));
+    }
+
+    #[test]
+    fn accepts_https_to_https_redirect() {
+        let target = reqwest::Url::parse("https://cdn.example.com/answers.json").unwrap();
+        super::validate_redirect_scheme("https", "https", &target).unwrap();
+    }
+
+    #[test]
+    fn accepts_http_to_https_upgrade_redirect() {
+        let target = reqwest::Url::parse("https://secure.example.com/answers.json").unwrap();
+        super::validate_redirect_scheme("http", "https", &target).unwrap();
+    }
+
+    #[test]
+    fn accepts_http_to_http_redirect() {
+        let target = reqwest::Url::parse("http://other.example.com/answers.json").unwrap();
+        super::validate_redirect_scheme("http", "http", &target).unwrap();
+    }
+
+    // -- content-type validation --
+
+    #[test]
+    fn rejects_html_content_type() {
+        let err =
+            super::validate_content_type(Some("text/html"), "https://x.test/a.json").unwrap_err();
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("Content-Type"));
+    }
+
+    #[test]
+    fn rejects_html_content_type_with_charset() {
+        let err =
+            super::validate_content_type(Some("text/html; charset=utf-8"), "https://x.test/a.json")
+                .unwrap_err();
+        assert!(err.to_string().contains("Content-Type"));
+    }
+
+    #[test]
+    fn accepts_application_json_content_type() {
+        super::validate_content_type(Some("application/json"), "src").unwrap();
+    }
+
+    #[test]
+    fn accepts_vendor_json_content_type() {
+        super::validate_content_type(Some("application/vnd.greentic.answers.v1+json"), "src")
+            .unwrap();
+    }
+
+    #[test]
+    fn accepts_octet_stream_content_type() {
+        super::validate_content_type(Some("application/octet-stream"), "src").unwrap();
+    }
+
+    #[test]
+    fn accepts_text_plain_content_type() {
+        super::validate_content_type(Some("text/plain"), "src").unwrap();
+    }
+
+    #[test]
+    fn accepts_missing_content_type() {
+        super::validate_content_type(None, "src").unwrap();
+    }
+
+    #[test]
+    fn accepts_json_content_type_with_charset() {
+        super::validate_content_type(Some("application/json; charset=utf-8"), "src").unwrap();
+    }
+
+    // -- response size validation --
+
+    #[test]
+    fn rejects_oversized_response() {
+        let err =
+            super::validate_response_size(super::HTTP_MAX_BYTES + 1, "https://x.test/big.json")
+                .unwrap_err();
+        assert!(matches!(err, GtcError::InvalidData { .. }));
+        assert!(err.to_string().contains("exceeding"));
+    }
+
+    #[test]
+    fn accepts_response_at_size_limit() {
+        super::validate_response_size(super::HTTP_MAX_BYTES, "src").unwrap();
+    }
+
+    #[test]
+    fn accepts_small_response() {
+        super::validate_response_size(42, "src").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens `answer_resolver.rs` HTTP fetch path against four transport-level weaknesses that apply to all three commands using it (`wizard`, `setup`, `up`).

- **Redirect policy**: Manual redirect loop (max 10 hops) with HTTPS-to-HTTP downgrade rejection. Follows the `Policy::none()` + manual-loop pattern already used by `fetch_https_bytes` in `install.rs` and the `https_only + redirect(Policy::none())` precedent from `greentic-trust`.
- **Response size cap**: Enforced during the read via `response.take(cap+1).read_to_end()` — the client never buffers more than 10 MiB + 1 byte regardless of Content-Length or its absence. A Content-Length pre-check provides a fast path for the honest case (immediate rejection, no body read). `validate_response_size` remains a separate function for the +1 distinguishability check after the read.
- **Timeouts**: 30-second connect timeout, 60-second total request timeout. Prevents a hung endpoint from wedging the CLI indefinitely.
- **Content-Type validation**: Rejects responses whose Content-Type is clearly non-JSON (e.g. `text/html` error pages). Missing Content-Type is allowed (some CDNs and GitHub raw URLs omit it). Accepts `application/json`, `+json` variants, `application/octet-stream`, and `text/plain`.

### Streaming cap proof

The size cap is enforced structurally by `std::io::Read::take()`, which wraps the response reader in an adapter that returns EOF after reading the specified number of bytes. `read_to_end` on that adapter is guaranteed by the standard library to read at most N bytes, regardless of what the underlying stream produces. The cap+1 idiom makes "exactly at cap" (passes) distinguishable from "over cap" (fails). The Content-Length pre-check is an optimization that avoids any I/O when the server declares a large body, but the streaming guard is the real protection and does not rely on Content-Length being present or honest.

### What was left out (with reasons)

- **SHA-256 integrity (`--answers-sha256`)**: Deferred. Requires adding CLI flags to three commands (`wizard`, `setup`, `up`), modifying the `AnswerSourceLoader` trait or adding a post-load verification step, and plumbing through multiple call paths. The utility function is straightforward (`sha2` is already a dependency) but shipping it without a wired CLI flag would be dead code. Recommended as a follow-up PR.

### Backwards compatibility

The README's documented path (`--answers https://...releases/latest/...`) continues to work unchanged. GitHub's `releases/latest` redirects are HTTPS-to-HTTPS (same-scheme), so the redirect hardening does not block them. All new guards are either always-on-safe (redirect, timeout, size) or accept the content types GitHub actually returns.

### Version bump

Deliberately omitted. A sibling PR is bumping 1.1.8 to 1.1.9 concurrently; this change rides the next release.

## Test plan

- [x] 16 unit tests covering all four validation functions with accept and reject paths
- [x] 4 integration tests (`#[ignore = "requires local socket binding"]`) that drive `DefaultAnswerSourceLoader::load_http` against a real TcpListener server, proving the guards are wired into the actual fetch path
- [x] All existing tests pass (32 lib + 423 bin + 63 integration + 4 perf)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `bash ci/local_check.sh` passes (perf bench link failure is pre-existing mold/alloca issue)
- [x] Mutation testing: 8 mutations, all caught

### Mutation table

**Function-body mutations** (prove the validation logic is correct):

| Mutation | Result | Catching test |
|----------|--------|---------------|
| Disable redirect scheme check (always Ok) | CAUGHT | `rejects_https_to_http_redirect` |
| Disable content-type validation (always Ok) | CAUGHT | `rejects_html_content_type` |
| Disable size check (always Ok) | CAUGHT | `rejects_oversized_response` |
| Reject missing Content-Type (invert None branch) | CAUGHT | `accepts_missing_content_type` |

**Call-site mutations** (prove the guards are wired into `load_http`):

| Mutation | Result | Catching test |
|----------|--------|---------------|
| Remove `validate_content_type(...)?` call | CAUGHT | `load_http_rejects_html_content_type` |
| Remove `validate_response_size(...)? ` call | CAUGHT | `load_http_caps_body_without_content_length` |
| Remove Content-Length pre-check block | CAUGHT | `load_http_rejects_oversized_content_length` |
| Remove `validate_redirect_scheme(...)?` call | CAUGHT (compile) | dead-code error: `original_scheme` unused + `validate_redirect_scheme` never used |

The redirect scheme call-site cannot be exercised end-to-end via TcpListener (would require a TLS server to test HTTPS-to-HTTP downgrade). The compile-time dead-code detection under `-D warnings` catches the unwiring. This is an honest stated gap.


## The integration tests are now actually run

The tests that drive `load_http` end to end are `#[ignore]`d so a sandbox without loopback can still run `cargo test` — the right default, but nothing then ran them. `local_check.sh` invoked exactly one ignored test by name (`perf_scaling`), so the four new fetch tests, plus the two pre-existing `fetch_https_bytes` redirect tests that had been ignored since they were written, never executed in any gate.

That matters more here than it looks: every other test in this module calls the validation helpers directly, so deleting a guard from its **call site** leaves the whole suite green. The ignored tests are the only ones that would notice — and a test that proves the wiring but never runs proves nothing.

`local_check.sh` now runs `cargo test --bin gtc -- --ignored`, covering all six. Proved by deleting `validate_response_size(buf.len(), source)?` from the fetch path: `cargo test --bin gtc` stayed fully green (423 passed), while the new step failed with `load_http_caps_body_without_content_length`.
