### PR TITLE
ci(release): give cargo binstall a token and forbid source fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,25 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install deployer pack tooling
+        # Without a token, binstall queries api.github.com anonymously and gets
+        # rate-limited (403 Forbidden) per runner IP. It does not fail on that:
+        # it silently falls back to building the crate from source, so the step
+        # burns ~10 extra minutes with nothing in the log naming the cause. In a
+        # release workflow that means a slow, silent, non-reproducible build.
+        # --disable-strategies compile makes that fallback fatal at the install
+        # step instead of silent. Both crates publish a prebuilt
+        # x86_64-unknown-linux-gnu tarball on their GitHub releases
+        # (greentic-pack v1.1.5, greentic-flow v1.1.4 verified), so forbidding
+        # the compile strategy costs nothing on the happy path.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          cargo binstall -y greentic-pack
-          cargo binstall -y greentic-flow
+          cargo binstall -y --disable-strategies compile greentic-pack
+          cargo binstall -y --disable-strategies compile greentic-flow
+          command -v greentic-pack
+          command -v greentic-flow
 
       - name: Build and sync deployer pack
         shell: bash


### PR DESCRIPTION
Closes the last unhardened `cargo binstall` call site in this repo. `nightly-coverage.yml` was fixed in #290 (develop) / #291 (main); `release.yml` was noticed at the time but left out of scope.

## The bug

`.github/workflows/release.yml`, job `prepare_deployer_assets`, step *Install deployer pack tooling*:

```yaml
cargo binstall -y greentic-pack
cargo binstall -y greentic-flow
```

No `GITHUB_TOKEN`, so binstall queries `api.github.com` anonymously and is rate-limited per runner IP. On a 403 binstall does **not** fail — it silently degrades to building from source. Neither crate is `cargo-nextest`, so there is no `compile_error!` tripwire: nothing in the log names the cause and the job just takes ~10 extra minutes. In a **release** workflow that is a slow, silent, non-reproducible release build.

## The fix

- `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the step.
- `--disable-strategies compile` so a resolution failure is fatal at the install step instead of silent.
- `command -v` assertions for both binaries.
- Comment explaining why, matching the `nightly-coverage.yml` wording.

## Prebuilt availability — verified, not assumed

`--disable-strategies compile` turns "slow" into "hard fail" for any tool with no non-compile path (e.g. `cargo-component@0.21.x` and `cargo-audit` publish zero release assets). So both crates were checked first:

| crate | version binstall resolves | GitHub release asset `x86_64-unknown-linux-gnu` | HTTP | payload | cargo-quickinstall | verdict |
|---|---|---|---|---|---|---|
| `greentic-pack` | 1.1.5 | `greentic-pack-v1.1.5-x86_64-unknown-linux-gnu.tgz` | 200 | 24,654,325 B, valid gzip tar containing `greentic-pack` | 404 (9-byte body) | flag safe |
| `greentic-flow` | 1.1.4 | `greentic-flow-v1.1.4-x86_64-unknown-linux-gnu.tgz` | 200 | 18,705,139 B, valid gzip tar containing `greentic-flow` | 404 (9-byte body) | flag safe |

quickinstall has no build for either, so the GitHub-release path is the *only* non-compile route — which is exactly why it had to be confirmed.

End-to-end proof with binstall itself (v1.20.0, isolated `CARGO_HOME`, `--dry-run` so nothing was installed):

```
$ cargo binstall -y --dry-run --disable-strategies compile \
    --targets x86_64-unknown-linux-gnu greentic-pack
 INFO resolve: Resolving package: 'greentic-pack'
 WARN The package greentic-pack v1.1.5 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-pack => .../bin/greentic-pack
 INFO Dry-run: Not proceeding to install fetched binaries
PACK_EXIT=0

$ cargo binstall -y --dry-run --disable-strategies compile \
    --targets x86_64-unknown-linux-gnu greentic-flow
 INFO resolve: Resolving package: 'greentic-flow'
 WARN The package greentic-flow v1.1.4 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - greentic-flow => .../bin/greentic-flow
 INFO Dry-run: Not proceeding to install fetched binaries
FLOW_EXIT=0
```

## How this was verified

`release.yml` triggers on `push: tags: ["v*"]` and `workflow_dispatch`. A dispatch is **not** safe: the `github_release` job runs `softprops/action-gh-release` with `tag_name: v{Cargo.toml version}` against `main`, so dispatching would cut a real GitHub release. **This workflow was deliberately not run.** Static verification instead:

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses; the step's `env`/`shell`/`run` keys read back as intended.
- `actionlint` v1.7.7 — exit 0 on the patched file, and exit 0 on the pre-patch baseline too (so no pre-existing findings were masked).
- Prebuilt evidence above.

## Not touched

Only `.github/workflows/release.yml`, only that one step. Specifically left alone:

- `cargo install --locked cargo-sbom` in the `sbom` job — that is `cargo install`, not binstall, and is already `--locked`/deterministic.
- No `--force` (unlike `nightly-coverage.yml`): that flag exists there to work around `Swatinem/rust-cache` pruning `~/.cargo/bin`, and this job has no rust-cache step.
- `shell: bash` on the step was preserved.

Both lanes' `release.yml` were byte-identical before this change (`git diff origin/main origin/develop -- .github/workflows/release.yml` → empty), so a companion cherry-pick PR onto `main` follows once this merges, exactly as #290 → #291.