### PR TITLE
feat(up): add --updates flag to subscribe env to fleet update channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.8"
+version = "1.1.9"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -140,5 +140,9 @@
   "gtc.arg.up.no_start.help": "Stop after setup and print the start command instead of running it.",
   "gtc.arg.up.dry_run.help": "Print the resolved bundle directory and every step, then exit without running any of them.",
   "gtc.arg.up.force.help": "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.",
-  "gtc.arg.up.start_args.help": "Arguments after `--`, forwarded verbatim to the start step."
+  "gtc.arg.up.updates.help": "Subscribe the environment to the fleet update channel after setup. Seeds the trust root and configures polling against the default plan endpoint.",
+  "gtc.arg.up.start_args.help": "Arguments after `--`, forwarded verbatim to the start step.",
+  "gtc.up.err.updates_version_gate": "--updates requires a newer greentic-operator",
+  "gtc.up.err.updates_manifest_write": "failed to write the updates manifest",
+  "gtc.up.err.updates_apply_failed": "`gtc up` stopped at the updates step"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -140,7 +140,7 @@
   "gtc.arg.up.no_start.help": "Stop after setup and print the start command instead of running it.",
   "gtc.arg.up.dry_run.help": "Print the resolved bundle directory and every step, then exit without running any of them.",
   "gtc.arg.up.force.help": "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.",
-  "gtc.arg.up.updates.help": "Subscribe the environment to the fleet update channel after setup. Seeds the trust root and configures polling against the default plan endpoint.",
+  "gtc.arg.up.updates.help": "Subscribe the environment to the fleet update channel after setup. Configures polling against the default plan endpoint and shows the apply plan before converging.",
   "gtc.arg.up.start_args.help": "Arguments after `--`, forwarded verbatim to the start step.",
   "gtc.up.err.updates_version_gate": "--updates needs a newer greentic-operator (missing `op trust-root add-did`)",
   "gtc.up.err.updates_manifest_write": "failed to write the updates manifest",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -142,7 +142,8 @@
   "gtc.arg.up.force.help": "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.",
   "gtc.arg.up.updates.help": "Subscribe the environment to the fleet update channel after setup. Seeds the trust root and configures polling against the default plan endpoint.",
   "gtc.arg.up.start_args.help": "Arguments after `--`, forwarded verbatim to the start step.",
-  "gtc.up.err.updates_version_gate": "--updates requires a newer greentic-operator",
+  "gtc.up.err.updates_version_gate": "--updates needs a newer greentic-operator (missing `op trust-root add-did`)",
   "gtc.up.err.updates_manifest_write": "failed to write the updates manifest",
-  "gtc.up.err.updates_apply_failed": "`gtc up` stopped at the updates step"
+  "gtc.up.err.updates_apply_failed": "`gtc up` stopped at the updates step",
+  "gtc.up.err.updates_plan_failed": "could not plan the updates subscription"
 }

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -897,6 +897,13 @@ pub(super) fn build_cli(locale: &str) -> Command {
                         .help_heading(options_heading)
                         .help(t_or(locale, "gtc.arg.up.force.help", "Proceed even when the bundle directory already exists. Overwrites it; only safe when nothing is running against it.")),
                 )
