### PR TITLE
feat(platform): route `gtc platform` to greentic-deploy-platform

### DIFF
--- a/docs/00-start-here.md
+++ b/docs/00-start-here.md
@@ -94,6 +94,8 @@ Start with these repo-local docs:
   Canonical install entrypoint, release channels, and stable OCI reference guidance.
 - [`docs/02-cli/greentic-flow.md`](./02-cli/greentic-flow.md)
   Repo-local guidance for using `greentic-flow component-schema` before wiring steps.
+- [`docs/02-cli/gtc-platform.md`](./02-cli/gtc-platform.md)
+  Canonical `gtc platform` routing boundary and how to obtain its companion binary.
 - [`docs/03-authoring/happy-path-build-an-app.md`](./03-authoring/happy-path-build-an-app.md)
   Linear repo-local path from authoring into setup and start.
 - [`docs/03-authoring/answers-json-patterns.md`](./03-authoring/answers-json-patterns.md)

--- a/docs/02-cli/gtc-platform.md
+++ b/docs/02-cli/gtc-platform.md
@@ -1,0 +1,72 @@
+Status: Canonical in this repo
+Scope: Repo-owned `gtc platform` command surface and its ownership boundary
+Implementation owner: `gtc` for the routing only; `greentic-deploy-platform` for every verb, flag and default
+
+# `gtc platform`
+
+Installs the Greentic platform itself — the admin, the designer, the
+tenant-manager, the edge and the datastore they share.
+
+It is deliberately **not** under `gtc deploy`. That group is about a bundle
+reaching an environment that already exists; this is about bringing the
+environment into being. The two share a verb in English and nothing in
+implementation, and nesting one inside the other made `gtc deploy` mean two
+unrelated things.
+
+## What this repo owns
+
+Routing, and nothing more. `gtc` resolves `platform` to the companion binary
+`greentic-deploy-platform` and forwards everything after it **verbatim** — no
+token added, none removed — so the string the operator typed is the string that
+binary parses. Its usage and error lines name `gtc platform ...`, which is the
+only form anyone is told to run.
+
+The subcommand declares no flags of its own. Every verb, option and default
+lives in `greentic-deploy-platform`; mirroring them here would be a second copy
+that goes stale the first time that binary adds a flag. A flag this router has
+never heard of is forwarded rather than rejected — whether it means anything is
+the companion's question to answer.
+
+## Getting the binary
+
+`greentic-deploy-platform` is **not** part of the toolchain `gtc install`
+places, and `gtc doctor` does not probe for it — a machine that never installs
+the platform has no reason to carry it, and failing doctor over an absent one
+would train operators to ignore the check.
+
+It is released as a single binary from the greentic-deploy-platform repository.
+Put it anywhere `gtc` looks — `~/.cargo/bin`, or beside `gtc` itself — and the
+subcommand starts working. For a local build, point `gtc` straight at it:
+
+```bash
+export GREENTIC_PLATFORM_BIN="/path/to/target/debug/greentic-deploy-platform"
+```
+
+When it is missing, `gtc platform` says so by name and repeats both of those
+options rather than reporting a generic exec failure.
+
+## Verbs
+
+The pipeline, in order; each stage writes what the next reads.
+
+```
+init  →  render  →  [bundle]  →  apply  →  bootstrap  →  verify
+```
+
+`apply` is aliased `deploy`. `destroy` uninstalls, and `openapi` writes the
+deploy-facing OpenAPI document.
+
+The install target — Kubernetes or AWS ECS — is chosen once, at `init`, and
+recorded in `platform.yaml`:
+
+```bash
+gtc platform init --target aws-ecs --region ap-southeast-1
+gtc platform deploy
+```
+
+No later verb takes `--target`; every one of them reads it from the spec. On the
+AWS target there is nothing to `render` or `bundle` and both refuse it: it
+creates AWS resources directly, and Fargate cannot side-load an image.
+
+Run `gtc platform --help` for the current list — it is answered by the companion
+binary, so it cannot drift from what is actually installed.

--- a/docs/02-cli/gtc-platform.md
+++ b/docs/02-cli/gtc-platform.md
@@ -45,6 +45,17 @@ export GREENTIC_PLATFORM_BIN="/path/to/target/debug/greentic-deploy-platform"
 When it is missing, `gtc platform` says so by name and repeats both of those
 options rather than reporting a generic exec failure.
 
