### PR TITLE
feat(gtc install): install a toolchain package from the release archive its manifest names

### DIFF
--- a/src/bin/gtc.rs
+++ b/src/bin/gtc.rs
@@ -20,6 +20,8 @@ mod i18n_support;
 mod install;
 #[path = "gtc/min_versions.rs"]
 mod min_versions;
+#[path = "gtc/package_artifact.rs"]
+mod package_artifact;
 #[path = "gtc/process.rs"]
 mod process;
 #[path = "gtc/prompt.rs"]

--- a/src/bin/gtc/package_artifact.rs
+++ b/src/bin/gtc/package_artifact.rs
@@ -1,0 +1,497 @@
+//! Installing a toolchain package straight from a release archive the manifest
+//! names, instead of through `cargo binstall`.
+//!
+//! `cargo binstall` resolves every version through the crates.io index, so a
+//! toolchain manifest could only ever pin a version crates.io carries. That
+//! stopped being a safe assumption on 2026-09-08, when crates.io locked the
+//! account that publishes every Greentic crate: dev builds kept attaching their
+//! archives to GitHub releases, but none of them reached the index, and the dev
+//! channel froze on whatever it pinned the day before.
+//!
+//! A package that carries `artifacts` names, per target, the archive URL and its
+//! sha256 — the same shape the manifest's `gtc` field already uses for
+//! self-update, and for the same reason: a name the publisher states cannot
+//! drift from the name the publisher used. When the running target has an
+//! entry, the archive is fetched, verified, and exactly the package's `bins` are
+//! installed into the cargo bin directory `cargo binstall` would have used. A
+//! package without an entry for this target installs through `cargo binstall`
+//! exactly as before, so every manifest published so far keeps its meaning.
+//!
+//! There is deliberately no fallback from a failed artifact install to
+//! `cargo binstall`. A manifest names an artifact precisely when the version is
+//! not reachable any other way, and quietly installing whatever crates.io has
+//! instead would report success for a binary the manifest never pinned.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use gtc::error::{GtcError, GtcResult};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::archive::{
+    extract_targz_bytes, extract_zip_bytes, looks_like_gzip, looks_like_zip, set_executable_if_unix,
+};
+use super::install::{fetch_https_bytes, list_files_recursive};
+
+/// One release archive of a toolchain package, as named by whoever published it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PackageArtifactRef {
+    /// Rust target triple the archive was built for, e.g. `x86_64-unknown-linux-gnu`.
+    pub target: String,
+    /// `https://` URL of a `.tgz` or `.zip` archive (`file://` is accepted for
+    /// local manifests and tests).
+    pub url: String,
+    /// Hex sha256 of the archive, WITHOUT a `sha256:` prefix — the same shape as
+    /// `GtcArtifactRef::sha256`.
+    pub sha256: String,
+}
+
+/// The artifact `artifacts` names for `target`, if it names one.
+pub(crate) fn artifact_for_target<'a>(
+    artifacts: Option<&'a [PackageArtifactRef]>,
+    target: &str,
+) -> Option<&'a PackageArtifactRef> {
+    artifacts?.iter().find(|artifact| artifact.target == target)
+}
+
+/// Structural checks for one package's `artifacts`, run with the rest of
+/// manifest validation so a malformed entry is refused before anything is
+/// downloaded or installed.
+pub(crate) fn validate_package_artifacts(
+    crate_name: &str,
+    version: &str,
+    artifacts: &[PackageArtifactRef],
+) -> GtcResult<()> {
+    if super::toolchain::is_latest_version(version) {
+        // An archive is one concrete build. Pairing it with `latest` would
+        // make the manifest claim a version it cannot know.
+        return Err(GtcError::message(format!(
+            "toolchain package '{crate_name}' names release artifacts but pins no version"
+        )));
+    }
+    let mut targets = std::collections::HashSet::new();
+    for artifact in artifacts {
+        if artifact.target.trim().is_empty() {
+            return Err(GtcError::message(format!(
+                "toolchain package '{crate_name}' has an artifact with no target"
+            )));
+        }
+        if !targets.insert(artifact.target.as_str()) {
+            return Err(GtcError::message(format!(
+                "toolchain package '{crate_name}' names more than one artifact for {}",
+                artifact.target
+            )));
+        }
+        if !is_hex_sha256(&artifact.sha256) {
+            return Err(GtcError::message(format!(
+                "toolchain package '{crate_name}' artifact for {} has an invalid sha256 \
+                 (expected 64 hex characters without a prefix)",
+                artifact.target
+            )));
+        }
+        if !(artifact.url.starts_with("https://") || artifact.url.starts_with("file://")) {
+            return Err(GtcError::message(format!(
+                "toolchain package '{crate_name}' artifact for {} must be an https:// URL: {}",
+                artifact.target, artifact.url
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_hex_sha256(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+/// Download `artifact`, verify it, and install `bins` from it into `bin_dir`.
+///
+/// Every bin is located in the extracted archive BEFORE any of them is written,
+/// so an archive missing one of them installs nothing rather than half a
+/// package. Returns the installed paths.
+pub(crate) fn install_package_artifact(
+    artifact: &PackageArtifactRef,
+    bins: &[String],
+    bin_dir: &Path,
+    locale: &str,
+) -> GtcResult<Vec<PathBuf>> {
+    let bytes = fetch_artifact_bytes(&artifact.url, locale)?;
+    verify_artifact_sha256(&bytes, &artifact.sha256, &artifact.url)?;
+    install_bins_from_archive(&bytes, bins, bin_dir)
+}
+
+fn fetch_artifact_bytes(url: &str, locale: &str) -> GtcResult<Vec<u8>> {
+    if let Some(path) = url.strip_prefix("file://") {
+        return fs::read(path).map_err(|e| GtcError::io(format!("failed to read {path}"), e));
+    }
+    if url.starts_with("https://") {
+        // No credential: a toolchain archive is a public release asset, and
+        // `fetch_https_bytes` follows GitHub's redirect to its object storage
+        // the same way self-update does.
+        return fetch_https_bytes(url, "", locale, "application/octet-stream");
+    }
+    Err(GtcError::invalid_data(
+        "toolchain artifact URL",
+        format!("unsupported scheme for {url}"),
+    ))
+}
+
+fn verify_artifact_sha256(bytes: &[u8], expected_hex: &str, url: &str) -> GtcResult<()> {
+    let digest = Sha256::digest(bytes);
+    let mut actual = String::with_capacity(64);
+    for byte in digest {
+        actual.push_str(&format!("{byte:02x}"));
+    }
+    if actual.eq_ignore_ascii_case(expected_hex) {
+        return Ok(());
+    }
+    Err(GtcError::invalid_data(
+        format!("integrity check for {url}"),
+        format!(
+            "expected sha256:{}, got sha256:{actual}",
+            expected_hex.to_lowercase()
+        ),
+    ))
+}
+
+pub(crate) fn install_bins_from_archive(
+    bytes: &[u8],
+    bins: &[String],
+    bin_dir: &Path,
+) -> GtcResult<Vec<PathBuf>> {
+    let extract_dir = tempfile::tempdir()
+        .map_err(|e| GtcError::io("failed to create artifact extract directory", e))?;
+    if looks_like_gzip(bytes) {
+        extract_targz_bytes(bytes, extract_dir.path())?;
+    } else if looks_like_zip(bytes) {
+        extract_zip_bytes(bytes, extract_dir.path())?;
+    } else {
+        return Err(GtcError::invalid_data(
+            "toolchain artifact",
+            "not a .tgz or .zip archive",
+        ));
+    }
+
+    let files = list_files_recursive(extract_dir.path())?;
+    let mut located = Vec::with_capacity(bins.len());
+    for bin in bins {
+        located.push((bin, locate_bin(&files, bin)?));
+    }
+
+    fs::create_dir_all(bin_dir)
+        .map_err(|e| GtcError::io(format!("failed to create {}", bin_dir.display()), e))?;
+    let mut installed = Vec::with_capacity(located.len());
+    for (bin, source) in located {
+        let file_name = source
+            .file_name()
+            .ok_or_else(|| GtcError::message(format!("invalid file name for {bin}")))?;
+        let target = bin_dir.join(file_name);
+        replace_file(&source, &target)?;
+        installed.push(target);
+    }
+    Ok(installed)
+}
+
+/// The single file in the archive that IS `bin`.
+///
+/// Matched by exact file name (plus `.exe`), never by prefix: a dev archive
+/// ships `greentic-start-dev` beside a README and a LICENSE, and a prefix match
+/// is how the wrong file gets installed under a tool's name. Ambiguity is an
+/// error for the same reason.
+fn locate_bin(files: &[PathBuf], bin: &str) -> GtcResult<PathBuf> {
+    let windows_name = format!("{bin}.exe");
+    let matches: Vec<&PathBuf> = files
+        .iter()
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == bin || name == windows_name)
+        })
+        .collect();
+    match matches.as_slice() {
+        [only] => Ok((*only).clone()),
+        [] => Err(GtcError::invalid_data(
+            "toolchain artifact",
+            format!("the archive contains no binary named {bin}"),
+        )),
+        _ => Err(GtcError::invalid_data(
+            "toolchain artifact",
+            format!("the archive contains more than one binary named {bin}"),
+        )),
+    }
+}
+
+/// Write `source` to `target` through a sibling temp file and a rename, so an
+/// interrupted install never leaves a truncated binary where a working one was.
+fn replace_file(source: &Path, target: &Path) -> GtcResult<()> {
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| GtcError::message(format!("invalid install path {}", target.display())))?;
+    let staging = target.with_file_name(format!(".{file_name}.gtc-install-{}", std::process::id()));
+    fs::copy(source, &staging).map_err(|e| {
+        GtcError::io(
+            format!(
+                "failed to stage {} -> {}",
+                source.display(),
+                staging.display()
+            ),
+            e,
+        )
+    })?;
+    if let Err(err) = set_executable_if_unix(&staging) {
+        let _ = fs::remove_file(&staging);
+        return Err(err);
+    }
+    // Windows refuses to rename over an existing file.
+    #[cfg(windows)]
+    if target.exists() {
+        fs::remove_file(target)
+            .map_err(|e| GtcError::io(format!("failed to replace {}", target.display()), e))?;
+    }
+    fs::rename(&staging, target).map_err(|e| {
+        let _ = fs::remove_file(&staging);
+        GtcError::io(
+            format!(
+                "failed to install {} -> {}",
+                staging.display(),
+                target.display()
+            ),
+            e,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tgz_with(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::default(),
+        ));
+        for (path, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path, *data)
+                .expect("append tar entry");
+        }
+        builder
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gzip")
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn artifact(target: &str, url: &str, sha256: &str) -> PackageArtifactRef {
+        PackageArtifactRef {
+            target: target.to_string(),
+            url: url.to_string(),
+            sha256: sha256.to_string(),
+        }
+    }
+
+    #[test]
+    fn artifact_for_target_picks_the_running_target_only() {
+        let artifacts = vec![
+            artifact("x86_64-unknown-linux-gnu", "https://a", &"a".repeat(64)),
+            artifact("aarch64-apple-darwin", "https://b", &"b".repeat(64)),
+        ];
+        assert_eq!(
+            artifact_for_target(Some(&artifacts), "aarch64-apple-darwin").map(|a| a.url.as_str()),
+            Some("https://b")
+        );
+        assert!(artifact_for_target(Some(&artifacts), "x86_64-pc-windows-msvc").is_none());
+        assert!(artifact_for_target(None, "x86_64-unknown-linux-gnu").is_none());
+    }
+
+    #[test]
+    fn validation_refuses_what_could_not_be_installed_safely() {
+        let good = artifact(
+            "x86_64-unknown-linux-gnu",
+            "https://x/y.tgz",
+            &"0".repeat(64),
+        );
+        validate_package_artifacts("greentic-start-dev", "1.2.3", std::slice::from_ref(&good))
+            .expect("valid");
+
+        assert!(validate_package_artifacts("p", "latest", std::slice::from_ref(&good)).is_err());
+        assert!(
+            validate_package_artifacts("p", "1.2.3", &[good.clone(), good.clone()]).is_err(),
+            "two artifacts for one target"
+        );
+        let prefixed = artifact(
+            &good.target,
+            &good.url,
+            &format!("sha256:{}", "0".repeat(64)),
+        );
+        assert!(validate_package_artifacts("p", "1.2.3", &[prefixed]).is_err());
+        let short = artifact(&good.target, &good.url, "abc");
+        assert!(validate_package_artifacts("p", "1.2.3", &[short]).is_err());
+        let plain_http = artifact(&good.target, "http://x/y.tgz", &good.sha256);
+        assert!(validate_package_artifacts("p", "1.2.3", &[plain_http]).is_err());
+        let no_target = artifact(" ", &good.url, &good.sha256);
+        assert!(validate_package_artifacts("p", "1.2.3", &[no_target]).is_err());
+    }
+
+    #[test]
+    fn installs_exactly_the_named_bins_from_a_verified_archive() {
+        let archive = tgz_with(&[
+            (
+                "greentic-start-dev-v1.2.3-x86_64-unknown-linux-gnu/greentic-start-dev",
+                b"#!bin",
+            ),
+            (
+                "greentic-start-dev-v1.2.3-x86_64-unknown-linux-gnu/README.md",
+                b"readme",
+            ),
+            (
+                "greentic-start-dev-v1.2.3-x86_64-unknown-linux-gnu/greentic-start-dev.sha256",
+                b"x",
+            ),
+        ]);
+        let work = tempfile::tempdir().expect("tempdir");
+        let archive_path = work.path().join("pkg.tgz");
+        fs::write(&archive_path, &archive).expect("write archive");
+        let bin_dir = work.path().join("bin");
+        let entry = artifact(
+            "x86_64-unknown-linux-gnu",
+            &format!("file://{}", archive_path.display()),
+            &sha256_hex(&archive),
+        );
+
+        let installed =
+            install_package_artifact(&entry, &["greentic-start-dev".to_string()], &bin_dir, "en")
+                .expect("install");
+
+        assert_eq!(installed, vec![bin_dir.join("greentic-start-dev")]);
+        assert_eq!(
+            fs::read(bin_dir.join("greentic-start-dev")).expect("read"),
+            b"#!bin"
+        );
+        let mut names: Vec<_> = fs::read_dir(&bin_dir)
+            .expect("read bin dir")
+            .map(|entry| entry.expect("entry").file_name())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["greentic-start-dev"],
+            "no README, sidecar or staging file"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(bin_dir.join("greentic-start-dev"))
+                .expect("stat")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o111, 0o111, "installed binary is executable");
+        }
+    }
+
+    #[test]
+    fn a_checksum_mismatch_installs_nothing() {
+        let archive = tgz_with(&[("pkg/greentic-flow-dev", b"#!bin")]);
+        let work = tempfile::tempdir().expect("tempdir");
+        let archive_path = work.path().join("pkg.tgz");
+        fs::write(&archive_path, &archive).expect("write archive");
+        let bin_dir = work.path().join("bin");
+        let entry = artifact(
+            "x86_64-unknown-linux-gnu",
+            &format!("file://{}", archive_path.display()),
+            &"0".repeat(64),
+        );
+
+        let err =
+            install_package_artifact(&entry, &["greentic-flow-dev".to_string()], &bin_dir, "en")
+                .expect_err("mismatch must fail");
+
+        assert!(err.to_string().contains("integrity check"), "{err}");
+        assert!(
+            !bin_dir.exists(),
+            "nothing written on a failed verification"
+        );
+    }
+
+    #[test]
+    fn a_missing_bin_installs_none_of_the_package() {
+        let archive = tgz_with(&[("pkg/greentic-runner-dev", b"#!bin")]);
+        let bin_dir = tempfile::tempdir().expect("tempdir");
+
+        let err = install_bins_from_archive(
+            &archive,
+            &[
+                "greentic-runner-dev".to_string(),
+                "greentic-runner-cli".to_string(),
+            ],
+            bin_dir.path(),
+        )
+        .expect_err("missing bin must fail");
+
+        assert!(err.to_string().contains("greentic-runner-cli"), "{err}");
+        assert!(
+            fs::read_dir(bin_dir.path()).expect("read").next().is_none(),
+            "the bin that WAS present must not be installed on its own"
+        );
+    }
+
+    #[test]
+    fn an_ambiguous_bin_is_refused() {
+        let archive = tgz_with(&[
+            ("a/greentic-pack-dev", b"one"),
+            ("b/greentic-pack-dev", b"two"),
+        ]);
+        let bin_dir = tempfile::tempdir().expect("tempdir");
+        let err =
+            install_bins_from_archive(&archive, &["greentic-pack-dev".to_string()], bin_dir.path())
+                .expect_err("ambiguous must fail");
+        assert!(err.to_string().contains("more than one"), "{err}");
+    }
+
+    #[test]
+    fn a_prefix_match_is_not_the_bin() {
+        let archive = tgz_with(&[("pkg/greentic-pack-dev-helper", b"nope")]);
+        let bin_dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            install_bins_from_archive(&archive, &["greentic-pack-dev".to_string()], bin_dir.path())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reinstalling_replaces_the_previous_binary() {
+        let bin_dir = tempfile::tempdir().expect("tempdir");
+        fs::write(bin_dir.path().join("greentic-setup-dev"), b"old").expect("seed");
+        let archive = tgz_with(&[("pkg/greentic-setup-dev", b"new")]);
+        install_bins_from_archive(
+            &archive,
+            &["greentic-setup-dev".to_string()],
+            bin_dir.path(),
+        )
+        .expect("install");
+        assert_eq!(
+            fs::read(bin_dir.path().join("greentic-setup-dev")).expect("read"),
+            b"new"
+        );
+    }
+
+    #[test]
+    fn a_non_archive_is_refused() {
+        let bin_dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            install_bins_from_archive(b"plain text", &["x".to_string()], bin_dir.path()).is_err()
+        );
+    }
+}

--- a/src/bin/gtc/toolchain.rs
+++ b/src/bin/gtc/toolchain.rs
@@ -20,7 +20,10 @@ use sha2::{Digest, Sha256};
 
 use super::i18n_support::{t, tf};
 use super::install::{run_cargo, run_cargo_capture};
-use super::process::run_binary_capture;
+use super::package_artifact::{
+    PackageArtifactRef, artifact_for_target, install_package_artifact, validate_package_artifacts,
+};
+use super::process::{resolve_cargo_bin_dir, run_binary_capture};
 
 const TOOLCHAIN_MANIFEST_SCHEMA: &str = "greentic.toolchain-manifest.v1";
 const INSTALLED_TOOLCHAIN_SCHEMA: &str = "greentic.installed-toolchain.v1";
@@ -77,6 +80,15 @@ pub(crate) struct ToolchainPackage {
     pub crate_name: String,
     pub bins: Vec<String>,
     pub version: String,
+    /// Release archives for this exact version, one per target, installed
+    /// instead of `cargo binstall` when the running target has an entry. See
+    /// `package_artifact` for why a manifest needs to be able to say this.
+    ///
+    /// Optional so every manifest published before it keeps its meaning, and
+    /// omitted from serialization when absent so re-serialising one does not
+    /// grow a field it never had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<PackageArtifactRef>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -372,6 +384,17 @@ pub(crate) fn run_toolchain_install_detailed(
                         return 1.into();
                     }
                 };
+                if let Some(artifact) =
+                    artifact_for_target(package.artifacts.as_deref(), env!("GTC_TARGET_TRIPLE"))
+                {
+                    println!(
+                        "download {} (sha256 {}) -> {}",
+                        artifact.url,
+                        artifact.sha256,
+                        package.bins.join(", ")
+                    );
+                    continue;
+                }
                 for bin in &package.bins {
                     let args = toolchain_binstall_args_for_version(package, bin, &version);
                     println!("cargo {}", args.join(" "));
@@ -485,6 +508,13 @@ pub(crate) fn install_toolchain_package(
             return 1;
         }
     };
+    if let Some(artifact) =
+        artifact_for_target(package.artifacts.as_deref(), env!("GTC_TARGET_TRIPLE"))
+    {
+        return install_toolchain_package_from_artifact(
+            package, artifact, &version, force, debug, locale,
+        );
+    }
     for bin in &package.bins {
         if !force && installed_binary_version_matches(bin, &version, debug, locale) {
             println!("Installed {bin} binary already matches {version}; skipping.");
@@ -530,6 +560,66 @@ pub(crate) fn install_toolchain_package(
         );
     }
     0
+}
+
+/// Install `package` from the release archive its manifest names for this
+/// target. Whole-package, unlike the binstall path: one archive carries every
+/// bin, so it is skipped only when EVERY bin already reports `version`.
+fn install_toolchain_package_from_artifact(
+    package: &ToolchainPackage,
+    artifact: &PackageArtifactRef,
+    version: &str,
+    force: bool,
+    debug: bool,
+    locale: &str,
+) -> i32 {
+    if !force
+        && package
+            .bins
+            .iter()
+            .all(|bin| installed_binary_version_matches(bin, version, debug, locale))
+    {
+        println!(
+            "Installed {} binaries already match {version}; skipping.",
+            package.crate_name
+        );
+        return 0;
+    }
+    let bin_dir = match resolve_cargo_bin_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("{err}");
+            return 1;
+        }
+    };
+    println!(
+        "Installing {} {version} from {} into {}",
+        package.crate_name,
+        artifact.url,
+        bin_dir.display()
+    );
+    match install_package_artifact(artifact, &package.bins, &bin_dir, locale) {
+        Ok(installed) => {
+            for path in installed {
+                println!("  installed {}", path.display());
+            }
+            0
+        }
+        Err(err) => {
+            eprintln!(
+                "{}: {err}",
+                tf(
+                    locale,
+                    "gtc.install.toolchain.item_fail",
+                    &[
+                        ("crate", package.crate_name.as_str()),
+                        ("bin", package.bins.join(",").as_str())
+                    ]
+                )
+            );
+            1
+        }
+    }
 }
 
 fn installed_binary_version_matches(bin: &str, version: &str, debug: bool, locale: &str) -> bool {
@@ -820,6 +910,11 @@ pub(crate) fn validate_toolchain_manifest(manifest: &ToolchainManifest) -> GtcRe
                     package.crate_name, bin
                 )));
             }
