### PR TITLE
fix: print the full error chain for registry failures

### DIFF
--- a/src/bin/gtc/toolchain.rs
+++ b/src/bin/gtc/toolchain.rs
@@ -8,7 +8,7 @@ use directories::BaseDirs;
 use greentic_distributor_client::{
     CachePolicy, DistClient, DistOptions, ReleaseArtifactKind, ResolvePolicy,
 };
-use gtc::error::{GtcError, GtcResult};
+use gtc::error::{GtcError, GtcResult, error_chain};
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, WWW_AUTHENTICATE};
 use serde::{Deserialize, Serialize};
@@ -312,11 +312,17 @@ pub(crate) fn run_toolchain_install(
             options.phases,
             options.force,
         ) {
-            eprintln!("failed to prefetch release artifacts: {err}");
+            eprintln!(
+                "failed to prefetch release artifacts: {}",
+                error_chain(&err)
+            );
             return 1;
         }
         if let Err(err) = write_current_release_context(&ctx) {
-            eprintln!("failed to write current release context: {err}");
+            eprintln!(
+                "failed to write current release context: {}",
+                error_chain(&err)
+            );
             return 1;
         }
     }
@@ -1083,16 +1089,27 @@ fn prefetch_release_artifacts_and_write_index(
         );
         let resolved = if let Some(prefetch_ref) = mock_prefetch_source_ref(&version_ref)? {
             let source = client.parse_source(&prefetch_ref).map_err(|err| {
-                GtcError::message(format!("failed to parse {prefetch_ref}: {err}"))
+                GtcError::message(format!(
+                    "failed to parse {prefetch_ref}: {}",
+                    error_chain(&err)
+                ))
             })?;
             let descriptor = runtime
                 .block_on(client.resolve(source, ResolvePolicy))
                 .map_err(|err| {
-                    GtcError::message(format!("failed to resolve {version_ref}: {err}"))
+                    GtcError::message(format!(
+                        "failed to resolve {version_ref}: {}",
+                        error_chain(&err)
+                    ))
                 })?;
             runtime
                 .block_on(client.fetch(&descriptor, CachePolicy))
-                .map_err(|err| GtcError::message(format!("failed to fetch {version_ref}: {err}")))?
+                .map_err(|err| {
+                    GtcError::message(format!(
+                        "failed to fetch {version_ref}: {}",
+                        error_chain(&err)
+                    ))
+                })?
         } else {
             runtime
                 .block_on(client.prefetch_release_artifact(
@@ -1101,7 +1118,10 @@ fn prefetch_release_artifacts_and_write_index(
                     CachePolicy,
                 ))
                 .map_err(|err| {
-                    GtcError::message(format!("failed to prefetch {version_ref}: {err}"))
+                    GtcError::message(format!(
+                        "failed to prefetch {version_ref}: {}",
+                        error_chain(&err)
+                    ))
                 })?
         };
         let entry = client
@@ -1364,11 +1384,19 @@ fn send_ghcr_get(
         .try_clone()
         .ok_or_else(|| GtcError::message("failed to clone GHCR request"))?
         .send()
-        .map_err(|err| GtcError::message(format!("failed to fetch GHCR artifact: {err}")))?;
+        .map_err(|err| {
+            GtcError::message(format!(
+                "failed to fetch GHCR artifact: {}",
+                error_chain(&err)
+            ))
+        })?;
     if response.status() != reqwest::StatusCode::UNAUTHORIZED {
-        return response
-            .error_for_status()
-            .map_err(|err| GtcError::message(format!("failed to fetch GHCR artifact: {err}")));
+        return response.error_for_status().map_err(|err| {
+            GtcError::message(format!(
+                "failed to fetch GHCR artifact: {}",
+                error_chain(&err)
+            ))
+        });
     }
     let Some(challenge) = response
         .headers()
@@ -1386,9 +1414,19 @@ fn send_ghcr_get(
     }
     authed
         .send()
-        .map_err(|err| GtcError::message(format!("failed to fetch GHCR artifact: {err}")))?
+        .map_err(|err| {
+            GtcError::message(format!(
+                "failed to fetch GHCR artifact: {}",
+                error_chain(&err)
+            ))
+        })?
         .error_for_status()
-        .map_err(|err| GtcError::message(format!("failed to fetch GHCR artifact: {err}")))
+        .map_err(|err| {
+            GtcError::message(format!(
+                "failed to fetch GHCR artifact: {}",
+                error_chain(&err)
+            ))
+        })
 }
 
 fn fetch_bearer_token(client: &Client, challenge: &str) -> GtcResult<String> {
@@ -1411,7 +1449,10 @@ fn fetch_bearer_token(client: &Client, challenge: &str) -> GtcResult<String> {
     }
     let response_text = request
         .send()
-        .map_err(|err| GtcError::message(format!("failed to fetch GHCR auth token: {err}")))?
+        .map_err(|err| GtcError::message(format!(
+                    "failed to fetch GHCR auth token: {}",
+                    error_chain(&err)
+                )))?
         .error_for_status()
         .map_err(|err| {
             if err.status() == Some(reqwest::StatusCode::FORBIDDEN) {
@@ -1425,7 +1466,10 @@ fn fetch_bearer_token(client: &Client, challenge: &str) -> GtcResult<String> {
                     )
                 }
             } else {
-                GtcError::message(format!("failed to fetch GHCR auth token: {err}"))
+                GtcError::message(format!(
+                    "failed to fetch GHCR auth token: {}",
+                    error_chain(&err)
+                ))
             }
         })?
         .text()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,37 @@
+use std::error::Error as StdError;
 use std::path::StripPrefixError;
 
 use thiserror::Error;
 
 pub type GtcResult<T> = Result<T, GtcError>;
+
+/// Render an error and its full `source` chain as a single line.
+///
+/// Most errors reaching [`GtcError::Message`] are flattened with `{err}`, which
+/// prints only the outermost message. For a failed registry pull that reads
+/// `error sending request for url (...)` and drops the cause that actually
+/// explains it -- connection reset, TLS failure, DNS failure -- leaving the
+/// operator nothing to act on. Walking the chain keeps that detail.
+///
+/// `greentic-distributor-client` carries an identical helper next to the retry
+/// policy that produces these errors. It is duplicated rather than imported
+/// because this crate depends on that one through a published version range,
+/// so sharing it would gate every `gtc` change on a distributor-client release.
+pub fn error_chain(error: &dyn StdError) -> String {
+    let mut rendered = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        let text = cause.to_string();
+        // `#[error(transparent)]` wrappers repeat their source verbatim; the
+        // duplicate would only make the line harder to read.
+        if !rendered.ends_with(&text) {
+            rendered.push_str(": ");
+            rendered.push_str(&text);
+        }
+        source = cause.source();
+    }
+    rendered
+}
 
 #[derive(Debug, Error)]
 pub enum GtcError {
@@ -74,7 +103,9 @@ impl GtcError {
 
 #[cfg(test)]
 mod tests {
-    use super::GtcError;
+    use std::io::ErrorKind;
+
+    use super::{GtcError, error_chain};
 
     #[test]
     fn message_variant_preserves_text() {
@@ -86,5 +117,53 @@ mod tests {
     fn invalid_data_variant_includes_context() {
         let err = GtcError::invalid_data("index.json", "root must be an object");
         assert_eq!(err.to_string(), "index.json: root must be an object");
+    }
+
+    #[test]
+    fn error_chain_appends_every_cause() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("oci pack error")]
+        struct Middle {
+            #[source]
+            source: std::io::Error,
+        }
+
+        #[derive(Debug, thiserror::Error)]
+        #[error("failed to pull `ghcr.io/example:1.0.0`")]
+        struct Outer {
+            #[source]
+            source: Middle,
+        }
+
+        let rendered = error_chain(&Outer {
+            source: Middle {
+                source: std::io::Error::new(ErrorKind::ConnectionReset, "connection reset by peer"),
+            },
+        });
+        assert_eq!(
+            rendered,
+            "failed to pull `ghcr.io/example:1.0.0`: oci pack error: connection reset by peer"
+        );
+    }
+
+    #[test]
+    fn error_chain_does_not_repeat_transparent_wrappers() {
+        #[derive(Debug, thiserror::Error)]
+        #[error(transparent)]
+        struct Transparent {
+            #[from]
+            source: std::io::Error,
+        }
+
+        let rendered = error_chain(&Transparent {
+            source: std::io::Error::new(ErrorKind::ConnectionReset, "connection reset by peer"),
+        });
+        assert_eq!(rendered, "connection reset by peer");
+    }
+
+    #[test]
+    fn error_chain_of_a_sourceless_error_is_just_its_message() {
+        let err = GtcError::message("plain error");
+        assert_eq!(error_chain(&err), "plain error");
     }
 }


### PR DESCRIPTION
## Why

When `greentic-perf` nightly [run 30880759525](https://github.com/greenticai/greentic-perf/actions/runs/30880759525) failed on a dropped ghcr.io connection, this is everything the operator got:

```
failed to prefetch ghcr.io/greenticai/packs/dw/control/basic-policy-pack:0.5.8:
  oci pack error: failed to pull `...`: error sending request for url (https://ghcr.io/...)
```

`error sending request for url` is reqwest's outermost message. The cause that identifies the failure — connection reset, TLS failure, DNS failure — sits in the `source` chain and was never rendered, so a transport blip could not be told apart from a rate limit or a genuinely missing artifact. Diagnosing it needed comparing against a sibling job's log.

The cause is that errors reaching `GtcError::Message` are flattened with `{err}`, which prints only the outermost message and discards the chain.

## What

`error_chain()` in `gtc::error`, applied to:

- the release prefetch path — `parse`, `resolve`, `fetch`, `prefetch`, and the top-level report at `toolchain.rs:315`
- the GHCR artifact and auth-token fetches, which flatten `reqwest::Error` the same way

## Reuse note

`greentic-distributor-client` is gaining an identical helper next to the retry policy that produces these errors (greenticai/greentic-distributor-client#222). It is **duplicated rather than imported** because this crate depends on that one through a published version range (`>=1.2.0-dev, <1.3.0-0`) — sharing it would gate every `gtc` change on a distributor-client release. Flagging explicitly given the reuse-first policy; happy to converge once the release train settles if reviewers prefer.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-targets --all-features` — **590 passed, 0 failed** (35 + 488 + 63 + 1 + 3)
- **Mutation-checked:** stubbing `error_chain` to `error.to_string()` fails `error_chain_appends_every_cause`. The test discriminates.

### Pre-existing failure, outside this change

`bash ci/local_check.sh` fails at step **[1/6] schema docs sync** before reaching fmt/clippy/test:

```
updated: docs/04-schemas/wizard-schema.json
comm: file 1 is not in sorted order
```

I confirmed this is pre-existing by stashing this branch's changes and re-running on a clean `develop` — identical failure. It regenerates `docs/04-schemas/wizard-schema.json` and then aborts, so the later gates never run; I ran fmt, clippy and test directly instead. Not fixed here as it is unrelated to this change, but it means `local_check.sh` currently gates nothing in this repo and is probably worth a separate issue.