### PR TITLE
ci: fail the PR when Cargo.lock is out of sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,24 @@ concurrency:
 jobs:
   ci:
     uses: greenticai/.github/.github/workflows/host-crate-ci.yml@main
+
+  # `Cargo.lock` drift is invisible to the shared CI above, which does not pass
+  # `--locked`. dev-publish does — so a missing lock entry goes green through
+  # review, merges, and then fails every target of the release build:
+  #
+  #   error: cannot update the lock file ... because --locked was passed
+  #
+  # That failure arrives after the merge, where it looks like a publish problem
+  # rather than the PR's, and leaves reviewed work unreleased with nothing red.
+  # Checking it here costs seconds and moves the failure to the PR that caused
+  # it. Deliberately repo-local: the shared workflow is org-wide, and turning
+  # `--locked` on there would redden every repo whose lock has already drifted.
+  lockfile:
+    name: Cargo.lock is in sync
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify the lockfile needs no update
+        run: cargo metadata --locked --format-version 1 > /dev/null


### PR DESCRIPTION
A lockfile drift is currently **invisible to PR CI here and only surfaces at publish**, where it takes the whole release with it.

That is not hypothetical — it happened earlier today. #319 made `semver` a direct dependency without the lock entry. PR CI was green (the shared workflow does not pass `--locked`), it merged, and `dev-publish` then failed **all five targets**:

```
error: cannot update the lock file … because --locked was passed to prevent this
```

The shape is the dangerous part: the failure lands *after* the merge, where it reads as a publish problem rather than as the PR's, and reviewed work sits unreleased with nothing red anywhere. It needed a second PR (#320) to unstick.

`cargo metadata --locked` costs seconds and moves that failure to the PR that caused it.

**Deliberately repo-local.** The obvious fix is `--locked` in `host-crate-ci.yml`, but that workflow is org-wide: turning it on there would redden every repo whose lock has already drifted, all at once. That is a rollout decision, not a fix for this break — worth doing, worth doing on purpose.