### PR TITLE
release: gtc 1.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "backhand",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.10"
+version = "1.1.11"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"


### PR DESCRIPTION
Ships the multi-bundle webchat routing work merged to `main` on 2026-07-25 (gtc#276) — the router side of the bundle/flow URL forms. That PR never bumped a root version, so `Tag on Version Bump` no-op'd and crates.io has sat at **1.1.10**.

Version-only bump. `gtc` gates companion capabilities with a probe (`UPDATES_CAPABILITY_PROBE` — `op trust-root add-did --help`), not a version comparison, so nothing here needs to know that the rest of the train moved. `Cargo.lock` moves this crate's own version and nothing else.

## Verification

| check | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --lib --bins --tests --all-features -- -D warnings` | clean |
| `cargo test --lib --bins --tests --all-features` | **559 passed, 0 failed** |

**`ci/local_check.sh` cannot complete on my workstation, for a reason unrelated to this change.** Step 4 (`cargo test --all-targets`) builds the `perf` bench, whose `criterion` → `alloca` dependency fails to link:

```
mold: error: undefined symbol: c_with_alloca
  >>> referenced by perf-*.rcgu.o:(alloca::with_alloca::h23a20c2f616d58b6)
error: could not compile `gtc` (bench "perf") due to 1 previous error
```

Confirmed **pre-existing** by A/B: stashing this branch's diff and building clean `main` fails identically. The cause is `rustflags = ["-C", "link-arg=-fuse-ld=mold"]` in the *user's global* `~/.cargo/config.toml` — not this repo's `.cargo/config.toml` (which does not exist) — so CI, which uses the default linker, is unaffected. Everything the gate runs except that bench link is reported above.

## Note for whoever owns the schema-doc sync

`ci/local_check.sh` step 1 rewrote four files under `docs/04-schemas/` with **machine-local absolute paths** — the committed copy embeds `fixture:///Users/maarten/.cargo/registry/.../greentic-flow-1.1.4/...` and my run replaced it with `/home/vampik/.cargo/registry/.../greentic-flow-1.3.0-research.0/...`. Reverted here, since it is environment noise and does not belong in a release bump, but it means the generated docs churn for every developer who runs the check. Worth making the generator emit a relative or placeholder path.

Last of four in the release train: `greentic-setup` 1.1.26 (greenticai/greentic-setup#237), `greentic-start` 1.1.29 (greenticai/greentic-start#452), `greentic-operator` 1.1.5 (greenticai/greentic-operator#125 — a real dep fix, not just a bump), this.
