### PR TITLE
fix(up): make the absolute-path tests portable so releases can ship (1.1.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "backhand",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/up.rs
+++ b/src/bin/gtc/up.rs
@@ -710,6 +710,36 @@ mod tests {
         }))
     }
 
+    /// Build an absolute path out of `parts` that is absolute on EVERY platform
+    /// we release for.
+    ///
+    /// A literal like `/opt/bundles/demo` is absolute on Unix but not on
+    /// Windows, where a path needs a prefix (`C:\`) to satisfy `is_absolute()`.
+    /// Any test that hands such a literal to `absolutize` therefore takes the
+    /// `current_dir().join(..)` branch on Windows and compares against a path
+    /// that can never match. That is not hypothetical: it broke the
+    /// `x86_64-pc-windows-msvc` release build and kept 1.1.8 off crates.io.
+    /// PR CI runs Linux only, so nothing catches it before the tag.
+    ///
+    /// Rooting at `current_dir()`'s topmost ancestor yields `/` on Unix and the
+    /// drive prefix on Windows, and pushing the components one at a time lets
+    /// `PathBuf` pick the native separator.
+    fn absolute_path(parts: &[&str]) -> PathBuf {
+        let cwd = std::env::current_dir().expect("current_dir");
+        let mut path = cwd
+            .ancestors()
+            .last()
+            .expect("every absolute path has a root")
+            .to_path_buf();
+        path.extend(parts);
+        assert!(
+            path.is_absolute(),
+            "{} is not absolute on this platform — the helper's premise is wrong",
+            path.display()
+        );
+        path
+    }
+
     #[test]
     fn output_dir_is_taken_verbatim_from_the_create_document() {
         let doc = bundle_doc(json!({
@@ -807,8 +837,9 @@ mod tests {
 
     #[test]
     fn an_absolute_prediction_is_left_alone() {
-        let pinned = absolutize(Path::new("/opt/bundles/demo")).unwrap();
-        assert_eq!(pinned, PathBuf::from("/opt/bundles/demo"));
+        let already_absolute = absolute_path(&["opt", "bundles", "demo"]);
+        let pinned = absolutize(&already_absolute).unwrap();
+        assert_eq!(pinned, already_absolute);
     }
 
     #[test]
@@ -1025,13 +1056,15 @@ mod tests {
         // wizard_dir from the override, the document's directory becomes
         // overwritable without --force.
         let dir = TempDir::new().unwrap();
-        let plan = build_plan_from(dir.path(), &["--bundle-dir", "/work/override"]);
+        let override_dir = absolute_path(&["work", "override"]);
+        let override_arg = override_dir.display().to_string();
+        let plan = build_plan_from(dir.path(), &["--bundle-dir", &override_arg]);
         assert!(
             plan.wizard_dir.ends_with("from-document"),
             "wizard_dir must come from the document, got {}",
             plan.wizard_dir.display()
         );
-        assert_eq!(plan.bundle_dir, PathBuf::from("/work/override"));
+        assert_eq!(plan.bundle_dir, override_dir);
         assert_eq!(guarded_dirs(&plan).len(), 2);
     }
 


### PR DESCRIPTION
## The releases are not shipping

crates.io serves **gtc 1.1.7**, but `v1.1.8` and `v1.1.9` are both tagged. The
`Publish And Release` run for v1.1.8 ([29897059070]) failed, and the v1.1.9 run
is failing the same way:

```
build_binaries (windows-latest, x86_64-pc-windows-msvc) -> Test native target
  test up::tests::an_absolute_prediction_is_left_alone ... FAILED
  test up::tests::bundle_dir_never_detaches_the_guard_from_the_wizard ... FAILED
  test result: FAILED. 344 passed; 2 failed
```

[29897059070]: https://github.com/greenticai/greentic/actions/runs/29897059070

## Cause

Both tests hardcode POSIX-absolute literals (`/opt/bundles/demo`,
`/work/override`). On Windows a path with no drive prefix is **not** absolute,
so `absolutize` takes its `current_dir().join(path)` branch and returns
`C:\...\opt\bundles\demo` — which can never equal the expected literal.

`absolutize` is correct and is left untouched. The tests were not portable.

## Fix

A test helper builds the expected path from `current_dir()`'s topmost
ancestor — `/` on Unix, the drive prefix on Windows — and pushes components one
at a time so `PathBuf` picks the native separator. The helper asserts its own
result is absolute, so if the premise is ever wrong on a new target the failure
says so instead of showing a confusing path mismatch.

## Why 1.1.10 and not a re-cut tag

`v1.1.8` and `v1.1.9` point at commits whose release build cannot pass. Moving
a published tag is worse than skipping two patch numbers, so this bumps to
1.1.10; neither 1.1.8 nor 1.1.9 ever reached crates.io.

## Gap this exposes

`ci / pr-ci / test` runs Linux only. Windows is exercised **only** in the
tag-triggered release build, so a PR can be 7/7 green and still block the
release. Worth deciding separately whether the shared `host-crate-ci.yml`
should gain a Windows leg — that is a fleet-wide change, out of scope here.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --bins --tests --all-features` — 432 + 63 + 1 + 3 passed, 0 failed
- `cargo test --bin gtc -- --ignored` — 6 passed
- `bash ci/local_check.sh` — steps 1b/1c/2/3 pass; step 4 fails only on the
  pre-existing `perf` bench link error under mold (`undefined symbol:
  c_with_alloca`), which reproduces on a clean checkout and is environmental.

Windows itself cannot be run locally; the release build is the proof.