+### The dev channel
+
+`gtc-dev` looks for `greentic-deploy-platform-dev`, not
+`greentic-deploy-platform` — the launcher's suffix propagates to every companion,
+which is what keeps a dev toolchain from silently reaching for stable tools. The
+release attaches both names for that reason; installing only the unsuffixed one
+leaves `gtc-dev platform` unable to find anything.
+
+The missing-binary message names whichever one was actually looked for, and says
+so explicitly when the two differ.
+
 ## Verbs
 
 The pipeline, in order; each stage writes what the next reads.

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,11 @@ recognizes directly through `GtcConfig`.
   Override the `greentic-deployer` binary path.
 - `GREENTIC_SETUP_BIN`
   Override the `greentic-setup` binary path.
+- `GREENTIC_PLATFORM_BIN`
+  Override the `greentic-deploy-platform` binary path — the companion behind
+  `gtc platform`. Unlike the others it is not installed by `gtc install`; it
+  ships as a release binary of the greentic-deploy-platform repository, so this
+  is how you point `gtc` at a local build of it.
 
 Cloud-provider credentials and generic process environment values such as `PATH`
 are intentionally not listed here. They are still supported, but they are treated

--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -111,6 +111,10 @@ const DEV_BIN: &str = "greentic-dev";
 const OP_BIN: &str = "greentic-operator";
 const BUNDLE_BIN: &str = "greentic-bundle";
 const DEPLOYER_BIN: &str = "greentic-deployer";
+/// Installs the Greentic platform itself — admin, designer, tenant-manager,
+/// edge and their datastore. Distinct from DEPLOYER_BIN, which deploys a
+/// bundle onto a platform that already exists.
+const PLATFORM_BIN: &str = "greentic-deploy-platform";
 const SETUP_BIN: &str = "greentic-setup";
 const START_BIN: &str = "greentic-start";
 const COMPONENT_BIN: &str = "greentic-component";

--- a/src/bin/gtc/cli.rs
+++ b/src/bin/gtc/cli.rs
@@ -1063,7 +1063,7 @@ pub(super) fn build_cli(locale: &str) -> Command {
                     "gtc.cmd.provider.about",
                     "Manage messaging providers (passthrough to greentic-setup).",
                 ))
-                .arg(cmd_args),
+                .arg(cmd_args.clone()),
         )
         .subcommand(
             Command::new("deploy")
@@ -1113,6 +1113,23 @@ pub(super) fn build_cli(locale: &str) -> Command {
                                 .help(t(locale, "gtc.arg.upload_bundle_presign_expires.help").into_owned()),
                         ),
                 ),
+        )
+        .subcommand(
+            // Declared with no flags of its own on purpose. Every verb, option
+            // and default belongs to greentic-deploy-platform, and mirroring
+            // them here would be a second copy that goes stale the first time
+            // that binary adds a flag.
+            Command::new("platform")
+                .help_template(help_template)
+                .subcommand_help_heading(commands_heading)
+                .disable_help_flag(true)
+                .disable_version_flag(true)
+                .about(t_or(
+                    locale,
+                    "gtc.cmd.platform.about",
+                    "Install the Greentic platform: admin, designer, tenant-manager, edge and their datastore.",
+                ))
+                .arg(cmd_args),
         )
         .subcommand(
             Command::new("help")

--- a/src/bin/gtc/commands.rs
+++ b/src/bin/gtc/commands.rs
@@ -157,7 +157,10 @@ pub(super) fn run(raw_args: Vec<String>) -> i32 {
                 2
             }
         },
