### PR TITLE
fix(ci): carry binstall hardening onto the main lane

### DIFF
--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -34,15 +34,25 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install coverage toolchain
+        # Without a token, binstall queries api.github.com anonymously and gets
+        # rate-limited (403 Forbidden) per runner IP. It does not fail on that:
+        # it silently falls back to building from source via `cargo install`
+        # without --locked, which cargo-nextest rejects with a deliberate
+        # compile_error!, so the job burns ~11 minutes and exits 70 looking like
+        # a Rust build break. --disable-strategies compile makes that fallback
+        # fatal at the install step instead of silent.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # rust-cache restores ~/.cargo/.crates.toml but prunes ~/.cargo/bin of
           # binstall-installed binaries, so binstall says "already installed"
           # while the binary is gone. --force sidesteps that.
-          cargo binstall -y --force cargo-llvm-cov
-          cargo binstall -y --force cargo-nextest
-          cargo binstall -y --force greentic-dev
+          cargo binstall -y --force --disable-strategies compile cargo-llvm-cov
+          cargo binstall -y --force --disable-strategies compile cargo-nextest
+          cargo binstall -y --force --disable-strategies compile greentic-dev
           command -v cargo-llvm-cov
           command -v cargo-nextest
+          command -v greentic-dev
           greentic-dev --version
 
       - name: Install llvm-tools-preview


### PR DESCRIPTION
## Outcome

Carries the binstall hardening onto this repo's other lane so the fix survives — and applies — regardless of promote direction.

## Why this is needed

The companion PR landed on the opposite lane. That alone is not enough:

- **Scheduled nightlies only ever run on the default branch.** A fix that lives only on the development lane does not protect a single real nightly run until a promote happens — and some lanes are hundreds of commits apart.
- **Conversely**, a fix that lives only on the default branch gets **silently reverted** the next time the development lane is promoted, because that lane still carries the old block.

Either way, a single-lane fix has an expiry date. This PR closes the other half.

## The change

Cherry-picked verbatim from the already-merged companion commit — same diff, no re-authoring.

## Root cause (short)

`cargo binstall` without a GitHub token queries `api.github.com` anonymously, which is rate-limited per runner IP. On a 403 it does **not** fail: it silently degrades to installing from source, running `cargo install <tool>` **without** `--locked`. `cargo-nextest` carries a deliberate `compile_error!` rejecting exactly that, so the job burns ~11 minutes compiling and exits 70 looking like a Rust build break.

Root-caused in `greenticai/greentic-cap#39`. The companion PR on the other lane was verified green with the prebuilt path intact (3 tools downloaded from github.com, 0 source builds, 0 rate-limit errors).