### PR TITLE
fix(install): make --dry-run describe the tenant hand-off

### DIFF
--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -56,12 +56,6 @@ pub(super) fn run_install(
         if toolchain_status != 0 {
             return toolchain_status;
         }
-        if dry_run {
-            return 0;
-        }
-    }
-    if dry_run {
-        return 0;
     }
 
     let tenant = sub_matches
@@ -78,6 +72,20 @@ pub(super) fn run_install(
     };
 
     if !phases.tenant {
+        return 0;
+    }
+
+    // A dry run used to `return 0` above, BEFORE this block — so `--dry-run`
+    // reported success while exercising none of the tenant path, and
+    // `--install-tenant-only --dry-run` printed nothing whatsoever. Anyone
+    // validating a tenant manifest that way concluded it was fine. Describe the
+    // hand-off instead; the key is deliberately not resolved or printed.
+    if dry_run {
+        println!(
+            "Dry run: would install tenant-authorized artifacts for `{tenant}` via `{DEV_BIN} \
+             install --tenant {tenant} --token env:{}`",
+            tenant_env_var_name(&tenant)
+        );
         return 0;
     }
 


### PR DESCRIPTION
## The bug

`run_install` returned `0` before the tenant block:

```rust
if dry_run { return 0; }      // ← inside the phases branch
}
if dry_run { return 0; }      // ← and again here

let tenant = sub_matches.get_one::<String>("tenant") …   // never reached
```

So `--dry-run` reported success while exercising none of the tenant path, and `--install-tenant-only --dry-run` printed **nothing at all**:

```
$ gtc install --tenant 3point --key … --install-tenant-only --dry-run
$ echo $?
0
```

Anyone validating a tenant manifest that way concluded it was fine. In the case that prompted this, the manifest's designer entry pointed at a release asset that did not exist — a hard error at install time, and `--dry-run` said nothing.

## The change

Resolve the tenant first, then describe the hand-off instead of returning early. The plan line names the delegate binary and the env var it passes; the key is deliberately never resolved or printed.

```
Dry run: would install tenant-authorized artifacts for `3point` via
`greentic-dev install --tenant 3point --token env:GREENTIC_TENANT_KEY_3POINT`
```

Non-dry-run behaviour is unchanged, and `--dry-run` with no `--tenant` still returns 0 after the toolchain plan exactly as before.

## Verification

`rustfmt --edition 2024 --check` clean against the repo's `rustfmt.toml`. Clippy and tests left to CI.
