### PR TITLE
ci(nightly-coverage): give cargo binstall a token and forbid source fallback

### DIFF
--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -34,15 +34,25 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install coverage toolchain
+        # Without a token, binstall queries api.github.com anonymously and gets
+        # rate-limited (403 Forbidden) per runner IP. It does not fail on that:
+        # it silently falls back to building from source via `cargo install`
+        # without --locked, which cargo-nextest rejects with a deliberate
+        # compile_error!, so the job burns ~11 minutes and exits 70 looking like
+        # a Rust build break. --disable-strategies compile makes that fallback
+        # fatal at the install step instead of silent.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # rust-cache restores ~/.cargo/.crates.toml but prunes ~/.cargo/bin of
           # binstall-installed binaries, so binstall says "already installed"
           # while the binary is gone. --force sidesteps that.
-          cargo binstall -y --force cargo-llvm-cov
-          cargo binstall -y --force cargo-nextest
-          cargo binstall -y --force greentic-dev
+          cargo binstall -y --force --disable-strategies compile cargo-llvm-cov
+          cargo binstall -y --force --disable-strategies compile cargo-nextest
+          cargo binstall -y --force --disable-strategies compile greentic-dev
           command -v cargo-llvm-cov
           command -v cargo-nextest
+          command -v greentic-dev
           greentic-dev --version
 
       - name: Install llvm-tools-preview


### PR DESCRIPTION
## Root cause

`cargo binstall` running **without** `GITHUB_TOKEN` queries `api.github.com` anonymously. Anonymous requests are rate-limited **per runner IP**, so on a busy shared runner the release-asset lookup comes back **403 Forbidden**.

binstall does **not** fail on that. It silently degrades to its `compile` strategy, i.e. `cargo install <tool>` **without `--locked`**. `cargo-nextest` ships a deliberate `compile_error!` rejecting exactly that invocation, so the job burns ~11 minutes compiling and then exits **70** — which reads like a Rust build break, several steps away from the real cause.

Root-caused and fixed in greenticai/greentic-cap#39. This mirrors the already-green implementation in `greenticai/greentic-bundle/.github/workflows/nightly-coverage.yml`.

## Change

Scoped to the `Install coverage toolchain` step of `.github/workflows/nightly-coverage.yml`:

1. `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` — the API calls become authenticated, so the rate limit stops being hit.
2. `--disable-strategies compile` on each `cargo binstall` invocation — if prebuilt resolution ever fails anyway, the install step fails loudly and immediately instead of silently falling back to a source build.
3. `command -v greentic-dev` added so all three installed tools are PATH-verified at the install step.
4. A comment recording *why*, so the flags survive future edits.

Existing flags (`-y`, `--force`) and the existing `--force` rationale comment are preserved verbatim. Nothing else in the repo is touched.

## Verification

The workflow has `workflow_dispatch`, so it was dispatched on this branch and the log inspected for `has been downloaded from github.com` (one per tool), `installed from source` (expect 0) and `Forbidden` (expect 0). Recent nightly runs are green, so a green run here confirms no regression.