### PR TITLE
fix(lock): record the semver edge #319 added to gtc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "rcgen",
  "reqwest 0.13.4",
  "rpassword",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_bw",


### PR DESCRIPTION
#319 made `semver` a direct dependency of `gtc` and I did not update `Cargo.lock`. My mistake.

PR CI does not pass `--locked`, so it went green. `dev-publish` builds with `cargo build --release --locked`, and **all five targets failed**:

```
error: cannot update the lock file … because --locked was passed to prevent this
```

No gtc dev release was produced for that merge — the newest is still the one from before it.

`semver 1.0.28` was already in the tree transitively, so this adds the dependency edge to the `gtc` package and changes nothing else.

## Worth a separate look

A lockfile drift is **invisible to PR CI here** and only surfaces at publish, where it takes the entire release with it. Adding `--locked` to the CI build (or a `cargo metadata --locked` check) would move that failure to the PR, where it is cheap. Not done here — it is a CI policy change, not a fix for this break.