### PR TITLE
feat(install): actually install a tenant's store_assets

### DIFF
--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -133,6 +133,9 @@ pub(super) fn run_install(
 
     let env_name = tenant_env_var_name(&tenant);
     let mut child_env = ChildProcessEnv::new();
+    // The delegate takes the key by env indirection; the store step below needs
+    // it too, and it is never written anywhere or printed.
+    let store_key = key.clone();
     child_env.set(env_name.clone(), key);
 
     let tenant_args = vec![
@@ -142,7 +145,34 @@ pub(super) fn run_install(
         "--token".to_string(),
         format!("env:{env_name}"),
     ];
-    let tenant_status = passthrough_with_env(DEV_BIN, &tenant_args, debug, locale, &child_env);
+    let mut tenant_status = passthrough_with_env(DEV_BIN, &tenant_args, debug, locale, &child_env);
+
+    // `store_assets` are the one part of a tenant manifest the delegate does not
+    // install: greentic-dev has no distributor client for them, so it reports
+    // them and moves on. gtc does have one — this whole path already existed
+    // here and had simply become unreachable when the tenant phase was handed
+    // over. Running it after the delegate keeps one owner per artifact kind
+    // rather than teaching the delegate a second way to fetch things.
+    //
+    // Only attempted when the delegate succeeded: a failed tools install is not
+    // a state worth adding store artifacts to.
+    if tenant_status == 0 {
+        match install_tenant_store_assets(&tenant, &store_key, locale) {
+            Ok(installed) if installed.is_empty() => {}
+            Ok(installed) => {
+                println!("Installed store assets:");
+                for path in installed {
+                    println!("- {}", path.display());
+                }
+            }
+            Err(err) => {
+                // The tools are already on disk and are not undone by this. Say
+                // so plainly and let the exit code carry the failure.
+                eprintln!("error: store assets could not be installed: {err}");
+                tenant_status = 1;
+            }
+        }
+    }
 
     // The tenant failure is the more actionable of the two, so it wins the exit
     // code; a toolchain failure still surfaces when the tenant phase succeeded.
@@ -1060,7 +1090,15 @@ fn resolve_tenant_manifest_url(tenant: &str, key: &str, locale: &str) -> GtcResu
     if let Some(template) = GtcConfig::from_env().tenant_manifest_url_template() {
         return Ok(template.replace("{tenant}", tenant));
     }
-    let release = fetch_github_release("greentic-biz", "customers-tools", "latest", key, locale)?;
+    // `/releases/tags/latest`, NOT `/releases/latest`. They are different
+    // releases: the rolling `latest` TAG is force-moved on every main push and
+    // is a prerelease, while GitHub's "latest release" resolves to the newest
+    // non-prerelease (`v0.2.0` today). greentic-dev — which installs the tools
+    // from this same manifest — reads the rolling tag, so reading anything else
+    // here risks taking a tenant's store assets from a different manifest than
+    // its tools.
+    let release =
+        fetch_github_release_by_tag("greentic-biz", "customers-tools", "latest", key, locale)?;
     let asset_name = format!("{tenant}.json");
     release
         .assets
@@ -1112,6 +1150,24 @@ fn resolve_github_release_asset_api_url(
         .into_iter()
         .find(|asset| asset.name == asset_name)
         .map(|asset| asset.url))
+}
+
+/// Always `/releases/tags/{tag}` — never GitHub's "latest release" shortcut.
+///
+/// `fetch_github_release` special-cases the literal tag `latest` into
+/// `/releases/latest`, which is a different thing entirely when a repository
+/// also has a rolling tag NAMED `latest`.
+fn fetch_github_release_by_tag(
+    owner: &str,
+    repo: &str,
+    tag: &str,
+    key: &str,
+    locale: &str,
+) -> GtcResult<GithubRelease> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}");
+    let bytes = fetch_https_json_or_file_bytes(&url, key, locale)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| GtcError::json(format!("failed to parse release metadata from {url}"), e))
 }
 
 fn fetch_github_release(
@@ -1383,6 +1439,48 @@ pub(super) fn expand_into_target(source_dir: &Path, target_dir: &Path) -> GtcRes
     }
 
     Ok(())
