### PR TITLE
feat: take the default tenant and team from greentic-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-types"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853321f6d463c7a805821fb54a126cc44d50a1b3ffb009f14718d34e158799cf"
+checksum = "9553e9c3e1a357f14da4a44581d506b2771325da9a71ee7a499679e6d695ff83"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "backhand",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.12"
+version = "1.1.13"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"
@@ -40,7 +40,9 @@ chrono = "0.4"
 directories = "6"
 flate2 = "1.1"
 greentic-i18n-lib = ">=1.1.0-0, <1.2.0-0"
-greentic-types = ">=1.1.0-0, <1.2.0-0"
+# Floor is 1.1.4: that publish adds DEFAULT_TENANT / DEFAULT_TEAM, which the
+# `Starting tenant=` report and the cloud-deploy tenant fallback both read.
+greentic-types = ">=1.1.4, <1.2.0-0"
 rcgen = "0.14"
 rpassword = "7.4"
 serde_json = "1.0"

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use directories::BaseDirs;
+use greentic_types::DEFAULT_TENANT;
 use gtc::config::GtcConfig;
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{StartRequest, StopRequest};
@@ -272,7 +273,10 @@ fn run_multi_target_deployer_apply(
         target,
         cli_options.provider_pack.as_ref(),
     )?;
-    let tenant = request.tenant.clone().unwrap_or_else(|| "demo".to_string());
+    let tenant = request
+        .tenant
+        .clone()
+        .unwrap_or_else(|| DEFAULT_TENANT.to_string());
     let target_name = target.as_str().to_string();
     println!("Deployment artifact: {}", bundle_artifact.display());
     println!("Deployment bundle source: {deploy_bundle_source}");

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
+use greentic_types::{DEFAULT_TEAM, DEFAULT_TENANT};
 use gtc::error::{GtcError, GtcResult};
 use gtc::start_stop_parsing::{
     parse_runtime_config_start_request, parse_runtime_config_stop_request, parse_start_request,
@@ -178,8 +179,8 @@ fn run_start_runtime_config(tail: &[String], debug: bool, locale: &str) -> i32 {
     println!("Deployment mode: local runtime (no bundle — env runtime-config)");
     println!(
         "Starting tenant={} team={}",
-        request.tenant.as_deref().unwrap_or("demo"),
-        request.team.as_deref().unwrap_or("default")
+        request.tenant.as_deref().unwrap_or(DEFAULT_TENANT),
+        request.team.as_deref().unwrap_or(DEFAULT_TEAM)
     );
     let mut args = request.to_runtime_start_args(locale);
     if let Some(flag) = open_webchat_arg(
@@ -362,8 +363,8 @@ pub(crate) fn run_start_with_bundle_ref_and_tail(
     println!("Deployment mode: local runtime (environment `{env_id}`)");
     println!(
         "Starting tenant={} team={}",
-        request.tenant.as_deref().unwrap_or("demo"),
-        request.team.as_deref().unwrap_or("default")
+        request.tenant.as_deref().unwrap_or(DEFAULT_TENANT),
+        request.team.as_deref().unwrap_or(DEFAULT_TEAM)
     );
     // `--admin` without an explicit cert dir generates a dev CA plus server and
     // client PRIVATE keys inside the prepared root. The legacy path kept that
@@ -1072,9 +1073,10 @@ fn prompt_start_target(targets: &[StartTarget], locale: &str) -> GtcResult<Start
 #[cfg(test)]
 mod tests {
     use super::{
-        env_deploy_args, load_default_deployment_target, parse_runtime_config_start_request,
-        parse_start_cli_options, parse_start_request, parse_stop_cli_options, parse_stop_request,
-        select_start_target, select_start_target_with_mode,
+        DEFAULT_TEAM, DEFAULT_TENANT, env_deploy_args, load_default_deployment_target,
+        parse_runtime_config_start_request, parse_start_cli_options, parse_start_request,
+        parse_stop_cli_options, parse_stop_request, select_start_target,
+        select_start_target_with_mode,
     };
     use crate::deploy::StartTarget;
     use gtc::start_stop_parsing::{
@@ -1710,6 +1712,27 @@ mod tests {
     }
 
     // ── env-deploy argv forwards the tenant/team the user asked for ─────
+
+    /// The other half of the same defect: with no `--tenant`, this crate
+    /// PRINTED `Starting tenant=demo` while greentic-setup — which actually
+    /// writes the binding — applied its own default. Both ends now read
+    /// `greentic_types::DEFAULT_TENANT`, so the banner cannot claim a tenant
+    /// the deployment did not get.
+    ///
+    /// `env_deploy_args` omitting the flag is what makes that work: setup then
+    /// applies the same constant rather than a value this crate guessed.
+    #[test]
+    fn the_reported_tenant_is_the_one_setup_will_apply() {
+        assert_eq!(DEFAULT_TENANT, "default");
+        assert_eq!(DEFAULT_TEAM, "default");
+
+        let argv = env_deploy_args(Path::new("b.gtbundle"), "local", None, None, "en");
+        assert!(
+            !argv.iter().any(|arg| arg == "--tenant"),
+            "with no tenant the flag must be omitted so setup applies \
+             DEFAULT_TENANT itself, got {argv:?}"
+        );
+    }
 
     /// `gtc start <bundle> --tenant X` used to print `Starting tenant=X`, run
     /// the runtime under X, and bind the deployment under setup's own default


### PR DESCRIPTION
> **BLOCKED on greentic-types#179.** Needs greentic-types 1.1.4 on crates.io.

Three sites. One is a behaviour change; two are a report that stops lying.

| site | what it is |
|---|---|
| `deploy/cloud_deploy/deployment_state.rs:275` | cloud deploy's tenant when none is given |
| `deploy/start_stop.rs:181` | `Starting tenant=` banner |
| `deploy/start_stop.rs:365` | `Starting tenant=` banner |

## The banners

This is the other half of the defect #280 fixed. With no `--tenant`, gtc
**printed** `Starting tenant=demo` while greentic-setup — which actually writes
the binding — applied its own default. The two were never connected: the banner
reported a guess this crate made, not the tenant the deployment got.

Both ends now read `greentic_types::DEFAULT_TENANT`. `env_deploy_args` omitting
the flag when the caller named no tenant is what makes that hold — setup then
applies the same constant rather than a value gtc invented.

The new test pins both halves together. A test that only checked the banner
value would have passed against the old code too, which is precisely how the
original mismatch survived.

## Verification

- `cargo fmt --all` → clean
- `cargo clippy --all-targets --all-features -- -D warnings` → exit 0
- `cargo test --lib --bins` → 32 + 464 passed, 0 failed

Verified against greentic-types 1.1.4 with a temporary `[patch.crates-io]`,
which is **not** in this diff. `Cargo.lock` is `origin/main`'s plus gtc's own
version bump; its `greentic-types` entry must be refreshed once 1.1.4 publishes.

`bash ci/local_check.sh` was not run: its step 4 builds the `perf` bench, whose
`criterion → alloca` C shim fails under the mold linker configured in this
workstation's global `~/.cargo/config.toml` (`mold: error: undefined symbol:
c_with_alloca`). Pre-existing and unrelated — it reproduces on a clean `main`.
