### PR TITLE
feat(install): add --airgap for the airgapped toolchain channel

### DIFF
--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -264,6 +264,14 @@ pub(super) fn build_cli(locale: &str) -> Command {
                         .action(ArgAction::SetTrue)
                         .help_heading(options_heading)
                         .help("Skip replacing the gtc binary itself; only install companion binaries and artifacts."),
+                )
+                .arg(
+                    Arg::new("airgap")
+                        .long("airgap")
+                        .action(ArgAction::SetTrue)
+                        .conflicts_with_all(["channel", "release", "manifest"])
+                        .help_heading(options_heading)
+                        .help("Install the airgapped toolchain: the dev-lane binaries carrying the `op updates export/import/--push-to` verbs. Shorthand for `--channel airgapped`; never self-updates gtc."),
                 ),
         )
         .subcommand(

--- a/src/bin/gtc/toolchain.rs
+++ b/src/bin/gtc/toolchain.rs
@@ -22,6 +22,11 @@ const TOOLCHAIN_MANIFEST_SCHEMA: &str = "greentic.toolchain-manifest.v1";
 const INSTALLED_TOOLCHAIN_SCHEMA: &str = "greentic.installed-toolchain.v1";
 const TOOLCHAIN_MANIFEST_MEDIA_TYPE: &str = "application/vnd.greentic.toolchain.manifest.v1+json";
 const DEFAULT_GHCR_PREFIX: &str = "ghcr.io/greenticai/greentic-versions/gtc";
+/// GHCR tag holding the dev-lane toolchain used for air-gapped workflows —
+/// the `-dev` binaries that carry `op updates export`/`import`/`--push-to`.
+/// Its packages pin `"latest"`, so each install resolves the newest dev
+/// publish rather than a frozen set.
+const AIRGAP_CHANNEL: &str = "airgapped";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ToolchainManifest {
@@ -104,6 +109,20 @@ pub(crate) enum ToolchainSource {
     LocalManifest(PathBuf),
 }
 
+impl ToolchainSource {
+    /// Whether this source resolves the air-gap channel, however it was
+    /// reached (`--airgap`, `--channel airgapped`, or `--release <r> --channel
+    /// airgapped`). A local manifest is never the air-gap channel — it already
+    /// suppresses self-update on its own.
+    fn targets_airgap_channel(&self) -> bool {
+        match self {
+            Self::Channel(channel) => channel == AIRGAP_CHANNEL,
+            Self::Release { channel, .. } => channel == AIRGAP_CHANNEL,
+            Self::LocalManifest(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ToolchainInstallPhases {
     pub binaries: bool,
@@ -127,7 +146,9 @@ impl ToolchainInstallPhases {
 
 impl ToolchainInstallOptions {
     pub(crate) fn from_matches(matches: &ArgMatches, default_channel: &str) -> GtcResult<Self> {
-        let source = if let Some(path) = matches.get_one::<String>("manifest") {
+        let source = if matches.get_flag("airgap") {
+            ToolchainSource::Channel(AIRGAP_CHANNEL.to_string())
+        } else if let Some(path) = matches.get_one::<String>("manifest") {
             ToolchainSource::LocalManifest(PathBuf::from(path))
         } else if let Some(release) = matches
             .get_one::<String>("release")
@@ -165,12 +186,21 @@ impl ToolchainInstallOptions {
             ToolchainInstallPhases::all()
         };
 
+        // Keyed on the resolved channel, not on `--airgap`, so `--channel
+        // airgapped` behaves identically. That path is what operators use
+        // before a gtc carrying `--airgap` reaches them, and a self-update
+        // attempt there is guaranteed to fail: the dev lane's release assets
+        // are named `gtc-dev-v<version>-<target>.tgz`, which
+        // `gtc_release_asset_url` does not build.
+        let skip_self_update =
+            matches.get_flag("skip-self-update") || source.targets_airgap_channel();
+
         Ok(Self {
             source,
             force: matches.get_flag("force"),
             dry_run: matches.get_flag("dry-run"),
             phases,
-            skip_self_update: matches.get_flag("skip-self-update"),
+            skip_self_update,
         })
     }
 }
@@ -2301,6 +2331,11 @@ mod tests {
                         .long("skip-self-update")
                         .action(clap::ArgAction::SetTrue),
                 )
+                .arg(
+                    clap::Arg::new("airgap")
+                        .long("airgap")
+                        .action(clap::ArgAction::SetTrue),
+                )
         };
 
         let release_matches = cmd()
@@ -2350,6 +2385,49 @@ mod tests {
             channel_options.source,
             ToolchainSource::Channel(ref channel) if channel == "dev"
         ));
+        // The default channel must NOT pick up the air-gap self-update skip.
+        assert!(!channel_options.skip_self_update);
+
+        // `--airgap` resolves the airgapped channel even though the caller
+        // passed a different default, and suppresses self-update.
+        let airgap_matches = cmd()
+            .try_get_matches_from(["install", "--airgap"])
+            .expect("matches");
+        let airgap_options =
+            ToolchainInstallOptions::from_matches(&airgap_matches, "stable").expect("options");
+        assert!(matches!(
+            airgap_options.source,
+            ToolchainSource::Channel(ref channel) if channel == AIRGAP_CHANNEL
+        ));
+        assert!(airgap_options.skip_self_update);
+
+        // Reaching the same channel the long way must behave identically —
+        // operators use this before a gtc carrying `--airgap` reaches them.
+        let explicit_matches = cmd()
+            .try_get_matches_from(["install", "--channel", "airgapped"])
+            .expect("matches");
+        let explicit_options =
+            ToolchainInstallOptions::from_matches(&explicit_matches, "stable").expect("options");
+        assert!(explicit_options.skip_self_update);
+    }
+
+    #[test]
+    fn airgap_channel_detection_is_scoped_to_that_channel() {
+        assert!(ToolchainSource::Channel(AIRGAP_CHANNEL.to_string()).targets_airgap_channel());
+        assert!(
+            ToolchainSource::Release {
+                release: "1.0.4".to_string(),
+                channel: AIRGAP_CHANNEL.to_string(),
+            }
+            .targets_airgap_channel()
+        );
+        // Neighbouring channels must not inherit the skip.
+        assert!(!ToolchainSource::Channel("stable".to_string()).targets_airgap_channel());
+        assert!(!ToolchainSource::Channel("latest".to_string()).targets_airgap_channel());
+        assert!(!ToolchainSource::Channel("airgap".to_string()).targets_airgap_channel());
+        assert!(
+            !ToolchainSource::LocalManifest(PathBuf::from("/tmp/m.json")).targets_airgap_channel()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `gtc install --airgap`, resolving a new GHCR channel `airgapped` that
pins the dev-lane binaries carrying the air-gap update verbs.

```
$ gtc install --airgap --dry-run
Resolved Greentic toolchain manifest from ghcr.io/greenticai/greentic-versions/gtc:airgapped.
  digest: sha256:3be18de3ebfbdcec6f0df72ba11b5cb4287be11edd495b72dc532db9fb701ad5
Dry run: planned toolchain install commands.
cargo binstall … gtc-dev --version 1.2.30553927257 --bin gtc-dev
cargo binstall … greentic-operator-dev --version 1.2.30516422630 --bin greentic-operator-dev
cargo binstall … greentic-deployer-dev --version 1.2.30522356308 --bin greentic-deployer-dev
…
```

The manifest is **already published**, so this flag is sugar over a channel
that works today via `--channel airgapped --skip-self-update`.

## Why

`op updates export` / `import` / `import --push-to` and `config-set
--blob-base-url` only exist on the dev lane. Reaching them meant knowing that
`gtc-dev` suffixes its companions, and hand-pinning half a dozen `-dev`
crates. `--airgap` makes that one flag.

## Design note: the self-update skip is keyed on the channel, not the flag

```rust
let skip_self_update =
    matches.get_flag("skip-self-update") || source.targets_airgap_channel();
```

Deliberately not `matches.get_flag("airgap")`. Two reasons:

1. **`--channel airgapped` must behave identically.** That is the only route
   available to anyone whose `gtc` predates this PR, and it is what the docs
   will tell operators to use until this ships.
2. **A self-update on this channel cannot succeed.** `gtc_release_asset_url`
   builds `gtc-{target}.tgz`, but the dev lane's release assets are named
   `gtc-dev-v{version}-{target}.tgz` with per-asset `.sha256` sidecars rather
   than a combined `gtc-{version}-checksums.txt`. Attempting it is a
   guaranteed 404, so the channel opts out rather than failing loudly.

This touches neither `gtc_release_asset_url` nor the stable self-update path.

`--airgap` conflicts with `--channel`, `--release` and `--manifest` — it is a
source selector, and silently losing to another one would be worse than a
parse error.

## Tests

Extends the existing `from_matches` test and adds
`airgap_channel_detection_is_scoped_to_that_channel`, which pins that
neighbouring channels (`stable`, `latest`, and the near-miss `airgap`) do
**not** inherit the skip, and that a local manifest never reports as the
air-gap channel.

Mutation-proved, 5/5 killed:

| mutation | result |
|---|---|
| channel check always false | KILLED |
| `AIRGAP_CHANNEL` renamed to `airgap` | KILLED |
| skip honours only the explicit flag | KILLED |
| `Release` arm stops matching | KILLED |
| `--airgap` made inert | KILLED |

## Verification

`cargo fmt --all -- --check` clean; `cargo clippy --lib --bins --tests
--all-features -- -D warnings` clean; test suite green.

Benches are excluded from the local run: `benches/perf` fails to link in my
environment with `mold: error: undefined symbol: c_with_alloca`, from the
`alloca` crate's C shim. Confirmed pre-existing and unrelated by rebuilding
the bench with pristine `develop` files in the same tree — it fails
identically. `-fuse-ld=mold` comes from a user-global `~/.cargo/config.toml`,
not this repo, so CI's `--all-targets` run is unaffected.

## Help text

Literal string, matching the adjacent `--skip-self-update`, so no new i18n key
is needed across the 67 locale catalogues.