+}
+
+/// Install every `store_assets` entry a tenant manifest declares.
+///
+/// Returns the paths written, empty when the tenant declares none.
+fn install_tenant_store_assets(tenant: &str, key: &str, locale: &str) -> GtcResult<Vec<PathBuf>> {
+    let manifest_url = resolve_tenant_manifest_url(tenant, key, locale)?;
+    // The URL is a release ASSET, so it must be fetched as octet-stream.
+    // `fetch_json_with_auth` sends `Accept: application/vnd.github+json`, which
+    // GitHub answers with the asset's METADATA — a clean JSON body that then
+    // fails to parse as a manifest, for a reason the error would not name.
+    let bytes = fetch_asset_bytes(&manifest_url, key, locale)?;
+    let manifest: TenantInstallManifest = serde_json::from_slice(&bytes).map_err(|e| {
+        GtcError::json(
+            format!("failed to parse the tenant manifest from {manifest_url}"),
+            e,
+        )
+    })?;
+    if manifest.tenant != tenant {
+        return Err(GtcError::invalid_data(
+            "tenant manifest",
+            format!(
+                "requested `{tenant}` but the manifest declares `{}`",
+                manifest.tenant
+            ),
+        ));
+    }
+    if manifest.store_assets.is_empty() {
+        return Ok(Vec::new());
+    }
+    let artifacts_root = resolve_artifacts_root()?;
+    let mut installed = Vec::new();
+    for asset in &manifest.store_assets {
+        installed.extend(install_store_asset_reference(
+            asset,
+            tenant,
+            key,
+            &artifacts_root,
+            locale,
+        )?);
+    }
+    Ok(installed)
 }
 
 fn resolve_artifacts_root() -> GtcResult<PathBuf> {

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -158,20 +158,34 @@ pub(super) fn run_install(
     // Only attempted when the delegate succeeded: a failed tools install is not
     // a state worth adding store artifacts to.
     if tenant_status == 0 {
-        match install_tenant_store_assets(&tenant, &store_key, locale) {
-            Ok(installed) if installed.is_empty() => {}
-            Ok(installed) => {
-                println!("Installed store assets:");
-                for path in installed {
-                    println!("- {}", path.display());
-                }
-            }
+        // Two failures, two meanings, and collapsing them was wrong.
+        //
+        // Failing to READ the manifest means we do not know whether this tenant
+        // declares any store assets — so it cannot be reported as "they failed
+        // to install". The tools are on disk and correct; warn and leave the
+        // exit code alone. Doing otherwise made an offline or unauthorized
+        // lookup fail an install that had entirely succeeded.
+        //
+        // Failing to PULL an asset the manifest DOES declare is a real failure
+        // of a declared entitlement, and carries the exit code.
+        match resolve_tenant_store_assets(&tenant, &store_key, locale) {
             Err(err) => {
-                // The tools are already on disk and are not undone by this. Say
-                // so plainly and let the exit code carry the failure.
-                eprintln!("error: store assets could not be installed: {err}");
-                tenant_status = 1;
+                eprintln!("warning: could not check {tenant}'s store assets: {err}");
             }
+            Ok(assets) if assets.is_empty() => {}
+            Ok(assets) => match install_resolved_store_assets(&assets, &tenant, &store_key, locale)
+            {
+                Ok(installed) => {
+                    println!("Installed store assets:");
+                    for path in installed {
+                        println!("- {}", path.display());
+                    }
+                }
+                Err(err) => {
+                    eprintln!("error: store assets could not be installed: {err}");
+                    tenant_status = 1;
+                }
+            },
         }
     }
 
@@ -1442,10 +1456,15 @@ pub(super) fn expand_into_target(source_dir: &Path, target_dir: &Path) -> GtcRes
     Ok(())
 }
 
-/// Install every `store_assets` entry a tenant manifest declares.
+/// The `store_assets` a tenant manifest declares, if it can be read.
 ///
-/// Returns the paths written, empty when the tenant declares none.
-fn install_tenant_store_assets(tenant: &str, key: &str, locale: &str) -> GtcResult<Vec<PathBuf>> {
+/// An error here means the manifest could not be READ — never that a tenant has
+/// none. Those are different answers and the caller treats them differently.
+fn resolve_tenant_store_assets(
+    tenant: &str,
+    key: &str,
+    locale: &str,
+) -> GtcResult<Vec<TenantManifestReference>> {
     let manifest_url = resolve_tenant_manifest_url(tenant, key, locale)?;
     // The URL is a release ASSET, so it must be fetched as octet-stream.
     // `fetch_json_with_auth` sends `Accept: application/vnd.github+json`, which
@@ -1467,12 +1486,20 @@ fn install_tenant_store_assets(tenant: &str, key: &str, locale: &str) -> GtcResu
             ),
         ));
     }