-        Some((name @ ("dev" | "op" | "wizard" | "setup" | "worker" | "provider"), sub_matches)) => {
+        Some((
+            name @ ("dev" | "op" | "wizard" | "setup" | "worker" | "provider" | "platform"),
+            sub_matches,
+        )) => {
             let tail = collect_tail(sub_matches);
             let tail = if matches!(name, "wizard" | "setup") {
                 let release_context =

--- a/src/bin/gtc/process.rs
+++ b/src/bin/gtc/process.rs
@@ -13,7 +13,7 @@ use super::toolchain::{
 };
 use super::{
     BUNDLE_BIN, COMPONENT_BIN, DEPLOYER_BIN, DEV_BIN, DW_BIN, FLOW_BIN, OP_BIN, PACK_BIN,
-    RUNNER_BIN, SECRETS_BIN, SETUP_BIN, START_BIN,
+    PLATFORM_BIN, RUNNER_BIN, SECRETS_BIN, SETUP_BIN, START_BIN,
 };
 use crate::i18n_support::{t, t_or, tf_or};
 use crate::min_versions::{self, VersionVerdict};
@@ -205,6 +205,7 @@ fn passthrough_in_dir_with_env(
                     DEV_BIN => print_missing_dev_message(locale),
                     OP_BIN => print_missing_op_message(locale),
                     SETUP_BIN => eprintln!("{}", t(locale, "gtc.err.bin_missing_setup")),
+                    PLATFORM_BIN => print_missing_platform_message(locale),
                     _ => eprintln!("{}", t(locale, "gtc.err.exec_failed")),
                 }
             } else {
@@ -625,6 +626,23 @@ fn print_missing_op_message(locale: &str) {
     );
 }
 
+/// `greentic-deploy-platform` is not part of the installed toolchain set, so a
+/// missing one is a normal state rather than a broken install. Saying where it
+/// comes from is the whole message: the generic "exec failed" line names a
+/// binary the operator has never heard of and gives them nothing to act on.
+fn print_missing_platform_message(locale: &str) {
+    eprintln!(
+        "{}",
+        t_or(
+            locale,
+            "gtc.err.bin_missing_platform",
+            "greentic-deploy-platform not found. It is released from the \
+             greentic-deploy-platform repository as a single binary: copy it next to gtc (or \
+             into ~/.cargo/bin), or point GREENTIC_PLATFORM_BIN at a local build.",
+        )
+    );
+}
+
 fn resolve_binary_command(binary: &str) -> String {
     let invocation = env::args().next();
     let command = if let Some(path) = resolve_companion_binary_from_parts(
@@ -745,6 +763,7 @@ fn is_greentic_companion_binary(binary: &str) -> bool {
             | BUNDLE_BIN
             | COMPONENT_BIN
             | DEPLOYER_BIN
+            | PLATFORM_BIN
             | FLOW_BIN
             | PACK_BIN
             | RUNNER_BIN
@@ -808,6 +827,7 @@ fn companion_binary_env_override(binary: &str) -> Option<std::ffi::OsString> {
         BUNDLE_BIN => cfg.bundle_bin_override(),
         COMPONENT_BIN => cfg.component_bin_override(),
         DEPLOYER_BIN => cfg.deployer_bin_override(),
+        PLATFORM_BIN => cfg.platform_bin_override(),
         FLOW_BIN => cfg.flow_bin_override(),
         PACK_BIN => cfg.pack_bin_override(),
         RUNNER_BIN => cfg.runner_bin_override(),

--- a/src/bin/gtc/process.rs
+++ b/src/bin/gtc/process.rs
@@ -205,7 +205,7 @@ fn passthrough_in_dir_with_env(
                     DEV_BIN => print_missing_dev_message(locale),
                     OP_BIN => print_missing_op_message(locale),
                     SETUP_BIN => eprintln!("{}", t(locale, "gtc.err.bin_missing_setup")),
-                    PLATFORM_BIN => print_missing_platform_message(locale),
+                    PLATFORM_BIN => print_missing_platform_message(locale, &command),
                     _ => eprintln!("{}", t(locale, "gtc.err.exec_failed")),
                 }
             } else {
@@ -630,17 +630,40 @@ fn print_missing_op_message(locale: &str) {
 /// missing one is a normal state rather than a broken install. Saying where it
 /// comes from is the whole message: the generic "exec failed" line names a
 /// binary the operator has never heard of and gives them nothing to act on.
-fn print_missing_platform_message(locale: &str) {
+///
+/// `sought` is the name that was actually looked for, not the logical constant.
+/// Under `gtc-dev` those differ — the launcher's `-dev` suffix propagates to
+/// every companion — and naming the constant there would tell the operator to
+/// install the one file that cannot satisfy the lookup.
+fn print_missing_platform_message(locale: &str, sought: &str) {
+    let sought = Path::new(sought)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(sought);
     eprintln!(
         "{}",
-        t_or(
+        tf_or(
             locale,
             "gtc.err.bin_missing_platform",
-            "greentic-deploy-platform not found. It is released from the \
-             greentic-deploy-platform repository as a single binary: copy it next to gtc (or \
-             into ~/.cargo/bin), or point GREENTIC_PLATFORM_BIN at a local build.",
+            "{binary} not found. It is released from the greentic-deploy-platform repository: \
+             copy it next to gtc (or into ~/.cargo/bin), or point GREENTIC_PLATFORM_BIN at a \
+             local build.",
+            &[("binary", sought)],
         )
     );
+    if sought.ends_with("-dev") {
+        eprintln!(
+            "{}",
+            tf_or(
+                locale,
+                "gtc.err.bin_missing_platform_dev",
+                "This launcher is gtc-dev, so it looked for the dev-channel build \
+                 ({binary}) and not greentic-deploy-platform. The release attaches both \
+                 names; installing only the unsuffixed one leaves gtc-dev unable to find it.",
+                &[("binary", sought)],
+            )
+        );
+    }
 }
 
 fn resolve_binary_command(binary: &str) -> String {

--- a/src/bin/gtc/router.rs
+++ b/src/bin/gtc/router.rs
@@ -5,7 +5,7 @@ use gtc::perf_targets::{
     rewrite_legacy_op_args as perf_rewrite_legacy_op_args,
 };
 
-use super::{DEV_BIN, DW_BIN, OP_BIN, SETUP_BIN};
+use super::{DEV_BIN, DW_BIN, OP_BIN, PLATFORM_BIN, SETUP_BIN};
 use crate::extensions::has_extension_flags;
 use crate::i18n_support::i18n;
 
@@ -68,6 +68,13 @@ pub(super) fn route_passthrough_subcommand(
         "wizard" => Some((DEV_BIN, build_wizard_args(tail, locale))),
         "worker" => Some((DW_BIN, build_worker_args(tail))),
         "provider" => Some((SETUP_BIN, build_provider_args(tail))),
+        // Verbatim, like `setup`: greentic-deploy-platform's own verbs are its
+        // top level, so there is no token to re-add. This entry is also what
+        // makes `gtc platform --help` reach the companion — the root's `--help`
+        // is a global arg, so a subcommand left to clap would have its help
+        // answered here instead, printing an empty `[args]...` list rather than
+        // the eight verbs the operator asked about.
+        "platform" => Some((PLATFORM_BIN, tail.to_vec())),
         _ => None,
     }
 }

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -1,11 +1,11 @@
 use super::{
-    AdminRegistryDocument, DEV_BIN, DW_BIN, FLOW_BIN, SETUP_BIN, StartTarget, admin_registry_path,
-    build_cli, build_wizard_args, collect_tail, default_install_channel_for_invocation,
-    detect_bundle_root, detect_locale, ensure_admin_certs_ready, extract_tar_archive,
-    fingerprint_bundle_dir, locale_from_args, normalize_bundle_fingerprint,
-    normalize_expected_sha256, normalize_install_arch, parse_prompt_choice,
-    parse_start_cli_options, parse_start_request, parse_stop_cli_options, parse_stop_request,
-    remove_admin_registry_entry, resolve_admin_cert_dir,
+    AdminRegistryDocument, DEV_BIN, DW_BIN, FLOW_BIN, PLATFORM_BIN, SETUP_BIN, StartTarget,
+    admin_registry_path, build_cli, build_wizard_args, collect_tail,
+    default_install_channel_for_invocation, detect_bundle_root, detect_locale,
+    ensure_admin_certs_ready, extract_tar_archive, fingerprint_bundle_dir, locale_from_args,
+    normalize_bundle_fingerprint, normalize_expected_sha256, normalize_install_arch,
+    parse_prompt_choice, parse_start_cli_options, parse_start_request, parse_stop_cli_options,
+    parse_stop_request, remove_admin_registry_entry, resolve_admin_cert_dir,
     resolve_canonical_target_provider_pack_from, resolve_companion_binary_from,
     resolve_companion_binary_from_invocation, resolve_deploy_app_pack_path,
     resolve_local_mutable_bundle_dir, resolve_target_provider_pack, resolve_tenant_key,
@@ -275,6 +275,98 @@ fn route_passthrough_subcommand_routes_provider_to_greentic_setup() {
             "telegram".to_string()
         ]
     );
+}
+
+#[test]
+fn route_passthrough_subcommand_routes_platform_to_the_platform_binary() {
+    let tail = vec![
+        "apply".to_string(),
+        "--kube-context".to_string(),
+        "prod".to_string(),
+    ];
+    let (binary, args) =
+        route_passthrough_subcommand("platform", &tail, "en").expect("platform route");
+
+    assert_eq!(binary, PLATFORM_BIN);
+    // Verbatim, unlike `worker`/`provider`: greentic-deploy-platform's verbs
+    // are its own top level, so there is no token to re-add. Prepending one
+    // would hand it a subcommand it does not have.
+    assert_eq!(args, tail);
+}
+
+#[test]
+fn platform_forwards_a_flag_the_router_has_never_heard_of() {
+    // The subcommand declares no flags of its own, so the router must not be
+    // the thing that rejects one. Whether --another-env means anything is the
+    // companion's question to answer, and it can only answer it if the flag
+    // arrives.
+    let tail = vec![
+        "deploy".to_string(),
+        "--target".to_string(),
+        "aws".to_string(),
+        "--another-env".to_string(),
+    ];
+    let (binary, args) =
+        route_passthrough_subcommand("platform", &tail, "en").expect("platform route");
+
+    assert_eq!(binary, PLATFORM_BIN);
+    assert_eq!(args, tail);
+}
+
+#[test]
+fn deploy_stays_in_process_and_does_not_route_out() {
+    // `gtc deploy refresh-bundle-url` is handled by gtc itself. `platform` used
+    // to live under `deploy`, and routing the group out would send every one of
+    // its verbs to a binary that has never heard of them.
+    let tail = vec![
+        "refresh-bundle-url".to_string(),
+        "acme.gtbundle".to_string(),
+    ];
+    assert!(route_passthrough_subcommand("deploy", &tail, "en").is_none());
+    assert!(route_passthrough_subcommand("deploy", &[], "en").is_none());
+}
+
+#[test]
+fn platform_takes_the_verb_line_verbatim() {
+    // The subcommand declares no flags of its own, so clap must hand every
+    // token through — including ones it would otherwise reject.
+    let matches = build_cli("en")
+        .try_get_matches_from([
+            "gtc",
+            "platform",
+            "init",
+            "--target",
+            "aws-ecs",
+            "--region",
+            "ap-southeast-1",
+        ])
+        .expect("platform parses");
+    let platform = matches.subcommand_matches("platform").expect("platform");
+
+    assert_eq!(
+        collect_tail(platform),
+        vec![
+            "init".to_string(),
+            "--target".to_string(),
+            "aws-ecs".to_string(),
+            "--region".to_string(),
+            "ap-southeast-1".to_string()
+        ]
+    );
+}
+
+#[test]
+fn resolve_companion_binary_uses_platform_env_override() {
+    let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    unsafe {
+        std::env::set_var("GREENTIC_PLATFORM_BIN", "/tmp/custom-deploy-platform");
+    }
+    let resolved =
+        resolve_companion_binary_from(Some(Path::new("/tmp/gtc")), PLATFORM_BIN).expect("path");
+    assert_eq!(resolved, PathBuf::from("/tmp/custom-deploy-platform"));
+    unsafe {
+        std::env::remove_var("GREENTIC_PLATFORM_BIN");
+    }
 }
 
 #[test]

--- a/src/bin/gtc/tests.rs
+++ b/src/bin/gtc/tests.rs
@@ -356,6 +356,28 @@ fn platform_takes_the_verb_line_verbatim() {
 }
 
 #[test]
+fn gtc_dev_looks_for_the_dev_build_of_the_platform_binary() {
+    // The launcher's `-dev` suffix propagates to every companion. If
+    // PLATFORM_BIN were left out of `is_greentic_companion_binary`, a developer
+    // running gtc-dev would silently get the STABLE wizard next to their dev
+    // toolchain — the one arrangement the suffix convention exists to prevent.
+    let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempdir().expect("tempdir");
+    let dev_build = dir.path().join("greentic-deploy-platform-dev");
+    fs::write(&dev_build, "").expect("write");
+    #[cfg(unix)]
+    fs::set_permissions(&dev_build, fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let resolved = resolve_companion_binary_from_invocation(
+        Some("gtc-dev"),
+        Some(dir.path().join("gtc-dev").as_path()),
+        PLATFORM_BIN,
+    )
+    .expect("gtc-dev must resolve the -dev build");
+    assert_eq!(resolved, dev_build);
+}
+
+#[test]
 fn resolve_companion_binary_uses_platform_env_override() {
     let _guard = env_test_lock().lock().unwrap_or_else(|e| e.into_inner());
     unsafe {

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,10 @@ impl GtcConfig {
         self.non_empty_var_os("GREENTIC_DEPLOYER_BIN")
     }
 
+    pub fn platform_bin_override(&self) -> Option<OsString> {
+        self.non_empty_var_os("GREENTIC_PLATFORM_BIN")
+    }
+
     pub fn flow_bin_override(&self) -> Option<OsString> {
         self.non_empty_var_os("GREENTIC_FLOW_BIN")
     }


### PR DESCRIPTION
## What

Routes `gtc platform <verb>` to the companion binary `greentic-deploy-platform` — the wizard that installs the Greentic platform itself: admin, designer, tenant-manager, edge and the datastore they share.

It had no way in. Its repo documented a `gtc` subcommand and shipped a binary **called `gtc`** to provide it, which meant installing the wizard replaced this CLI. Routing it here is what lets that binary go back to being a companion. (Paired with greentic-biz/greentic-deploy-platform#1, which does the rename on that side.)

## Why `platform` is top level, not under `deploy`

`gtc deploy` is about a bundle reaching an environment that already exists. This is about bringing the environment into being. They share a verb in English and nothing in implementation, and nesting one inside the other made `gtc deploy` mean two unrelated things.

Being top level also makes the forwarding **verbatim** — no token added, none removed — unlike `worker`/`provider`, which re-add a token because their companion nests the verbs one level down. `greentic-deploy-platform`'s verbs are its own top level.

## The router-table entry is not redundant with the clap subcommand

Easy to read as duplication; it is not. The root's `--help` is a **global** arg, so a subcommand left to clap has its help answered *here*. Without the `"platform"` arm in `route_passthrough_subcommand`, `gtc platform --help` prints this router's help for a subcommand that declares no flags of its own — an empty `[args]...` list instead of the eight verbs the operator asked about. `disable_help_flag(true)` does not save it; the global arg wins.

## No flags of its own, deliberately

Every verb, option and default belongs to `greentic-deploy-platform`. Mirroring them here would be a second copy that goes stale the first time that binary adds a flag. A flag this router has never heard of is **forwarded, not rejected** — whether it means anything is the companion's question to answer, and it can only answer it if the flag arrives. There is a test pinning that.

```
$ gtc --debug-router platform deploy --target aws --another-env
Router exec: greentic-deploy-platform ["deploy", "--target", "aws", "--another-env"]
```

## Deliberately NOT in `gtc doctor` or the toolchain manifest

This binary is released separately, and a machine that never installs the platform has no reason to carry it. `run_doctor` sets `failed = true` on a missing companion — so probing for it would turn a normal state into a red check for every existing user, and train operators to ignore the one signal that catches a real version skew. It also means no `MINIMUM_VERSIONS` row is owed.

A missing one is reported where it is *used* instead, by name, with both ways to supply it:

```
$ gtc platform init
greentic-deploy-platform not found. It is released from the greentic-deploy-platform
repository as a single binary: copy it next to gtc (or into ~/.cargo/bin), or point
GREENTIC_PLATFORM_BIN at a local build.
```

## Tests

```
cargo test    472 passed, 0 failed
cargo fmt --check    clean
cargo clippy --all-targets -- -D warnings    clean
```

Five new tests: the route and its verbatim forwarding, an unknown flag surviving the router, `deploy` **staying in-process** (routing that group out would send `refresh-bundle-url` to a binary that has never heard of it), the clap subcommand taking the verb line verbatim, and `GREENTIC_PLATFORM_BIN`.

## Docs

- `docs/02-cli/gtc-platform.md` — the routing boundary, and how to obtain the binary
- `docs/config.md` — `GREENTIC_PLATFORM_BIN`, flagged as the one override whose binary `gtc install` does not place
- `docs/00-start-here.md` — index entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8jrKYEmrCYYVigaqSp9sE
