### PR TITLE
fix(ci): carry release.yml binstall hardening onto the main lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,25 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install deployer pack tooling
+        # Without a token, binstall queries api.github.com anonymously and gets
+        # rate-limited (403 Forbidden) per runner IP. It does not fail on that:
+        # it silently falls back to building the crate from source, so the step
+        # burns ~10 extra minutes with nothing in the log naming the cause. In a
+        # release workflow that means a slow, silent, non-reproducible build.
+        # --disable-strategies compile makes that fallback fatal at the install
+        # step instead of silent. Both crates publish a prebuilt
+        # x86_64-unknown-linux-gnu tarball on their GitHub releases
+        # (greentic-pack v1.1.5, greentic-flow v1.1.4 verified), so forbidding
+        # the compile strategy costs nothing on the happy path.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          cargo binstall -y greentic-pack
-          cargo binstall -y greentic-flow
+          cargo binstall -y --disable-strategies compile greentic-pack
+          cargo binstall -y --disable-strategies compile greentic-flow
+          command -v greentic-pack
+          command -v greentic-flow
 
       - name: Build and sync deployer pack
         shell: bash


### PR DESCRIPTION
Companion cherry-pick of #292 onto `main`, mirroring how #291 carried #290 across. Nightlies and tag-triggered releases run on `main`, so a develop-only fix would protect nothing here; a main-only fix would be reverted on the next promote.

**Merge #292 first.** This is `git cherry-pick -x` of that commit and nothing else.

## What it fixes

`.github/workflows/release.yml`, job `prepare_deployer_assets`, step *Install deployer pack tooling*, ran `cargo binstall -y` with no token. Anonymous `api.github.com` calls are rate-limited per runner IP, and on a 403 binstall does **not** fail — it silently degrades to building from source. Neither `greentic-pack` nor `greentic-flow` is `cargo-nextest`, so there is no `compile_error!` tripwire: nothing in the log names the cause and the release job just takes ~10 extra minutes. That is a slow, silent, non-reproducible **release** build.

Adds `GITHUB_TOKEN`, `--disable-strategies compile`, and `command -v` assertions for both binaries.

## Lanes were identical before this change

```
$ git rev-parse origin/main:.github/workflows/release.yml
0579b9beacffd4dbc83666711576cdb1b9c7bbe7
$ git rev-parse origin/develop:.github/workflows/release.yml
0579b9beacffd4dbc83666711576cdb1b9c7bbe7
$ git diff origin/main origin/develop -- .github/workflows/release.yml
(empty)
```

Same blob on both lanes, so the cherry-pick applied without conflict and lands the identical resulting blob (`75a6104`) here.

## Prebuilt availability — verified, not assumed

`--disable-strategies compile` turns "slow" into "hard fail" for any tool with no non-compile path (`cargo-component@0.21.x` and `cargo-audit` publish zero release assets, for instance). Both crates were checked before the flag was added:

| crate | version binstall resolves | GitHub release asset `x86_64-unknown-linux-gnu` | HTTP | payload | cargo-quickinstall | verdict |
|---|---|---|---|---|---|---|
| `greentic-pack` | 1.1.5 | `greentic-pack-v1.1.5-x86_64-unknown-linux-gnu.tgz` | 200 | 24,654,325 B, valid gzip tar containing `greentic-pack` | 404 (9-byte body) | flag safe |
| `greentic-flow` | 1.1.4 | `greentic-flow-v1.1.4-x86_64-unknown-linux-gnu.tgz` | 200 | 18,705,139 B, valid gzip tar containing `greentic-flow` | 404 (9-byte body) | flag safe |

quickinstall has no build for either, so the GitHub-release path is the *only* non-compile route — which is exactly why it had to be confirmed rather than assumed. End-to-end proof with binstall v1.20.0 (isolated `CARGO_HOME`, `--dry-run`, nothing installed): both resolve at exit 0 under `--disable-strategies compile --targets x86_64-unknown-linux-gnu`.

## How this was verified

`release.yml` triggers on `push: tags: ["v*"]` and `workflow_dispatch`. A dispatch is **not** safe: the `github_release` job runs `softprops/action-gh-release` with `tag_name: v{Cargo.toml version}` against `main`, so dispatching would cut a real GitHub release. **This workflow was deliberately not run.** Static verification instead: `yaml.safe_load` parses and the step's `env`/`shell`/`run` keys read back as intended; `actionlint` v1.7.7 exits 0 on the patched file and also on the pre-patch baseline (so no pre-existing findings were masked); plus the prebuilt evidence above. #292 additionally carries a full green PR-CI run of the identical diff.

## Not touched

Only `.github/workflows/release.yml`, only that one step. Deliberately left alone: `cargo install --locked cargo-sbom` in the `sbom` job (that is `cargo install`, not binstall, and already `--locked`); no `--force` (that flag exists in `nightly-coverage.yml` only to work around `Swatinem/rust-cache` pruning `~/.cargo/bin`, and this job has no rust-cache step); `shell: bash` on the step was preserved.

After this, every `cargo binstall` call site in the repo is hardened on both lanes — `rc-build.yml` deliberately uses `gh release download` instead.