+        }
+    }
+    for package in &manifest.packages {
+        if let Some(artifacts) = package.artifacts.as_deref() {
+            validate_package_artifacts(&package.crate_name, &package.version, artifacts)?;
         }
     }
     validate_toolchain_artifact_refs("extension_packs", manifest.extension_packs.as_deref())?;
@@ -2161,6 +2256,7 @@ mod tests {
                     crate_name: "greentic-dev".to_string(),
                     bins: vec!["greentic-dev".to_string()],
                     version: "0.5.9".to_string(),
+                    artifacts: None,
                 },
                 ToolchainPackage {
                     crate_name: "greentic-runner".to_string(),
@@ -2169,6 +2265,7 @@ mod tests {
                         "greentic-runner-cli".to_string(),
                     ],
                     version: "0.5.10".to_string(),
+                    artifacts: None,
                 },
             ],
             extension_packs: None,
@@ -2189,6 +2286,57 @@ mod tests {
         let manifest: ToolchainManifest = serde_json::from_str(raw).expect("manifest");
         validate_toolchain_manifest(&manifest).expect("valid");
         assert_eq!(manifest.packages[0].crate_name, "greentic-dev");
+    }
+
+    #[test]
+    fn parses_a_package_that_names_release_artifacts() {
+        let raw = format!(
+            r#"{{
+            "schema":"greentic.toolchain-manifest.v1",
+            "toolchain":"gtc",
+            "version":"1.2.34087396714",
+            "channel":"dev",
+            "packages":[{{
+                "crate":"greentic-start-dev",
+                "bins":["greentic-start-dev"],
+                "version":"1.2.34207645334",
+                "artifacts":[{{
+                    "target":"x86_64-unknown-linux-gnu",
+                    "url":"https://github.com/greenticai/greentic-start/releases/download/v1.2.34207645334/greentic-start-dev-v1.2.34207645334-x86_64-unknown-linux-gnu.tgz",
+                    "sha256":"{}"
+                }}]
+            }}]
+        }}"#,
+            "a".repeat(64)
+        );
+        let manifest: ToolchainManifest = serde_json::from_str(&raw).expect("manifest");
+        validate_toolchain_manifest(&manifest).expect("valid");
+        let artifact = artifact_for_target(
+            manifest.packages[0].artifacts.as_deref(),
+            "x86_64-unknown-linux-gnu",
+        )
+        .expect("artifact for linux");
+        assert!(artifact.url.ends_with("x86_64-unknown-linux-gnu.tgz"));
+    }
+
+    #[test]
+    fn a_manifest_without_artifacts_round_trips_without_growing_the_field() {
+        let manifest = pinned_manifest();
+        let json = serde_json::to_string(&manifest).expect("serialize");
+        assert!(!json.contains("artifacts"), "{json}");
+        let back: ToolchainManifest = serde_json::from_str(&json).expect("parse");
+        assert_eq!(back, manifest);
+    }
+
+    #[test]
+    fn rejects_a_package_whose_artifacts_are_malformed() {
+        let mut manifest = pinned_manifest();
+        manifest.packages[0].artifacts = Some(vec![PackageArtifactRef {
+            target: "x86_64-unknown-linux-gnu".to_string(),
+            url: "https://example.invalid/pkg.tgz".to_string(),
+            sha256: "not-a-digest".to_string(),
+        }]);
+        assert!(validate_toolchain_manifest(&manifest).is_err());
     }
 
     #[test]