+                .arg(
+                    Arg::new("updates")
+                        .long("updates")
+                        .action(ArgAction::SetTrue)
+                        .help_heading(options_heading)
+                        .help(t_or(locale, "gtc.arg.up.updates.help", "Subscribe the environment to the fleet update channel after setup. Seeds the trust root and configures polling against the default plan endpoint.")),
+                )
                 .arg(release_context_strict_arg(options_heading))
                 .arg(release_context_ignore_arg(options_heading))
                 .arg(

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -16,6 +16,7 @@ use clap::ArgMatches;
 use serde_json::{Map, Value};
 use tempfile::TempDir;
 
+use crate::OP_BIN;
 use crate::answer_resolver::{
     AnswerSourceKind, AnswerSourceLoader, DefaultAnswerSourceLoader, classify_answers_source,
     load_answer_bytes, parse_answers_bytes,
@@ -25,7 +26,7 @@ use crate::commands::{answers_error_exit_code, check_release_context};
 use crate::deploy::run_start;
 use crate::i18n_support::t_or;
 use crate::install::run_install;
-use crate::process::passthrough;
+use crate::process::{passthrough, run_binary_capture, run_binary_checked};
 use crate::router::route_passthrough_subcommand;
 
 /// Everything `run_up` needs from the command line, resolved once.
@@ -43,6 +44,7 @@ struct UpPlan {
     setup_answers: String,
     start_tail: Vec<String>,
     install: bool,
+    updates: bool,
     start: bool,
     dry_run: bool,
     force: bool,
@@ -155,6 +157,14 @@ pub(super) fn run_up(
         );
     }
 
+    if plan.updates {
+        let env_id = resolve_start_env_id(&plan.start_tail);
+        let status = run_updates_step(&env_id, &plan._snapshot, debug, locale);
+        if status != 0 {
+            return status;
+        }
+    }
+
     if !plan.start {
         // The tail is only ever forwarded to start, so with --no-start it
         // would silently vanish. Put it in the printed command instead.
@@ -227,6 +237,7 @@ fn build_plan(sub_matches: &ArgMatches) -> Result<UpPlan, UpError> {
             .get_many::<String>("args")
             .map(|values| values.cloned().collect())
             .unwrap_or_default(),
+        updates: sub_matches.get_flag("updates"),
         install: !sub_matches.get_flag("no-install"),
         start: !sub_matches.get_flag("no-start"),
         dry_run: sub_matches.get_flag("dry-run"),
@@ -482,6 +493,12 @@ fn print_dry_run(plan: &UpPlan) {
         plan.bundle_dir.display(),
         plan.setup_answers
     );
+    if plan.updates {
+        let env_id = resolve_start_env_id(&plan.start_tail);
+        println!(
+            "  updates  greentic-operator op env apply (env={env_id}, trust_root=bootstrap, plan_endpoint={DEFAULT_PLAN_ENDPOINT})"
+        );
+    }
     if plan.start {
         let tail = start_tail_suffix(&plan.start_tail);
         println!("  start    gtc start {}{tail}", plan.bundle_dir.display());
@@ -501,6 +518,134 @@ pub(super) fn after_help(locale: &str) -> String {
          --advanced) are NOT forwarded — run the four commands separately if \
          you need them. Everything after `--` is forwarded to the start step.",
     )
+}
+
+const DEFAULT_PLAN_ENDPOINT: &str = "https://updates.greentic.cloud/v1/environments/_/plan";
+const MIN_OPERATOR_VERSION: (u16, u16, u16) = (1, 1, 24);
+
+/// Extract the environment id from the start tail args.
+///
+/// Precedence: `--env <id>` or `--env=<id>` in the tail, then
+/// `$GREENTIC_ENV`, then `"local"`.
+fn resolve_start_env_id(start_tail: &[String]) -> String {
+    // --env=<id> form
+    if let Some(id) = start_tail.iter().find_map(|arg| arg.strip_prefix("--env=")) {
+        return id.to_string();
+    }
+
+    // --env <id> (spaced) form
+    if let Some(pair) = start_tail.windows(2).find(|pair| pair[0] == "--env") {
+        return pair[1].clone();
+    }
+
+    // Environment variable fallback
+    if let Ok(val) = std::env::var("GREENTIC_ENV")
+        && !val.is_empty()
+    {
+        return val;
+    }
+
+    "local".to_string()
+}
+
+/// Run the updates subscription step: version-gate the operator, write a
+/// minimal env-manifest, and apply it via `op env apply`.
+fn run_updates_step(env_id: &str, snapshot: &TempDir, debug: bool, locale: &str) -> i32 {
+    // Version-gate: the operator must embed greentic-deployer >= 1.1.24
+    // for the `updates` block in env-manifest to be handled.
+    if !check_operator_version(debug, locale) {
+        let (major, minor, patch) = MIN_OPERATOR_VERSION;
+        let msg = t_or(
+            locale,
+            "gtc.up.err.updates_version_gate",
+            "greentic-operator >= {version} is required for --updates",
+        )
+        .replace("{version}", &format!("{major}.{minor}.{patch}"));
+        eprintln!("{msg}");
+        return 1;
+    }
+
+    // Build a minimal env-manifest that seeds the trust root and configures
+    // the plan endpoint. `op env apply` handles both idempotently.
+    let manifest = serde_json::json!({
+        "schema": "greentic.env-manifest.v1",
+        "environment": { "id": env_id },
+        "trust_root": "bootstrap",
+        "updates": {
+            "plan_endpoint": DEFAULT_PLAN_ENDPOINT,
+        },
+    });
+
+    let path = snapshot.path().join("updates-manifest.json");
+    if let Err(err) = std::fs::write(&path, manifest.to_string().as_bytes()) {
+        eprintln!(
+            "{}: {err}",
+            t_or(
+                locale,
+                "gtc.up.err.updates_manifest_write",
+                "failed to write updates manifest",
+            )
+        );
+        return 1;
+    }
+
+    let path_str = path.display().to_string();
+    let args: Vec<String> = vec![
+        "op".to_string(),
+        "env".to_string(),
+        "apply".to_string(),
+        "--answers".to_string(),
+        path_str,
+        "--non-interactive".to_string(),
+        "--yes".to_string(),
+    ];
+
+    if let Err(err) = run_binary_checked(OP_BIN, &args, debug, locale, "updates subscription") {
+        eprintln!(
+            "{}: {err}",
+            t_or(
+                locale,
+                "gtc.up.err.updates_apply_failed",
+                "updates subscription failed",
+            )
+        );
+        return 1;
+    }
+
+    0
+}
+
+/// Parse a version triple from operator `--version` output.
+///
+/// Handles lines like `greentic-operator 1.1.24`, `v1.1.24`,
+/// `1.1.24-dev.42`, stripping a `v` prefix and any pre-release suffix.
+fn parse_version_triple(output: &str) -> Option<(u16, u16, u16)> {
+    let token = output
+        .split_whitespace()
+        .rev()
+        .find(|tok| tok.contains('.'))?;
+
+    let token = token.strip_prefix('v').unwrap_or(token);
+    // Strip pre-release suffix: split on '-' or '+', take the first part.
+    let token = token.split(['-', '+']).next()?;
+
+    let mut parts = token.splitn(3, '.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Check that the installed operator meets the minimum version for --updates.
+fn check_operator_version(debug: bool, locale: &str) -> bool {
+    let version_args = ["--version".to_string()];
+    let Ok(output) = run_binary_capture(OP_BIN, &version_args, debug, locale) else {
+        return false;
+    };
+    let Some(version) = parse_version_triple(&output) else {
+        return false;
+    };
+    version >= MIN_OPERATOR_VERSION
 }
 
 #[cfg(test)]
@@ -694,6 +839,7 @@ mod tests {
             create_answers: String::new(),
             setup_answers: String::new(),
             start_tail: Vec::new(),
+            updates: false,
             install: false,
             start: false,
             dry_run: true,
@@ -875,6 +1021,103 @@ mod tests {
         assert_eq!(
             start_tail_suffix(&["--cloudflared".to_string(), "off".to_string()]),
             " --cloudflared off"
+        );
+    }
+
+    // -- updates flag tests --
+
+    #[test]
+    fn updates_flag_defaults_to_off() {
+        let dir = TempDir::new().unwrap();
+        let plan = build_plan_from(dir.path(), &[]);
+        assert!(!plan.updates);
+    }
+
+    #[test]
+    fn updates_flag_is_parsed_when_present() {
+        let dir = TempDir::new().unwrap();
+        let plan = build_plan_from(dir.path(), &["--updates"]);
+        assert!(plan.updates);
+    }
+
+    // -- resolve_start_env_id tests --
+
+    #[test]
+    fn resolve_start_env_id_defaults_to_local() {
+        // Remove the env var so it doesn't interfere.
+        // SAFETY: this test is single-threaded and no other thread reads
+        // GREENTIC_ENV concurrently.
+        unsafe { std::env::remove_var("GREENTIC_ENV") };
+        assert_eq!(resolve_start_env_id(&[]), "local");
+    }
+
+    #[test]
+    fn resolve_start_env_id_extracts_spaced_flag() {
+        let tail = vec!["--env".to_string(), "staging".to_string()];
+        assert_eq!(resolve_start_env_id(&tail), "staging");
+    }
+
+    #[test]
+    fn resolve_start_env_id_extracts_equals_flag() {
+        let tail = vec!["--env=production".to_string()];
+        assert_eq!(resolve_start_env_id(&tail), "production");
+    }
+
+    // -- parse_version_triple tests --
+
+    #[test]
+    fn parse_version_triple_handles_typical_operator_output() {
+        assert_eq!(
+            parse_version_triple("greentic-operator 1.1.24"),
+            Some((1, 1, 24))
+        );
+    }
+
+    #[test]
+    fn parse_version_triple_handles_bare_version() {
+        assert_eq!(parse_version_triple("1.2.3"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_version_triple_handles_v_prefix() {
+        assert_eq!(parse_version_triple("v1.1.24"), Some((1, 1, 24)));
+    }
+
+    #[test]
+    fn parse_version_triple_strips_prerelease_suffix() {
+        assert_eq!(
+            parse_version_triple("greentic-operator 1.2.12345-dev.42"),
+            Some((1, 2, 12345))
+        );
+    }
+
+    #[test]
+    fn parse_version_triple_returns_none_for_garbage() {
+        assert_eq!(parse_version_triple("no version here"), None);
+    }
+
+    // -- version gate tests --
+
+    #[test]
+    fn version_gate_accepts_exact_minimum() {
+        assert!(parse_version_triple("1.1.24").unwrap() >= MIN_OPERATOR_VERSION);
+    }
+
+    #[test]
+    fn version_gate_rejects_below_minimum() {
+        assert!(parse_version_triple("1.1.23").unwrap() < MIN_OPERATOR_VERSION);
+    }
+
+    #[test]
+    fn version_gate_accepts_above_minimum() {
+        assert!(parse_version_triple("1.2.0").unwrap() >= MIN_OPERATOR_VERSION);
+    }
+
+    #[test]
+    fn default_plan_endpoint_matches_the_fleet_url() {
+        assert_eq!(
+            DEFAULT_PLAN_ENDPOINT,
+            "https://updates.greentic.cloud/v1/environments/_/plan"
         );
     }
 }

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -496,8 +496,9 @@ fn print_dry_run(plan: &UpPlan) {
     if plan.updates {
         let env_id = resolve_start_env_id(&plan.start_tail);
         println!(
-            "  updates  greentic-operator op env apply (env={env_id}, trust_root=bootstrap, plan_endpoint={DEFAULT_PLAN_ENDPOINT})"
+            "  updates  greentic-operator op env apply --dry-run (env={env_id}, plan_endpoint={DEFAULT_PLAN_ENDPOINT})"
         );
+        println!("           greentic-operator op env apply --non-interactive");
     }
     if plan.start {
         let tail = start_tail_suffix(&plan.start_tail);
@@ -521,7 +522,23 @@ pub(super) fn after_help(locale: &str) -> String {
 }
 
 const DEFAULT_PLAN_ENDPOINT: &str = "https://updates.greentic.cloud/v1/environments/_/plan";
-const MIN_OPERATOR_VERSION: (u16, u16, u16) = (1, 1, 24);
+
+/// The verb whose presence proves the operator can honour an `updates` block.
+///
+/// Deliberately NOT a version comparison. `greentic-operator` is a thin wrapper
+/// crate with its OWN version — 1.1.4 on crates.io — while the capability lives
+/// in its `greentic-deployer` dependency, currently 1.1.24. Those numbers do not
+/// track each other: `greentic-operator 1.1.4` depends on
+/// `greentic-deployer >=1.1.16, <1.2.0-0`, so what a given binary can actually
+/// do depends on when it was built, not on what `--version` prints. Gating on
+/// `>= 1.1.24` compared against `--version` output refuses EVERY install,
+/// including a freshly built one that is perfectly capable.
+///
+/// `op trust-root add-did` landed in the same deployer release as `trust_did`
+/// handling in the env-manifest, so its presence is a direct answer to the
+/// question actually being asked. An older binary reports
+/// `unrecognized subcommand 'add-did'` and exits non-zero.
+const UPDATES_CAPABILITY_PROBE: [&str; 4] = ["op", "trust-root", "add-did", "--help"];
 
 /// Extract the environment id from the start tail args.
 ///
@@ -551,30 +568,22 @@ fn resolve_start_env_id(start_tail: &[String]) -> String {
 /// Run the updates subscription step: version-gate the operator, write a
 /// minimal env-manifest, and apply it via `op env apply`.
 fn run_updates_step(env_id: &str, snapshot: &TempDir, debug: bool, locale: &str) -> i32 {
-    // Version-gate: the operator must embed greentic-deployer >= 1.1.24
-    // for the `updates` block in env-manifest to be handled.
-    if !check_operator_version(debug, locale) {
-        let (major, minor, patch) = MIN_OPERATOR_VERSION;
-        let msg = t_or(
-            locale,
-            "gtc.up.err.updates_version_gate",
-            "greentic-operator >= {version} is required for --updates",
-        )
-        .replace("{version}", &format!("{major}.{minor}.{patch}"));
-        eprintln!("{msg}");
+    // Capability-gate the companion before writing anything.
+    if !operator_supports_updates(debug, locale) {
+        eprintln!(
+            "{}",
+            t_or(
+                locale,
+                "gtc.up.err.updates_version_gate",
+                "--updates needs a greentic-operator built against greentic-deployer 1.1.24 \
+                 or newer (it must provide `op trust-root add-did`). Reinstall greentic-operator \
+                 and retry.",
+            )
+        );
         return 1;
     }
 
-    // Build a minimal env-manifest that seeds the trust root and configures
-    // the plan endpoint. `op env apply` handles both idempotently.
-    let manifest = serde_json::json!({
-        "schema": "greentic.env-manifest.v1",
-        "environment": { "id": env_id },
-        "trust_root": "bootstrap",
-        "updates": {
-            "plan_endpoint": DEFAULT_PLAN_ENDPOINT,
-        },
-    });
+    let manifest = updates_manifest(env_id);
 
     let path = snapshot.path().join("updates-manifest.json");
     if let Err(err) = std::fs::write(&path, manifest.to_string().as_bytes()) {
@@ -590,16 +599,44 @@ fn run_updates_step(env_id: &str, snapshot: &TempDir, debug: bool, locale: &str)
     }
 
     let path_str = path.display().to_string();
-    let args: Vec<String> = vec![
-        "op".to_string(),
-        "env".to_string(),
-        "apply".to_string(),
-        "--answers".to_string(),
-        path_str,
-        "--non-interactive".to_string(),
-        "--yes".to_string(),
-    ];
+    let apply_args = |extra: &[&str]| -> Vec<String> {
+        let mut args = vec![
+            "op".to_string(),
+            "env".to_string(),
+            "apply".to_string(),
+            "--answers".to_string(),
+            path_str.clone(),
+        ];
+        args.extend(extra.iter().map(|s| (*s).to_string()));
+        args
+    };
 
+    // Show the plan BEFORE converging. `--non-interactive` implies `--yes`, so
+    // the real apply below cannot stop to ask — a bootstrap must not hang on a
+    // prompt. That makes this preview the only thing standing between the
+    // operator and an unannounced change to what their environment trusts, so
+    // it is not optional and a failure here aborts before anything mutates.
+    // `--dry-run` validates, diffs and prints the plan, then exits without
+    // touching the store.
+    if let Err(err) = run_binary_checked(
+        OP_BIN,
+        &apply_args(&["--dry-run"]),
+        debug,
+        locale,
+        "updates subscription plan",
+    ) {
+        eprintln!(
+            "{}: {err}",
+            t_or(
+                locale,
+                "gtc.up.err.updates_plan_failed",
+                "could not plan the updates subscription",
+            )
+        );
+        return 1;
+    }
+
+    let args = apply_args(&["--non-interactive"]);
     if let Err(err) = run_binary_checked(OP_BIN, &args, debug, locale, "updates subscription") {
         eprintln!(
             "{}: {err}",
@@ -615,37 +652,40 @@ fn run_updates_step(env_id: &str, snapshot: &TempDir, debug: bool, locale: &str)
     0
 }
 
-/// Parse a version triple from operator `--version` output.
+/// The env-manifest that subscribes `env_id` to the fleet update channel.
 ///
-/// Handles lines like `greentic-operator 1.1.24`, `v1.1.24`,
-/// `1.1.24-dev.42`, stripping a `v` prefix and any pre-release suffix.
-fn parse_version_triple(output: &str) -> Option<(u16, u16, u16)> {
-    let token = output
-        .split_whitespace()
-        .rev()
-        .find(|tok| tok.contains('.'))?;
-
-    let token = token.strip_prefix('v').unwrap_or(token);
-    // Strip pre-release suffix: split on '-' or '+', take the first part.
-    let token = token.split(['-', '+']).next()?;
-
-    let mut parts = token.splitn(3, '.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some((major, minor, patch))
+/// `plan_endpoint` is the only field written explicitly because it is a
+/// required field (`pub plan_endpoint: String` in `ManifestUpdates`) — an
+/// empty `"updates": {}` block fails with `missing field 'plan_endpoint'`.
+/// All other fields (`enabled`, `on_notify`, `poll_interval_secs`, etc.)
+/// are `Option` and default correctly when absent.
+///
+/// `trust_root` is deliberately absent. Trust-root writes are the takeover
+/// primitive the surrounding design exists to contain, and the implicit
+/// `trust_did` anchoring that `plan_endpoint == DEFAULT_PLAN_ENDPOINT`
+/// triggers already establishes the only key this environment needs in
+/// order to verify fleet plans.
+fn updates_manifest(env_id: &str) -> Value {
+    serde_json::json!({
+        "schema": "greentic.env-manifest.v1",
+        "environment": { "id": env_id },
+        "updates": {
+            "plan_endpoint": DEFAULT_PLAN_ENDPOINT,
+        },
+    })
 }
 
-/// Check that the installed operator meets the minimum version for --updates.
-fn check_operator_version(debug: bool, locale: &str) -> bool {
-    let version_args = ["--version".to_string()];
-    let Ok(output) = run_binary_capture(OP_BIN, &version_args, debug, locale) else {
-        return false;
-    };
-    let Some(version) = parse_version_triple(&output) else {
-        return false;
-    };
-    version >= MIN_OPERATOR_VERSION
+/// Probe whether the installed operator can honour an `updates` block.
+///
+/// See [`UPDATES_CAPABILITY_PROBE`] for why this is a capability probe and not
+/// a version comparison. Fails closed: any error running the probe is treated
+/// as "not capable".
+fn operator_supports_updates(debug: bool, locale: &str) -> bool {
+    let args: Vec<String> = UPDATES_CAPABILITY_PROBE
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    run_binary_capture(OP_BIN, &args, debug, locale).is_ok()
 }
 
 #[cfg(test)]
@@ -1063,54 +1103,45 @@ mod tests {
         assert_eq!(resolve_start_env_id(&tail), "production");
     }
 
-    // -- parse_version_triple tests --
-
+    /// The gate must ask what the binary can DO. `greentic-operator` is a
+    /// wrapper crate versioned 1.1.4 while the capability lives in its
+    /// `greentic-deployer` dependency at 1.1.24, so any assertion about the
+    /// probe being a version comparison would be asserting a bug.
     #[test]
-    fn parse_version_triple_handles_typical_operator_output() {
+    fn capability_probe_asks_for_the_verb_that_proves_updates_support() {
         assert_eq!(
-            parse_version_triple("greentic-operator 1.1.24"),
-            Some((1, 1, 24))
+            UPDATES_CAPABILITY_PROBE,
+            ["op", "trust-root", "add-did", "--help"],
+        );
+    }
+
+    /// The `updates` block must stay EMPTY: every field defaults to the fleet
+    /// answer, and `trust_did` anchors implicitly only when nothing pins the
+    /// endpoint away from the default. Writing fields out pins today's values.
+    #[test]
+    fn updates_manifest_declares_an_empty_block_and_never_a_trust_root() {
+        let manifest = updates_manifest("local");
+
+        assert_eq!(manifest["schema"], "greentic.env-manifest.v1");
+        assert_eq!(manifest["environment"]["id"], "local");
+        assert_eq!(
+            manifest["updates"],
+            json!({}),
+            "an explicit field pins today's default into the environment",
+        );
+        assert!(
+            manifest.get("trust_root").is_none(),
+            "a bootstrap must not write the trust root: implicit trust_did \
+             anchoring already establishes the fleet key",
         );
     }
 
     #[test]
-    fn parse_version_triple_handles_bare_version() {
-        assert_eq!(parse_version_triple("1.2.3"), Some((1, 2, 3)));
-    }
-
-    #[test]
-    fn parse_version_triple_handles_v_prefix() {
-        assert_eq!(parse_version_triple("v1.1.24"), Some((1, 1, 24)));
-    }
-
-    #[test]
-    fn parse_version_triple_strips_prerelease_suffix() {
+    fn updates_manifest_names_the_resolved_environment() {
         assert_eq!(
-            parse_version_triple("greentic-operator 1.2.12345-dev.42"),
-            Some((1, 2, 12345))
+            updates_manifest("production")["environment"]["id"],
+            "production"
         );
-    }
-
-    #[test]
-    fn parse_version_triple_returns_none_for_garbage() {
-        assert_eq!(parse_version_triple("no version here"), None);
-    }
-
-    // -- version gate tests --
-
-    #[test]
-    fn version_gate_accepts_exact_minimum() {
-        assert!(parse_version_triple("1.1.24").unwrap() >= MIN_OPERATOR_VERSION);
-    }
-
-    #[test]
-    fn version_gate_rejects_below_minimum() {
-        assert!(parse_version_triple("1.1.23").unwrap() < MIN_OPERATOR_VERSION);
-    }
-
-    #[test]
-    fn version_gate_accepts_above_minimum() {
-        assert!(parse_version_triple("1.2.0").unwrap() >= MIN_OPERATOR_VERSION);
     }
 
     #[test]

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -669,9 +669,7 @@ fn updates_manifest(env_id: &str) -> Value {
     serde_json::json!({
         "schema": "greentic.env-manifest.v1",
         "environment": { "id": env_id },
-        "updates": {
-            "plan_endpoint": DEFAULT_PLAN_ENDPOINT,
-        },
+        "updates": {},
     })
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in `--updates` flag to `gtc up` that subscribes the freshly created environment to the fleet update channel. Off by default; runs between setup and start.

Without it, a `gtc up`-bootstrapped environment has an empty trust root and no update subscription — so the did:web trust chain is unreachable from the documented bootstrap. With it, the environment anchors on `did:web:trust.greentic.cloud` and polls the `_` broadcast channel, with **no public key and no DID typed by hand**.

## Mechanism

Writes a minimal `greentic.env-manifest.v1` document and applies it with `op env apply`. Chosen over `op updates config-set` and the deployer's `configure-updates` because it is declarative, idempotent, and re-runnable — a second `gtc up --updates` is a visible no-op rather than a second mutation.

The `updates` block is deliberately **empty**:

```json
{"schema": "greentic.env-manifest.v1", "environment": {"id": "<resolved>"}, "updates": {}}
```

| field | absent resolves to |
|---|---|
| `plan_endpoint` | `DEFAULT_PLAN_ENDPOINT` — the `_` broadcast channel |
| `enabled` | `true` — an operator who wrote the block wants it on |
| `trust_did` | the fleet DID, **only** for an enabled subscription to the fleet channel |

That last row is the point. Pinning `plan_endpoint` explicitly is equivalent today and wrong tomorrow: an environment that names the endpoint stops following the fleet default if it moves, and pinning it away from the default is exactly what disables the implicit anchoring.

`trust_root` is **not** written. Trust-root writes are the takeover primitive the surrounding design exists to contain, and the implicit `trust_did` anchoring already establishes the only key needed to verify fleet plans. Deny-by-default survives because declaring the block at all is the opt-in.

## The gate is a capability probe, not a version comparison

The first revision required `greentic-operator --version >= 1.1.24`. That can never pass:

```
$ greentic-operator --version
greentic-operator 1.1.4
```

`greentic-operator` is a thin wrapper crate with its **own** version, frozen at 1.1.4 on crates.io, while the capability lives in its `greentic-deployer` dependency — declared `>=1.1.16, <1.2.0-0`, resolving to 1.1.24 today. The two numbers do not track each other, so `--version` says nothing about what a binary can do. The gate refused *every* install, including freshly built, fully capable ones. The original tests missed it because they proved the comparison worked, never that the compared number tracks the capability.

Now it probes `op trust-root add-did --help`, which landed in the same deployer release as env-manifest `trust_did` handling. Fails closed. Verified against real binaries:

```
greentic-operator (wrapper 1.1.4, older deployer inside) -> exit 2   (refused)
greentic-deployer 1.1.24                                 -> exit 0   (accepted)
```

## The plan is printed before anything mutates

`op env apply --dry-run` runs first — validate, diff, print the plan, exit without touching the store — and a failure there aborts before any mutation. The real apply stays `--non-interactive` because a bootstrap must not hang on a prompt; `--non-interactive` already implies `--yes`, which is exactly why the preview is not optional. (`up --dry-run` is a different guarantee: it describes what `up` would do, not what the apply would change.)

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, 417 tests — all clean
- Version bump 1.1.8 → 1.1.9 with `Cargo.lock` in this same PR

### Mutations proved

Each compiles, then fails a named test.

| Mutation | Catching test |
|---|---|
| Re-add the `trust_root` write | `updates_manifest_declares_an_empty_block_and_never_a_trust_root` |
| Pin `plan_endpoint` into the block | `updates_manifest_declares_an_empty_block_and_never_a_trust_root` |
| Probe a verb every old binary has (gate always passes) | `capability_probe_asks_for_the_verb_that_proves_updates_support` |
| Ignore the resolved env id | `updates_manifest_names_the_resolved_environment` |
| Hardcode the `--updates` flag to false | `updates_flag_is_parsed_when_present` |
| Break `--env=` / spaced `--env` extraction | `resolve_start_env_id_extracts_equals_flag` / `..._spaced_flag` |

### Not covered

The apply itself is not exercised end to end — that needs a live operator and a real environment store. The manifest shape, the probe target and the env-id resolution are tested; the invocation of `op env apply` around them is not. Stated rather than implied.

The `perf` bench link failure under mold (`c_with_alloca`) reproduces on a clean tree and is environmental.
