### PR TITLE
fix(start): forward the --gtunnel flags through the gtc router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "gtc"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "backhand",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bench = [
 
 [package]
 name = "gtc"
-version = "1.1.13"
+version = "1.1.14"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic - The digital workers operating system"

--- a/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
+++ b/src/bin/gtc/deploy/cloud_deploy/deployment_state.rs
@@ -474,7 +474,7 @@ mod tests {
     use crate::tests::fake_deployer_contract;
     #[cfg(unix)]
     use gtc::start_stop_parsing::{
-        CloudflaredModeArg, NatsModeArg, NgrokModeArg, StartRequest, StopRequest,
+        CloudflaredModeArg, GtunnelModeArg, NatsModeArg, NgrokModeArg, StartRequest, StopRequest,
     };
     use std::env;
     use std::fs;
@@ -610,6 +610,10 @@ mod tests {
             cloudflared_binary: None,
             ngrok: NgrokModeArg::Off,
             ngrok_binary: None,
+            gtunnel: GtunnelModeArg::Off,
+            gtunnel_worker_url: None,
+            gtunnel_tunnel_id: None,
+            gtunnel_explicit: false,
             runner_binary: None,
             restart: Vec::new(),
             log_dir: None,

--- a/src/bin/gtc/deploy/start_stop.rs
+++ b/src/bin/gtc/deploy/start_stop.rs
@@ -31,7 +31,8 @@ const START_USAGE: &str = "usage: gtc start [BUNDLE_REF] [start flags...]\n\
               --deploy-bundle-source <src> --upload-bundle <url> --upload-bundle-presign-expires <secs>\n\
               --extension-start-handoff <path>\n\
   runtime flags are forwarded to greentic-start (e.g. --env, --tenant, --team, --nats, --cloudflared, --ngrok,\n\
-  --admin, --restart, --verbose, --quiet, --no-updates); see `greentic-start start --help` for the full list";
+  --gtunnel, --gtunnel-worker-url, --gtunnel-tunnel-id, --admin, --restart, --verbose, --quiet, --no-updates);\n\
+  see `greentic-start start --help` for the full list";
 
 /// Probe whether the installed greentic-start supports `--open-webchat`.
 ///
@@ -1080,8 +1081,9 @@ mod tests {
     };
     use crate::deploy::StartTarget;
     use gtc::start_stop_parsing::{
-        CloudflaredModeArg, NatsModeArg, NgrokModeArg, RestartTarget, StartRequest, StopRequest,
-        parse_runtime_config_stop_request, start_flag_takes_value, stop_flag_takes_value,
+        CloudflaredModeArg, GtunnelModeArg, NatsModeArg, NgrokModeArg, RestartTarget, StartRequest,
+        StopRequest, parse_runtime_config_stop_request, start_flag_takes_value,
+        stop_flag_takes_value,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -1212,6 +1214,10 @@ mod tests {
             cloudflared_binary: Some(PathBuf::from("/tmp/cloudflared")),
             ngrok: NgrokModeArg::On,
             ngrok_binary: Some(PathBuf::from("/tmp/ngrok")),
+            gtunnel: GtunnelModeArg::Off,
+            gtunnel_worker_url: None,
+            gtunnel_tunnel_id: None,
+            gtunnel_explicit: false,
             runner_binary: Some(PathBuf::from("/tmp/runner")),
             restart: vec![RestartTarget::Gateway, RestartTarget::Nats],
             log_dir: Some(PathBuf::from("/tmp/logs")),
@@ -1365,6 +1371,87 @@ mod tests {
     }
 
     #[test]
+    fn gtunnel_flags_survive_both_spellings_after_a_bundle_ref() {
+        // The 2026-07-30 repro: `gtc start ./bundle --gtunnel on` died with
+        // "unexpected positional argument `on`" because the router did not
+        // know --gtunnel takes a value, so `on` looked like a second bundle
+        // ref. The `=` spelling only *looked* fine — it slipped past the
+        // splitter and then died in `parse_start_request` as an unsupported
+        // argument. Both spellings must reach greentic-start intact.
+        for spaced in [true, false] {
+            let tail = if spaced {
+                args(&[
+                    "bundle.gtbundle",
+                    "--gtunnel",
+                    "on",
+                    "--gtunnel-worker-url",
+                    "https://tunnel.example.com",
+                    "--gtunnel-tunnel-id",
+                    "acme",
+                ])
+            } else {
+                args(&[
+                    "bundle.gtbundle",
+                    "--gtunnel=on",
+                    "--gtunnel-worker-url=https://tunnel.example.com",
+                    "--gtunnel-tunnel-id=acme",
+                ])
+            };
+            let opts = parse_start_cli_options(&tail).expect("opts");
+            assert_eq!(opts.bundle_ref.as_deref(), Some("bundle.gtbundle"));
+            let request =
+                parse_start_request(&opts.start_args, PathBuf::from("/tmp/bundle")).expect("req");
+            assert_eq!(request.gtunnel, GtunnelModeArg::On);
+            assert!(request.gtunnel_explicit);
+            assert_eq!(
+                request.gtunnel_worker_url.as_deref(),
+                Some("https://tunnel.example.com")
+            );
+            assert_eq!(request.gtunnel_tunnel_id.as_deref(), Some("acme"));
+            let child = request.to_runtime_start_args("en");
+            assert_eq!(
+                child.windows(2).find(|pair| pair[0] == "--gtunnel"),
+                Some(["--gtunnel".to_string(), "on".to_string()].as_slice())
+            );
+            assert!(child.contains(&"--gtunnel-worker-url".to_string()));
+            assert!(child.contains(&"--gtunnel-tunnel-id".to_string()));
+        }
+    }
+
+    #[test]
+    fn gtunnel_is_not_forwarded_unless_asked_for() {
+        // A greentic-start that predates --gtunnel would reject the flag, so
+        // gtc must stay silent about it when the user never mentioned it —
+        // even when --cloudflared made the other tunnel flags explicit.
+        let request = parse_start_request(
+            &args(&["--cloudflared", "on"]),
+            PathBuf::from("/tmp/bundle"),
+        )
+        .expect("req");
+        assert!(!request.gtunnel_explicit);
+        assert!(
+            !request
+                .to_runtime_start_args("en")
+                .contains(&"--gtunnel".to_string())
+        );
+    }
+
+    #[test]
+    fn restart_accepts_the_gtunnel_target() {
+        // greentic-start's `--restart` lists gtunnel among its possible
+        // values; the router must not reject it on the way through.
+        let request =
+            parse_start_request(&args(&["--restart", "gtunnel"]), PathBuf::from("/tmp/b"))
+                .expect("gtunnel is a restart target");
+        assert_eq!(request.restart, vec![RestartTarget::Gtunnel]);
+        assert!(
+            request
+                .to_runtime_start_args("en")
+                .contains(&"gtunnel".to_string())
+        );
+    }
+
+    #[test]
     fn parse_start_cli_options_extracts_gtc_flags_after_positional() {
         // Pre-collapse these only worked in this position because the tail
         // parser duplicated the clap layer; pin the single-parser behavior.
@@ -1440,6 +1527,9 @@ mod tests {
             "--cloudflared-binary",
             "--ngrok",
             "--ngrok-binary",
+            "--gtunnel",
+            "--gtunnel-worker-url",
+            "--gtunnel-tunnel-id",
             "--runner-binary",
             "--restart",
             "--log-dir",
@@ -1485,6 +1575,9 @@ mod tests {
             "--cloudflared-binary",
             "--ngrok",
             "--ngrok-binary",
+            "--gtunnel",
+            "--gtunnel-worker-url",
+            "--gtunnel-tunnel-id",
             "--runner-binary",
             "--restart",
             "--log-dir",

--- a/src/start_stop_parsing.rs
+++ b/src/start_stop_parsing.rs
@@ -21,11 +21,19 @@ pub enum NgrokModeArg {
     Off,
 }
 
+/// Greentic's own managed tunnel (Cloudflare Worker + in-process agent).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GtunnelModeArg {
+    On,
+    Off,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RestartTarget {
     All,
     Cloudflared,
     Ngrok,
+    Gtunnel,
     Nats,
     Gateway,
     Egress,
@@ -53,6 +61,13 @@ pub struct StartRequest {
     pub cloudflared_binary: Option<PathBuf>,
     pub ngrok: NgrokModeArg,
     pub ngrok_binary: Option<PathBuf>,
+    pub gtunnel: GtunnelModeArg,
+    pub gtunnel_worker_url: Option<String>,
+    pub gtunnel_tunnel_id: Option<String>,
+    /// Whether the user explicitly set `--gtunnel`. Kept apart from
+    /// [`StartRequest::tunnel_explicit`] so gtc only ever forwards `--gtunnel`
+    /// when asked to: a greentic-start that predates the flag would reject it.
+    pub gtunnel_explicit: bool,
     pub runner_binary: Option<PathBuf>,
     pub restart: Vec<RestartTarget>,
     pub log_dir: Option<PathBuf>,
@@ -133,6 +148,21 @@ impl StartRequest {
         if let Some(binary) = self.ngrok_binary.as_deref() {
             args.push("--ngrok-binary".to_string());
             args.push(binary.display().to_string());
+        }
+        // gtunnel is forwarded only on explicit request (see
+        // `gtunnel_explicit`); its worker-url/tunnel-id overrides self-gate on
+        // being set, so greentic-start keeps resolving them zero-config.
+        if self.gtunnel_explicit {
+            args.push("--gtunnel".to_string());
+            args.push(self.gtunnel.as_cli_value().to_string());
+        }
+        if let Some(worker_url) = self.gtunnel_worker_url.as_deref() {
+            args.push("--gtunnel-worker-url".to_string());
+            args.push(worker_url.to_string());
+        }
+        if let Some(tunnel_id) = self.gtunnel_tunnel_id.as_deref() {
+            args.push("--gtunnel-tunnel-id".to_string());
+            args.push(tunnel_id.to_string());
         }
         if let Some(binary) = self.runner_binary.as_deref() {
             args.push("--runner-binary".to_string());
@@ -228,6 +258,10 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
         cloudflared_binary: None,
         ngrok: NgrokModeArg::Off,
         ngrok_binary: None,
+        gtunnel: GtunnelModeArg::Off,
+        gtunnel_worker_url: None,
+        gtunnel_tunnel_id: None,
+        gtunnel_explicit: false,
         runner_binary: None,
         restart: Vec::new(),
         log_dir: None,
@@ -294,6 +328,20 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
                 idx += 1;
                 request.ngrok_binary =
                     Some(PathBuf::from(required_value(tail, idx, "--ngrok-binary")?));
+            }
+            "--gtunnel" => {
+                idx += 1;
+                request.gtunnel = parse_gtunnel_mode(&required_value(tail, idx, "--gtunnel")?)?;
+                request.gtunnel_explicit = true;
+            }
+            "--gtunnel-worker-url" => {
+                idx += 1;
+                request.gtunnel_worker_url =
+                    Some(required_value(tail, idx, "--gtunnel-worker-url")?);
+            }
+            "--gtunnel-tunnel-id" => {
+                idx += 1;
+                request.gtunnel_tunnel_id = Some(required_value(tail, idx, "--gtunnel-tunnel-id")?);
             }
             "--runner-binary" => {
                 idx += 1;
@@ -368,6 +416,13 @@ pub fn parse_start_request(tail: &[String], bundle_dir: PathBuf) -> GtcResult<St
                     request.tunnel_explicit = true;
                 } else if let Some(value) = other.strip_prefix("--ngrok-binary=") {
                     request.ngrok_binary = Some(PathBuf::from(value));
+                } else if let Some(value) = other.strip_prefix("--gtunnel=") {
+                    request.gtunnel = parse_gtunnel_mode(value)?;
+                    request.gtunnel_explicit = true;
+                } else if let Some(value) = other.strip_prefix("--gtunnel-worker-url=") {
+                    request.gtunnel_worker_url = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--gtunnel-tunnel-id=") {
+                    request.gtunnel_tunnel_id = Some(value.to_string());
                 } else if let Some(value) = other.strip_prefix("--runner-binary=") {
                     request.runner_binary = Some(PathBuf::from(value));
                 } else if let Some(value) = other.strip_prefix("--restart=") {
@@ -496,6 +551,9 @@ pub fn start_flag_takes_value(flag: &str) -> bool {
             | "--cloudflared-binary"
             | "--ngrok"
             | "--ngrok-binary"
+            | "--gtunnel"
+            | "--gtunnel-worker-url"
+            | "--gtunnel-tunnel-id"
             | "--runner-binary"
             | "--restart"
             | "--log-dir"
@@ -582,11 +640,31 @@ impl NgrokModeArg {
     }
 }
 
+fn parse_gtunnel_mode(value: &str) -> GtcResult<GtunnelModeArg> {
+    match value.trim() {
+        "on" => Ok(GtunnelModeArg::On),
+        "off" => Ok(GtunnelModeArg::Off),
+        other => Err(GtcError::message(format!(
+            "unsupported --gtunnel value: {other}"
+        ))),
+    }
+}
+
+impl GtunnelModeArg {
+    fn as_cli_value(self) -> &'static str {
+        match self {
+            GtunnelModeArg::On => "on",
+            GtunnelModeArg::Off => "off",
+        }
+    }
+}
+
 fn parse_restart_target(value: &str) -> GtcResult<RestartTarget> {
     match value.trim() {
         "all" => Ok(RestartTarget::All),
         "cloudflared" => Ok(RestartTarget::Cloudflared),
         "ngrok" => Ok(RestartTarget::Ngrok),
+        "gtunnel" => Ok(RestartTarget::Gtunnel),
         "nats" => Ok(RestartTarget::Nats),
         "gateway" => Ok(RestartTarget::Gateway),
         "egress" => Ok(RestartTarget::Egress),
@@ -603,6 +681,7 @@ impl RestartTarget {
             RestartTarget::All => "all",
             RestartTarget::Cloudflared => "cloudflared",
             RestartTarget::Ngrok => "ngrok",
+            RestartTarget::Gtunnel => "gtunnel",
             RestartTarget::Nats => "nats",
             RestartTarget::Gateway => "gateway",
             RestartTarget::Egress => "egress",


### PR DESCRIPTION
## The bug

`gtc start` is a thin router: it splits its tail into "gtc flags", the positional
bundle ref, and "runtime flags" forwarded to `greentic-start`. To do that split it
needs to know which forwarded flags consume the next token. That knowledge is a
hardcoded allowlist, and the three `--gtunnel*` flags were never added to it.

Reproduced on the installed gtc 1.1.13:

```
$ gtc start ./bundle --gtunnel on
invalid start arguments: unexpected positional argument `on` (bundle ref already given as `./bundle`)
```

`on` is not a flag value to the router, so it looks like a second bundle ref.

The `=` spelling only *appeared* to work — it slips past the splitter and then dies
one layer deeper, because `parse_start_request` rebuilds the child argv from typed
fields and had no `--gtunnel` arm at all:

```
$ gtc start --gtunnel=on --tenant demo
invalid start arguments: unsupported start argument: --gtunnel=on
```

With a bundle ref that same call only looked healthy because bundle resolution runs
*before* `parse_start_request`, so a different error surfaced first. The fix therefore
has to go the whole way: arity, parse arms (both spellings), and forwarding.

This blocks the managed tunnel end to end: `--gtunnel on` and `--gtunnel-tunnel-id`
are how an operator *states* an explicit tunnel choice, and `--gtunnel-tunnel-id` is
the documented workaround for a tunnel-id mismatch. Existing validation went straight
to `greentic-start start --gtunnel on`, which is why the router path was never
exercised.

This is an argument-parsing bug, not a question of precedence. Nothing here decides
which tunnel wins: under the new convention the tunnel `greentic-setup` recorded is
authoritative for a configured bundle, and a runtime flag that disagrees with it is a
hard error raised by `greentic-start`. gtc's only job is to hand over what the user
typed so that greentic-start can rule on it. Today it mangles the flag first and
reports a confusing "unexpected positional argument" instead.

## The fix

`src/start_stop_parsing.rs`

- `GtunnelModeArg` (on/off) mirroring `CloudflaredModeArg`/`NgrokModeArg`.
- `StartRequest` gains `gtunnel`, `gtunnel_worker_url`, `gtunnel_tunnel_id` and
  `gtunnel_explicit`.
- `parse_start_request` arms for the spaced and `=` spellings of all three.
- `to_runtime_start_args` forwards them. `--gtunnel` is emitted **only** when the user
  set it (`gtunnel_explicit`), deliberately *not* piggybacked on the existing
  `tunnel_explicit`: gtc must never volunteer a tunnel flag the operator did not type.
  A `--gtunnel off` invented by gtc would be rejected outright by a greentic-start that
  predates the flag, and under the authoritative-tunnel convention it is exactly the
  kind of unrequested tunnel statement that should never leave the router.
  `--gtunnel-worker-url` / `--gtunnel-tunnel-id` self-gate on being `Some` and are
  forwarded verbatim.
- `start_flag_takes_value` gains the three flags — the actual arity fix.
- `RestartTarget::Gtunnel`: `greentic-start start --restart` lists `gtunnel` among its
  possible values and the router rejected it (`unsupported --restart target: gtunnel`).
  Same class, same feature, fixed here.

`src/bin/gtc/deploy/start_stop.rs` — `gtc start --help` now lists the gtunnel flags
among the flags it forwards. It does not describe them as overriding anything.

### What the router deliberately does not do

Knowing a flag's *arity* is not the same as having an opinion about its *value*, and
this PR only teaches it arity:

- no default and no injected tunnel flag — `gtunnel_explicit` is false unless the
  operator typed `--gtunnel`, and nothing is emitted in that case
  (`gtunnel_is_not_forwarded_unless_asked_for` pins this)
- no translation: `on` leaves as `on`, `--gtunnel-worker-url` and
  `--gtunnel-tunnel-id` are forwarded as the operator wrote them
- no tunnel policy: whether a stated tunnel is legal for the configured bundle is
  greentic-start's call, and stays there

## Whole-class audit

Diffed the router's allowlist against every flag in `greentic-start start --help`
(greentic-start 1.1.38). Everything else value-taking is already covered:
`--env --tenant --team --nats --nats-url --config --cloudflared --cloudflared-binary
--ngrok --ngrok-binary --runner-binary --restart --log-dir --admin-port
--admin-certs-dir --admin-allowed-clients`, plus `--bundle`, which is in the arity list
*and* rejected with a pointed message because gtc owns it. `gtc stop`'s allowlist is
likewise complete against `greentic-start stop --help`.

Three residual gaps, left alone because the right answer is not "add it to the
allowlist" and this is a bugfix:

- **`--locale <LOCALE>`** — value-taking, absent from the allowlist, so
  `gtc start ./bundle --locale fr` fails with the exact same "unexpected positional
  argument `fr`". But gtc *owns* `--locale`: it has its own global `--locale` and
  injects `--locale <locale>` into the child argv itself, so forwarding a second one
  would duplicate it. The `--bundle` treatment (in the arity list, rejected with a
  message pointing at `gtc --locale`) looks like the right shape.
- **`--no-auto-restart`** — boolean, so it cannot swallow a bundle ref, but
  `parse_start_request` rejects it as an unsupported argument: unforwardable through
  gtc today.
- **`--open-webchat [<OPEN_WEBCHAT>]`** — optional-value flag that gtc synthesizes
  itself (`open_webchat_arg`, behind a `--help` capability probe). Adding it to the
  arity allowlist would be actively wrong: clap accepts the spaced form, so the router
  would start eating the bundle ref in `gtc start --open-webchat ./bundle`.

## Maintenance hazard

The arity table is a hardcoded `matches!` list, duplicated in shape across
`parse_start_request`'s spaced arms, its `=`-prefix chain, `start_flag_takes_value`,
and two enumerated test lists. The existing lockstep test pins the list against the
parser — but both halves live in this repo, so it only catches inconsistencies gtc
already knows about. It cannot catch a flag `greentic-start` grew and gtc never heard
of, which is exactly this bug.

Suggestion (not built here): a `#[ignore]`d test run from `ci/local_check.sh` — the
same trick the socket-binding tests already use — that shells out to
`greentic-start start --help`, extracts every `--flag <VALUE>` line, and asserts each
one is either in `start_flag_takes_value` or on an explicit "gtc owns this" deny list
(`--bundle`, `--locale`). The repo already probes the child's `--help` at runtime in
`start_supports_open_webchat`, so the mechanism exists.

## Tests

Added to the existing `src/bin/gtc/deploy/start_stop.rs` unit tests, next to the
2026-06-10 `--cloudflared` repro they mirror:

- `gtunnel_flags_survive_both_spellings_after_a_bundle_ref` — drives all three flags
  spaced and `=`-joined through splitter → parser → child argv.
- `gtunnel_is_not_forwarded_unless_asked_for` — `--cloudflared on` must not make gtc
  volunteer `--gtunnel` at an older greentic-start.
- `restart_accepts_the_gtunnel_target`.
- Both lockstep lists gained the three flags.

## Verified against the built binary

Nonexistent bundle so the child never boots — the error now comes from bundle
resolution, not argument parsing:

```
$ ./target/debug/gtc start /nonexistent-xyz --gtunnel on --tenant demo
failed to resolve bundle: bundle path does not exist: /nonexistent-xyz
$ ./target/debug/gtc start /nonexistent-xyz --gtunnel=on --tenant demo
failed to resolve bundle: bundle path does not exist: /nonexistent-xyz
$ ./target/debug/gtc start /nonexistent-xyz --gtunnel on --gtunnel-tunnel-id acme \
    --gtunnel-worker-url https://t.example.com --tenant demo
failed to resolve bundle: bundle path does not exist: /nonexistent-xyz
$ ./target/debug/gtc start /nonexistent-xyz --restart gtunnel
failed to resolve bundle: bundle path does not exist: /nonexistent-xyz
```

Version bumped to 1.1.14 per the one-patch-bump-per-PR convention.