@@ -2226,6 +2374,7 @@ mod tests {
             crate_name: "greentic-dev".to_string(),
             bins: vec!["greentic-dev".to_string()],
             version: "0.5.10".to_string(),
+            artifacts: None,
         });
         assert!(validate_toolchain_manifest(&manifest).is_err());
     }
@@ -2256,6 +2405,7 @@ mod tests {
             crate_name: "greentic-start".to_string(),
             bins: vec!["greentic-start".to_string()],
             version: "0.5.8".to_string(),
+            artifacts: None,
         };
         assert_eq!(
             toolchain_binstall_args(&package, "greentic-start"),
@@ -2281,6 +2431,7 @@ mod tests {
             crate_name: "greentic-flow".to_string(),
             bins: vec!["greentic-flow".to_string()],
             version: "latest".to_string(),
+            artifacts: None,
         };
         assert_eq!(
             toolchain_binstall_args(&package, "greentic-flow"),


### PR DESCRIPTION
## Why

`gtc install` could only pin versions that crates.io carries, because every toolchain package goes through `cargo binstall`, and binstall resolves through the crates.io index.

Since 2026-09-08, crates.io has locked the account that publishes every Greentic crate. Dev builds still attach their archives to GitHub releases, but none of them reach the index. As a result, the dev channel (`ghcr.io/greenticai/greentic-versions/gtc:dev`, created 2026-09-07) is frozen. Fixes that are merged and built cannot be installed:
- greentic-start #566/#568
- greentic-pack #288
- greentic-runner #743/#757

The current manifest also pins six versions that have since been yanked, and one that does not exist at all.

The publisher side is a companion change in greentic-dev, which adds `release snapshot --source github-releases`.

## What

- **New manifest field.** `ToolchainPackage.artifacts: [{target, url, sha256}]` is optional and omitted when absent. It uses the same shape as the manifest's existing `gtc` field.
- **Install from the artifact.** When the running target has an entry, gtc downloads the archive and verifies its sha256. It then installs **exactly** the package's `bins` into the cargo bin dir that binstall would have used.
- **Otherwise unchanged.** A package without an entry for this target still installs through binstall, so every published manifest keeps its meaning.
- **No partial installs.** Every bin is located in the archive before anything is written. Bins are matched by exact name (plus `.exe`), and an ambiguous match is an error. Each file is written to a staging path next to its target and then renamed into place.
- **No fallback to binstall** when an artifact install fails. A manifest names an artifact precisely because that version is not reachable any other way.
- **Validation** refuses:
  - artifacts on a `latest` package;
  - a duplicate target;
  - a prefixed or malformed sha256;
  - a non-https URL (`file://` is allowed for local manifests).
- **`--dry-run`** prints the planned download instead of a binstall command.

## Compatibility

- An older gtc ignores the new field and keeps using binstall. For a version that exists only as a GitHub release, that binstall fails.
- Because self-update runs before the package install, the first `gtc install` against such a manifest updates gtc and then fails on the packages. The second run succeeds.
- `gtc install` still runs its existing prerequisite checks (cargo-binstall, cargo-component, wasm32-wasip2). This PR does not change them.

## Verification

- `cargo clippy --bin gtc --all-features --tests -- -D warnings` passes.
- `cargo test --bin gtc --all-features -- package_artifact toolchain::tests`: 78 passed. This includes 9 new `package_artifact` tests and 3 new manifest tests.
- **End to end against a real release asset.** I ran `target/debug/gtc install --manifest <local> --install-binaries-only --force` in a sandbox (`CARGO_HOME`, `GTC_TOOLCHAIN_STATE_DIR`). The manifest pinned `greentic-start-dev` `1.2.34207645334` with its real x86_64-unknown-linux-gnu asset and API digest.
  - The download went through GitHub's redirect and the checksum verified.
  - `greentic-start-dev` was the only file installed.
  - Its sha256 matches the binary inside the archive.
  - The installed-toolchain state recorded the artifact.
- **Not run locally:** the full `ci/local_check.sh` (full test suite, perf tests and publish dry-run). That is left to CI.
