### PR TITLE
fix(ci): carry the release.yml fix onto the main lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,25 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install deployer pack tooling
+        # Without a token, binstall queries api.github.com anonymously and gets
+        # rate-limited (403 Forbidden) per runner IP. It does not fail on that:
+        # it silently falls back to building the crate from source, so the step
+        # burns ~10 extra minutes with nothing in the log naming the cause. In a
+        # release workflow that means a slow, silent, non-reproducible build.
+        # --disable-strategies compile makes that fallback fatal at the install
+        # step instead of silent. Both crates publish a prebuilt
+        # x86_64-unknown-linux-gnu tarball on their GitHub releases
+        # (greentic-pack v1.1.5, greentic-flow v1.1.4 verified), so forbidding
+        # the compile strategy costs nothing on the happy path.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          cargo binstall -y greentic-pack
-          cargo binstall -y greentic-flow
+          cargo binstall -y --disable-strategies compile greentic-pack
+          cargo binstall -y --disable-strategies compile greentic-flow
+          command -v greentic-pack
+          command -v greentic-flow
 
       - name: Build and sync deployer pack
         shell: bash


### PR DESCRIPTION
Companion to #292, which landed on `develop`.

Scheduled workflows run **only on the default branch (`main`)**, so a fix that lives only on `develop` protects no real run until a promote — and in this fleet lanes can sit far apart. Conversely, leaving `main` alone means the next promote merges the old file back over it.

Cherry-picked verbatim from the merged `develop` commit; the resulting file is byte-identical to the lane that was already verified. No re-authoring.