-    if manifest.store_assets.is_empty() {
-        return Ok(Vec::new());
-    }
+    Ok(manifest.store_assets)
+}
+
+/// Pull every declared store asset. A failure here is a declared entitlement
+/// that did not install.
+fn install_resolved_store_assets(
+    assets: &[TenantManifestReference],
+    tenant: &str,
+    key: &str,
+    locale: &str,
+) -> GtcResult<Vec<PathBuf>> {
     let artifacts_root = resolve_artifacts_root()?;
     let mut installed = Vec::new();
-    for asset in &manifest.store_assets {
+    for asset in assets {
         installed.extend(install_store_asset_reference(
             asset,
             tenant,

--- a/src/bin/gtc/install.rs
+++ b/src/bin/gtc/install.rs
@@ -141,7 +141,8 @@ pub(super) fn run_install(
     let tenant_args = vec![
         "install".to_string(),
         "--tenant".to_string(),
-        tenant,
+        // Cloned: the store-asset step below needs the tenant too.
+        tenant.clone(),
         "--token".to_string(),
         format!("env:{env_name}"),
     ];


### PR DESCRIPTION
Closes the last functional gap in the tenant install: **`store_assets` were never installed by anything.**

Every tenant manifest declares them — `3point` has two (`greentic-chat2data-store`, `telco-x-store`) — and until recently they vanished with no message at all. greentic-dev now reports them, but it has no distributor client for `store://` refs, so it still skips them.

gtc has the entire path already: fetch the manifest, rewrite the `{tenant}` placeholder, pull each item through `DistClient`, write it under `~/.greentic/artifacts` sorted by kind (`packs/`, `bundles/`, `components/`). The `dist-client` feature is already enabled. It had simply become **unreachable** when the tenant phase was handed to the delegate — the file is headed `#![allow(dead_code)]` for exactly this reason.

This runs it after the delegate returns, keeping one owner per artifact kind rather than teaching greentic-dev a second way to fetch things. Only when the delegate succeeded: a failed tools install is not a state worth adding store artifacts to. A failure here does not undo the tools — it is reported and carried in the exit code.

```
store://greentic-biz/{tenant}/components/greentic-chat2data
store://greentic-biz/3point/catalogs/telco-x:latest
store://greentic-biz/3point/bundles/telco-x-bundle:latest
```

## Two bugs found while wiring it

Both would have made this fail in ways the error text would not have explained.

**The manifest URL is a release asset.** `fetch_json_with_auth` sends `Accept: application/vnd.github+json`; GitHub answers an asset API URL with the asset's *metadata* — valid JSON that then fails to parse as a manifest. Verified against the live endpoint:

```
GET .../releases/assets/525955831   Accept: application/vnd.github+json
{ "url": "...", "id": 525955831, ...        ← metadata, not the manifest
```

It has to be fetched as `application/octet-stream`.

**`resolve_tenant_manifest_url` read a different release than the delegate.**

```
gtc           /releases/latest        → v0.2.0   prerelease: false
greentic-dev  /releases/tags/latest   → latest   prerelease: true
```

Those are two different releases. The rolling `latest` **tag** is force-moved on every push to main; GitHub's "latest release" means the newest non-prerelease. Their bytes agree today, which is precisely why it is worth correcting now rather than after they drift and a tenant's store assets come from a different manifest than its tools. `fetch_github_release` special-cases the literal tag `latest` into `/releases/latest`, so this adds a by-tag fetch and leaves the other caller alone.

## Verification

`rustfmt --edition 2024 --check` clean. The metadata-vs-content behaviour was confirmed against the live GitHub API rather than assumed. Clippy and the suite left to CI; an end-to-end run needs a tenant key, so the install itself is verified after merge.
